### PR TITLE
ci: restrict all workflows to tpmjs org only

### DIFF
--- a/.github/workflows/auto-close-published.yml
+++ b/.github/workflows/auto-close-published.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   auto-close:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/build-omega-mac.yml
+++ b/.github/workflows/build-omega-mac.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'tpmjs'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.repository_owner == 'tpmjs'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,10 +14,12 @@ jobs:
   # Standard Claude trigger - responds to @claude mentions
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'assigned') && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.repository_owner == 'tpmjs' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'assigned') && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write      # Push branches, create commits
@@ -44,7 +46,7 @@ jobs:
 
   # Label-triggered Claude - for tool-request pipeline
   claude-label-trigger:
-    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude-working'
+    if: github.repository_owner == 'tpmjs' && github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude-working'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/discord-summary.yml
+++ b/.github/workflows/discord-summary.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   post-summary:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Generate conversation ID with date

--- a/.github/workflows/endpoint-health-check.yml
+++ b/.github/workflows/endpoint-health-check.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   health-check:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   health-check:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger health check sync

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   integration-tests:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -104,7 +105,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     needs: integration-tests
-    if: always()
+    if: always() && github.repository_owner == 'tpmjs'
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
+    if: github.repository_owner == 'tpmjs'
     name: Release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/sync-changes.yml
+++ b/.github/workflows/sync-changes.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   sync-changes:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger changes feed sync

--- a/.github/workflows/sync-enrich.yml
+++ b/.github/workflows/sync-enrich.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   sync-enrich:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger enrichment sync

--- a/.github/workflows/sync-keyword.yml
+++ b/.github/workflows/sync-keyword.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   sync-keyword:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger keyword search sync

--- a/.github/workflows/sync-manual.yml
+++ b/.github/workflows/sync-manual.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   sync-manual:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-metrics.yml
+++ b/.github/workflows/sync-metrics.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   sync-metrics:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger metrics sync

--- a/.github/workflows/sync-package.yml
+++ b/.github/workflows/sync-package.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   sync-package:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Sync package

--- a/.github/workflows/sync-vercel-registry.yml
+++ b/.github/workflows/sync-vercel-registry.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   sync-vercel:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/tool-request.yml
+++ b/.github/workflows/tool-request.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   trigger-claude:
-    # Only run when 'tool-request' label is added or manual dispatch
-    if: github.event.label.name == 'tool-request' || github.event_name == 'workflow_dispatch'
+    # Only run on main repo when 'tool-request' label is added or manual dispatch
+    if: github.repository_owner == 'tpmjs' && (github.event.label.name == 'tool-request' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -70,7 +70,7 @@ jobs:
   # Auto-close published issues after 24 hours
   auto-close:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'published'
+    if: github.repository_owner == 'tpmjs' && github.event.label.name == 'published'
     permissions:
       issues: write
     steps:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   update-docs:
+    if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Add `if: github.repository_owner == 'tpmjs'` guard to all 18 workflows except ci.yml (which is useful for fork contributors).

Prevents scheduled jobs, sync crons, Claude actions, releases, health checks, and Discord notifications from firing on forks.