### PR TITLE
feat: web-initiated install.sh setup flow for MCP editors

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,6 +14,14 @@ const nextConfig: NextConfig = {
   ],
   reactStrictMode: true,
   serverExternalPackages: ['@tpmjs/package-executor'],
+  async rewrites() {
+    return [
+      {
+        source: '/install.sh',
+        destination: '/api/setup/install.sh',
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/apps/web/src/app/api/setup/create-token/route.ts
+++ b/apps/web/src/app/api/setup/create-token/route.ts
@@ -1,0 +1,149 @@
+import { randomBytes } from 'node:crypto';
+import { prisma } from '@tpmjs/db';
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { DEFAULT_API_KEY_SCOPES, generateApiKey } from '~/lib/api-keys';
+import { auth } from '~/lib/auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const VALID_EDITORS = ['claude-code', 'cursor', 'windsurf', 'claude-desktop'] as const;
+type Editor = (typeof VALID_EDITORS)[number];
+
+interface MappingInput {
+  collectionId: string;
+  collectionSlug: string;
+  collectionName: string;
+  editor: Editor;
+}
+
+interface CreateTokenBody {
+  mappings: MappingInput[];
+  createApiKey?: boolean;
+}
+
+/**
+ * POST /api/setup/create-token
+ *
+ * Creates a one-time setup token for the install.sh flow.
+ * Called from the web UI (authenticated via session).
+ */
+export async function POST(request: Request) {
+  try {
+    const session = await auth.api.getSession({ headers: await headers() });
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body: CreateTokenBody = await request.json();
+    const { mappings, createApiKey } = body;
+
+    // Validate mappings
+    if (!Array.isArray(mappings) || mappings.length === 0) {
+      return NextResponse.json({ error: 'At least one mapping is required' }, { status: 400 });
+    }
+
+    if (mappings.length > 50) {
+      return NextResponse.json({ error: 'Maximum 50 mappings allowed' }, { status: 400 });
+    }
+
+    for (const mapping of mappings) {
+      if (!mapping.collectionId || !mapping.collectionSlug || !mapping.collectionName) {
+        return NextResponse.json(
+          { error: 'Each mapping must include collectionId, collectionSlug, and collectionName' },
+          { status: 400 }
+        );
+      }
+      if (!VALID_EDITORS.includes(mapping.editor as Editor)) {
+        return NextResponse.json(
+          {
+            error: `Invalid editor "${mapping.editor}". Must be one of: ${VALID_EDITORS.join(', ')}`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Validate all collections belong to the user
+    const collectionIds = mappings.map((m) => m.collectionId);
+    const collections = await prisma.collection.findMany({
+      where: {
+        id: { in: collectionIds },
+        userId: session.user.id,
+      },
+      select: { id: true },
+    });
+
+    const ownedIds = new Set(collections.map((c) => c.id));
+    const invalidIds = collectionIds.filter((id) => !ownedIds.has(id));
+    if (invalidIds.length > 0) {
+      return NextResponse.json(
+        { error: `Collections not found or not owned by you: ${invalidIds.join(', ')}` },
+        { status: 403 }
+      );
+    }
+
+    // Determine whether to create an API key
+    let rawApiKey: string | undefined;
+
+    const shouldCreateKey =
+      createApiKey ||
+      (await prisma.tpmjsApiKey.count({
+        where: { userId: session.user.id, isActive: true },
+      })) === 0;
+
+    if (shouldCreateKey) {
+      const { rawKey, keyHash, keyPrefix } = generateApiKey();
+      rawApiKey = rawKey;
+
+      await prisma.tpmjsApiKey.create({
+        data: {
+          userId: session.user.id,
+          name: 'Setup (auto-created)',
+          keyHash,
+          keyPrefix,
+          scopes: DEFAULT_API_KEY_SCOPES,
+        },
+      });
+    }
+
+    // Generate a random 32-byte hex token
+    const token = randomBytes(32).toString('hex');
+
+    // Create the SetupToken with 1 hour expiry
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+
+    await prisma.setupToken.create({
+      data: {
+        userId: session.user.id,
+        token,
+        config: {
+          mappings: mappings.map((m) => ({
+            collectionId: m.collectionId,
+            collectionSlug: m.collectionSlug,
+            collectionName: m.collectionName,
+            editor: m.editor,
+          })),
+          // Store raw key in the token config so the redeem endpoint can return it
+          // to the install script. This is safe because the token is single-use and
+          // expires in 1 hour.
+          ...(rawApiKey && { apiKey: rawApiKey }),
+        },
+        expiresAt,
+      },
+    });
+
+    const installCommand = `curl -fsSL https://tpmjs.com/install.sh | bash -s -- --token=${token}`;
+
+    return NextResponse.json({
+      token,
+      installCommand,
+      ...(rawApiKey && { apiKey: rawApiKey }),
+    });
+  } catch (error) {
+    console.error('[Setup] Error creating token:', error);
+    return NextResponse.json({ error: 'Failed to create setup token' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/setup/install.sh/route.ts
+++ b/apps/web/src/app/api/setup/install.sh/route.ts
@@ -1,0 +1,296 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/setup/install.sh
+ *
+ * Serves the TPMJS install script. This is the entry point for:
+ *   curl -fsSL https://tpmjs.com/install.sh | bash -s -- --token=<token>
+ */
+export async function GET() {
+  const script = `#!/bin/bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# TPMJS Setup Script
+# Configures MCP servers for your editors based on your tpmjs.com selections.
+# ---------------------------------------------------------------------------
+
+# Colors (disabled if not a terminal)
+if [ -t 1 ] && [ -t 2 ]; then
+  RED='\\033[0;31m'
+  GREEN='\\033[0;32m'
+  YELLOW='\\033[1;33m'
+  BLUE='\\033[0;34m'
+  CYAN='\\033[0;36m'
+  BOLD='\\033[1m'
+  NC='\\033[0m'
+else
+  RED='' GREEN='' YELLOW='' BLUE='' CYAN='' BOLD='' NC=''
+fi
+
+info()    { echo -e "\${BLUE}[info]\${NC}  $1"; }
+success() { echo -e "\${GREEN}[ok]\${NC}    $1"; }
+warn()    { echo -e "\${YELLOW}[warn]\${NC}  $1"; }
+error()   { echo -e "\${RED}[error]\${NC} $1"; }
+
+# Banner
+echo ""
+echo -e "\${BOLD}\${CYAN}"
+echo "  _____ ____  __  __     _ ____  "
+echo " |_   _|  _ \\|  \\/  |   | / ___| "
+echo "   | | | |_) | |\\/| |_  | \\___ \\ "
+echo "   | | |  __/| |  | | |_| |___) |"
+echo "   |_| |_|   |_|  |_|\\___/|____/ "
+echo ""
+echo -e "  MCP Server Setup\${NC}"
+echo ""
+
+# ---- Pre-flight checks ---------------------------------------------------
+
+# Check for curl
+if ! command -v curl &>/dev/null; then
+  error "curl is required but not installed."
+  exit 1
+fi
+
+# Check for node (needed for JSON config merging)
+if ! command -v node &>/dev/null; then
+  error "Node.js is required but not installed."
+  echo "  Install it from https://nodejs.org or via your package manager."
+  exit 1
+fi
+
+# ---- Parse arguments ------------------------------------------------------
+
+TOKEN=""
+for arg in "$@"; do
+  case "$arg" in
+    --token=*)
+      TOKEN="\${arg#--token=}"
+      ;;
+  esac
+done
+
+if [ -z "$TOKEN" ]; then
+  echo ""
+  warn "No setup token provided."
+  echo ""
+  echo "  To get started:"
+  echo "    1. Visit \${BOLD}https://tpmjs.com/setup\${NC}"
+  echo "    2. Select your collections and editors"
+  echo "    3. Copy the install command with your token"
+  echo ""
+  echo "  Usage:"
+  echo "    curl -fsSL https://tpmjs.com/install.sh | bash -s -- --token=YOUR_TOKEN"
+  echo ""
+  exit 1
+fi
+
+# ---- Redeem the token -----------------------------------------------------
+
+info "Redeeming setup token..."
+
+RESPONSE=$(curl -fsSL "https://tpmjs.com/api/setup/redeem/$TOKEN" 2>&1) || {
+  error "Failed to redeem token. It may be expired or already used."
+  echo "  Visit \${BOLD}https://tpmjs.com/setup\${NC} to generate a new one."
+  exit 1
+}
+
+# Parse JSON using node
+PARSED=$(node -e "
+  try {
+    const data = JSON.parse(process.argv[1]);
+    if (!data.success) {
+      console.error('Error: ' + (data.error || 'Unknown error'));
+      process.exit(1);
+    }
+    // Output as tab-separated values for bash consumption
+    console.log(JSON.stringify(data));
+  } catch (e) {
+    console.error('Failed to parse response: ' + e.message);
+    process.exit(1);
+  }
+" "$RESPONSE") || {
+  error "Failed to parse server response."
+  exit 1
+}
+
+# Extract fields
+USERNAME=$(node -e "console.log(JSON.parse(process.argv[1]).username)" "$PARSED")
+API_KEY=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.apiKey||'')" "$PARSED")
+MAPPING_COUNT=$(node -e "console.log(JSON.parse(process.argv[1]).mappings.length)" "$PARSED")
+
+success "Authenticated as \${BOLD}$USERNAME\${NC}"
+
+if [ -n "$API_KEY" ]; then
+  info "API key created: \${API_KEY:0:20}..."
+fi
+
+echo ""
+
+# ---- Configure editors ----------------------------------------------------
+
+CONFIGURED=0
+FAILED=0
+
+for i in $(seq 0 $((MAPPING_COUNT - 1))); do
+  SLUG=$(node -e "console.log(JSON.parse(process.argv[1]).mappings[$i].collectionSlug)" "$PARSED")
+  NAME=$(node -e "console.log(JSON.parse(process.argv[1]).mappings[$i].collectionName)" "$PARSED")
+  EDITOR=$(node -e "console.log(JSON.parse(process.argv[1]).mappings[$i].editor)" "$PARSED")
+  MCP_URL=$(node -e "console.log(JSON.parse(process.argv[1]).mappings[$i].mcpUrl)" "$PARSED")
+  SERVER_NAME="tpmjs-$SLUG"
+
+  info "Configuring \${BOLD}$NAME\${NC} for \${BOLD}$EDITOR\${NC}..."
+
+  case "$EDITOR" in
+    claude-code)
+      # Use the claude CLI to add the MCP server
+      if ! command -v claude &>/dev/null; then
+        warn "claude CLI not found. Skipping $NAME for Claude Code."
+        warn "  Install it: npm install -g @anthropic-ai/claude-code"
+        FAILED=$((FAILED + 1))
+        continue
+      fi
+
+      MCP_JSON=$(node -e "
+        const config = {
+          type: 'http',
+          url: process.argv[1]
+        };
+        if (process.argv[2]) {
+          config.headers = { Authorization: 'Bearer ' + process.argv[2] };
+        }
+        console.log(JSON.stringify(config));
+      " "$MCP_URL" "$API_KEY")
+
+      if claude mcp add-json "$SERVER_NAME" "$MCP_JSON" 2>/dev/null; then
+        success "$NAME configured for Claude Code"
+        CONFIGURED=$((CONFIGURED + 1))
+      else
+        warn "Failed to configure $NAME for Claude Code"
+        FAILED=$((FAILED + 1))
+      fi
+      ;;
+
+    cursor)
+      CONFIG_PATH="$HOME/.cursor/mcp.json"
+      node -e "
+        const fs = require('fs');
+        const path = require('path');
+        const configPath = process.argv[1];
+        const serverName = process.argv[2];
+        const mcpUrl = process.argv[3];
+        const apiKey = process.argv[4];
+        let config = {};
+        try { config = JSON.parse(fs.readFileSync(configPath, 'utf8')); } catch {}
+        if (!config.mcpServers) config.mcpServers = {};
+        const server = { type: 'http', url: mcpUrl };
+        if (apiKey) server.headers = { Authorization: 'Bearer ' + apiKey };
+        config.mcpServers[serverName] = server;
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      " "$CONFIG_PATH" "$SERVER_NAME" "$MCP_URL" "$API_KEY" && {
+        success "$NAME configured for Cursor (\${CONFIG_PATH})"
+        CONFIGURED=$((CONFIGURED + 1))
+      } || {
+        warn "Failed to configure $NAME for Cursor"
+        FAILED=$((FAILED + 1))
+      }
+      ;;
+
+    windsurf)
+      CONFIG_PATH="$HOME/.codeium/windsurf/mcp_config.json"
+      node -e "
+        const fs = require('fs');
+        const path = require('path');
+        const configPath = process.argv[1];
+        const serverName = process.argv[2];
+        const mcpUrl = process.argv[3];
+        const apiKey = process.argv[4];
+        let config = {};
+        try { config = JSON.parse(fs.readFileSync(configPath, 'utf8')); } catch {}
+        if (!config.mcpServers) config.mcpServers = {};
+        const server = { type: 'http', url: mcpUrl };
+        if (apiKey) server.headers = { Authorization: 'Bearer ' + apiKey };
+        config.mcpServers[serverName] = server;
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      " "$CONFIG_PATH" "$SERVER_NAME" "$MCP_URL" "$API_KEY" && {
+        success "$NAME configured for Windsurf (\${CONFIG_PATH})"
+        CONFIGURED=$((CONFIGURED + 1))
+      } || {
+        warn "Failed to configure $NAME for Windsurf"
+        FAILED=$((FAILED + 1))
+      }
+      ;;
+
+    claude-desktop)
+      # Detect OS for config path
+      if [ "$(uname)" = "Darwin" ]; then
+        CONFIG_PATH="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+      elif [ -n "\${APPDATA:-}" ]; then
+        CONFIG_PATH="$APPDATA/Claude/claude_desktop_config.json"
+      else
+        # Linux fallback
+        CONFIG_PATH="$HOME/.config/Claude/claude_desktop_config.json"
+      fi
+
+      node -e "
+        const fs = require('fs');
+        const path = require('path');
+        const configPath = process.argv[1];
+        const serverName = process.argv[2];
+        const mcpUrl = process.argv[3];
+        const apiKey = process.argv[4];
+        let config = {};
+        try { config = JSON.parse(fs.readFileSync(configPath, 'utf8')); } catch {}
+        if (!config.mcpServers) config.mcpServers = {};
+        const server = { type: 'http', url: mcpUrl };
+        if (apiKey) server.headers = { Authorization: 'Bearer ' + apiKey };
+        config.mcpServers[serverName] = server;
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      " "$CONFIG_PATH" "$SERVER_NAME" "$MCP_URL" "$API_KEY" && {
+        success "$NAME configured for Claude Desktop (\${CONFIG_PATH})"
+        CONFIGURED=$((CONFIGURED + 1))
+      } || {
+        warn "Failed to configure $NAME for Claude Desktop"
+        FAILED=$((FAILED + 1))
+      }
+      ;;
+
+    *)
+      warn "Unknown editor: $EDITOR. Skipping $NAME."
+      FAILED=$((FAILED + 1))
+      ;;
+  esac
+done
+
+# ---- Summary --------------------------------------------------------------
+
+echo ""
+echo -e "\${BOLD}── Summary ─────────────────────────────────────\${NC}"
+
+if [ "$CONFIGURED" -gt 0 ]; then
+  success "\${CONFIGURED} MCP server(s) configured successfully."
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+  warn "\${FAILED} configuration(s) skipped or failed."
+fi
+
+echo ""
+echo "  Your MCP tools are ready to use. Restart your editor(s) to load them."
+echo "  Manage your collections at \${BOLD}https://tpmjs.com/@$USERNAME\${NC}"
+echo ""
+`;
+
+  return new Response(script, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}

--- a/apps/web/src/app/api/setup/redeem/[token]/route.ts
+++ b/apps/web/src/app/api/setup/redeem/[token]/route.ts
@@ -1,0 +1,98 @@
+import { prisma } from '@tpmjs/db';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+interface RouteContext {
+  params: Promise<{ token: string }>;
+}
+
+interface ConfigMapping {
+  collectionId: string;
+  collectionSlug: string;
+  collectionName: string;
+  editor: string;
+}
+
+interface SetupConfig {
+  mappings: ConfigMapping[];
+  apiKey?: string;
+}
+
+/**
+ * GET /api/setup/redeem/[token]
+ *
+ * Called by install.sh to redeem a setup token and get the configuration payload.
+ * One-time use - marks the token as redeemed after successful retrieval.
+ */
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const { token } = await context.params;
+
+    if (!token || token.length !== 64) {
+      return NextResponse.json({ success: false, error: 'Invalid token format' }, { status: 400 });
+    }
+
+    // Look up the token
+    const setupToken = await prisma.setupToken.findUnique({
+      where: { token },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+          },
+        },
+      },
+    });
+
+    if (!setupToken) {
+      return NextResponse.json({ success: false, error: 'Token not found' }, { status: 404 });
+    }
+
+    // Check if already redeemed
+    if (setupToken.redeemed) {
+      return NextResponse.json(
+        { success: false, error: 'Token has already been redeemed' },
+        { status: 410 }
+      );
+    }
+
+    // Check if expired
+    if (setupToken.expiresAt < new Date()) {
+      return NextResponse.json({ success: false, error: 'Token has expired' }, { status: 410 });
+    }
+
+    // Mark as redeemed
+    await prisma.setupToken.update({
+      where: { id: setupToken.id },
+      data: {
+        redeemed: true,
+        redeemedAt: new Date(),
+      },
+    });
+
+    const config = setupToken.config as unknown as SetupConfig;
+    const username = setupToken.user.username || setupToken.user.id;
+
+    // Build the response payload
+    const mappings = config.mappings.map((m) => ({
+      collectionSlug: m.collectionSlug,
+      collectionName: m.collectionName,
+      editor: m.editor,
+      mcpUrl: `https://tpmjs.com/@${username}/collections/${m.collectionSlug}/mcp`,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      username,
+      mappings,
+      ...(config.apiKey && { apiKey: config.apiKey }),
+    });
+  } catch (error) {
+    console.error('[Setup] Error redeeming token:', error);
+    return NextResponse.json({ success: false, error: 'Failed to redeem token' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { AppHeader } from '../components/AppHeader';
 import { EcosystemStats } from '../components/home/EcosystemStats';
 import { FeaturesSection } from '../components/home/FeaturesSection';
+import { GetStartedSection } from '../components/home/GetStartedSection';
 import { HeroSection } from '../components/home/HeroSection';
 import { McpSection } from '../components/home/McpSection';
 
@@ -226,6 +227,9 @@ export default async function HomePage(): Promise<React.ReactElement> {
       <main>
         {/* Hero Section - Dithered Design */}
         <HeroSection stats={data.stats} />
+
+        {/* Get Started - Install Script Section */}
+        <GetStartedSection />
 
         {/* Ecosystem Stats */}
         <EcosystemStats stats={data.ecosystemStats} />

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -1,0 +1,509 @@
+'use client';
+
+import { Badge } from '@tpmjs/ui/Badge/Badge';
+import { Button } from '@tpmjs/ui/Button/Button';
+import { Container } from '@tpmjs/ui/Container/Container';
+import { Icon } from '@tpmjs/ui/Icon/Icon';
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { useSession } from '@/lib/auth-client';
+import { AppHeader } from '~/components/AppHeader';
+
+const EDITORS = [
+  {
+    id: 'claude-code' as const,
+    name: 'Claude Code',
+    description: 'Terminal CLI by Anthropic',
+    icon: '>_',
+  },
+  {
+    id: 'cursor' as const,
+    name: 'Cursor',
+    description: 'AI code editor',
+    icon: '{;}',
+  },
+  {
+    id: 'windsurf' as const,
+    name: 'Windsurf',
+    description: 'Agentic IDE',
+    icon: 'W',
+  },
+  {
+    id: 'claude-desktop' as const,
+    name: 'Claude Desktop',
+    description: 'Desktop app',
+    icon: 'C',
+  },
+] as const;
+
+type EditorId = (typeof EDITORS)[number]['id'];
+
+interface Collection {
+  id: string;
+  name: string;
+  slug: string | null;
+  description: string | null;
+  isPublic: boolean;
+  toolCount: number;
+}
+
+interface Mapping {
+  collectionId: string;
+  collectionSlug: string;
+  collectionName: string;
+  editor: EditorId;
+}
+
+type Step = 'collections' | 'editors' | 'command';
+
+export default function SetupPage(): React.ReactElement {
+  const { data: session, isPending } = useSession();
+
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [isLoadingCollections, setIsLoadingCollections] = useState(true);
+  const [selectedCollections, setSelectedCollections] = useState<Set<string>>(new Set());
+  const [mappings, setMappings] = useState<Map<string, EditorId>>(new Map());
+  const [step, setStep] = useState<Step>('collections');
+  const [installCommand, setInstallCommand] = useState('');
+  const [apiKeyCreated, setApiKeyCreated] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const fetchCollections = useCallback(async () => {
+    try {
+      const response = await fetch('/api/collections?limit=50');
+      const data = await response.json();
+      if (data.success && data.data) {
+        setCollections(data.data);
+      }
+    } catch {
+      setError('Failed to load collections');
+    } finally {
+      setIsLoadingCollections(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (session?.user) {
+      fetchCollections();
+    }
+  }, [session, fetchCollections]);
+
+  const toggleCollection = (id: string) => {
+    setSelectedCollections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+        setMappings((m) => {
+          const nm = new Map(m);
+          nm.delete(id);
+          return nm;
+        });
+      } else {
+        next.add(id);
+        // Default to claude-code
+        setMappings((m) => {
+          const nm = new Map(m);
+          nm.set(id, 'claude-code');
+          return nm;
+        });
+      }
+      return next;
+    });
+  };
+
+  const setEditorForCollection = (collectionId: string, editor: EditorId) => {
+    setMappings((m) => {
+      const nm = new Map(m);
+      nm.set(collectionId, editor);
+      return nm;
+    });
+  };
+
+  const generateInstallCommand = async () => {
+    setIsGenerating(true);
+    setError(null);
+
+    try {
+      const mappingPayload: Mapping[] = [];
+      for (const id of selectedCollections) {
+        const collection = collections.find((c) => c.id === id);
+        if (!collection) continue;
+        mappingPayload.push({
+          collectionId: id,
+          collectionSlug: collection.slug || collection.id,
+          collectionName: collection.name,
+          editor: mappings.get(id) || 'claude-code',
+        });
+      }
+
+      const response = await fetch('/api/setup/create-token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mappings: mappingPayload,
+          createApiKey: true,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to generate install command');
+      }
+
+      setInstallCommand(data.installCommand);
+      if (data.apiKey) {
+        setApiKeyCreated(data.apiKey);
+      }
+      setStep('command');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate install command');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const copyCommand = async () => {
+    await navigator.clipboard.writeText(installCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  // Not logged in
+  if (!isPending && !session?.user) {
+    return (
+      <>
+        <AppHeader />
+        <main className="min-h-screen bg-background">
+          <Container size="md" padding="lg" className="py-24">
+            <div className="text-center">
+              <div className="w-16 h-16 border border-dashed border-border bg-surface flex items-center justify-center mx-auto mb-6">
+                <span className="font-mono text-2xl text-primary">$</span>
+              </div>
+              <h1 className="font-mono text-3xl md:text-4xl font-bold text-foreground mb-4 lowercase">
+                set up tpmjs
+              </h1>
+              <p className="text-foreground-secondary mb-8 max-w-lg mx-auto">
+                Sign in to select your collections and generate a personalized install command that
+                configures your editors automatically.
+              </p>
+              <Link href="/auth/signin?callbackUrl=/setup">
+                <Button size="lg" variant="default">
+                  Sign In to Get Started
+                </Button>
+              </Link>
+            </div>
+          </Container>
+        </main>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <AppHeader />
+      <main className="min-h-screen bg-background">
+        <Container size="lg" padding="lg" className="py-12 md:py-20">
+          {/* Header */}
+          <div className="text-center mb-12">
+            <p className="font-mono text-xs text-primary uppercase tracking-widest mb-3">
+              one command setup
+            </p>
+            <h1 className="font-mono text-3xl md:text-4xl font-bold text-foreground mb-4 lowercase">
+              connect tpmjs to your editor
+            </h1>
+            <p className="text-foreground-secondary max-w-xl mx-auto">
+              Select collections, choose your editors, and get a single command that configures
+              everything.
+            </p>
+          </div>
+
+          {/* Progress Steps */}
+          <div className="flex items-center justify-center gap-2 mb-12 font-mono text-sm">
+            {(['collections', 'editors', 'command'] as Step[]).map((s, i) => (
+              <div key={s} className="flex items-center gap-2">
+                {i > 0 && (
+                  <div
+                    className={`w-8 h-px ${step === s || (['editors', 'command'].indexOf(step) > ['editors', 'command'].indexOf(s) ? true : false) ? 'bg-primary' : 'bg-border'}`}
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (s === 'collections') setStep('collections');
+                    else if (s === 'editors' && selectedCollections.size > 0) setStep('editors');
+                  }}
+                  className={`flex items-center gap-2 px-3 py-1.5 border transition-colors ${
+                    step === s
+                      ? 'border-primary text-primary bg-primary/5'
+                      : 'border-border text-foreground-tertiary hover:text-foreground-secondary'
+                  }`}
+                >
+                  <span className="w-5 h-5 border border-current flex items-center justify-center text-xs">
+                    {i + 1}
+                  </span>
+                  <span className="hidden sm:inline lowercase">{s}</span>
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {error && (
+            <div className="mb-8 p-4 border border-error/30 bg-error/5 text-error text-sm font-mono">
+              {error}
+            </div>
+          )}
+
+          {/* Step 1: Select Collections */}
+          {step === 'collections' && (
+            <div>
+              <fieldset className="border border-dashed border-border p-6 md:p-8">
+                <legend className="font-mono text-sm text-foreground-secondary px-3 lowercase">
+                  select collections
+                </legend>
+
+                {isPending || isLoadingCollections ? (
+                  <div className="text-center py-12 text-foreground-tertiary font-mono text-sm">
+                    Loading collections...
+                  </div>
+                ) : collections.length === 0 ? (
+                  <div className="text-center py-12">
+                    <p className="text-foreground-secondary mb-4">
+                      You don&apos;t have any collections yet.
+                    </p>
+                    <Link href="/dashboard/collections">
+                      <Button variant="default">Create a Collection</Button>
+                    </Link>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    {collections.map((collection) => {
+                      const isSelected = selectedCollections.has(collection.id);
+                      return (
+                        <button
+                          key={collection.id}
+                          type="button"
+                          onClick={() => toggleCollection(collection.id)}
+                          className={`text-left p-4 border transition-all ${
+                            isSelected
+                              ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                              : 'border-border bg-surface hover:border-foreground-tertiary'
+                          }`}
+                        >
+                          <div className="flex items-start justify-between gap-2 mb-1">
+                            <h3 className="font-mono text-sm font-semibold text-foreground">
+                              {collection.name}
+                            </h3>
+                            <div className="flex items-center gap-2">
+                              {collection.isPublic ? (
+                                <Badge variant="outline" size="sm">
+                                  public
+                                </Badge>
+                              ) : (
+                                <Badge variant="secondary" size="sm">
+                                  private
+                                </Badge>
+                              )}
+                              <div
+                                className={`w-4 h-4 border flex items-center justify-center transition-colors ${
+                                  isSelected
+                                    ? 'border-primary bg-primary text-white'
+                                    : 'border-border'
+                                }`}
+                              >
+                                {isSelected && <Icon icon="check" className="w-3 h-3" />}
+                              </div>
+                            </div>
+                          </div>
+                          {collection.description && (
+                            <p className="text-xs text-foreground-secondary line-clamp-2 mb-2">
+                              {collection.description}
+                            </p>
+                          )}
+                          <span className="font-mono text-xs text-foreground-tertiary">
+                            {collection.toolCount} tool{collection.toolCount !== 1 ? 's' : ''}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </fieldset>
+
+              <div className="flex justify-end mt-6">
+                <Button
+                  size="lg"
+                  variant="default"
+                  onClick={() => setStep('editors')}
+                  disabled={selectedCollections.size === 0}
+                >
+                  Choose Editors ({selectedCollections.size} selected)
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Step 2: Map Collections to Editors */}
+          {step === 'editors' && (
+            <div>
+              <fieldset className="border border-dashed border-border p-6 md:p-8">
+                <legend className="font-mono text-sm text-foreground-secondary px-3 lowercase">
+                  assign editors
+                </legend>
+
+                <div className="space-y-4">
+                  {Array.from(selectedCollections).map((collectionId) => {
+                    const collection = collections.find((c) => c.id === collectionId);
+                    if (!collection) return null;
+                    const currentEditor = mappings.get(collectionId) || 'claude-code';
+
+                    return (
+                      <div key={collectionId} className="p-4 border border-border bg-surface">
+                        <div className="flex items-center justify-between mb-3">
+                          <div>
+                            <h3 className="font-mono text-sm font-semibold text-foreground">
+                              {collection.name}
+                            </h3>
+                            <span className="font-mono text-xs text-foreground-tertiary">
+                              {collection.toolCount} tool{collection.toolCount !== 1 ? 's' : ''}
+                            </span>
+                          </div>
+                          <Icon icon="arrowRight" className="w-4 h-4 text-foreground-tertiary" />
+                        </div>
+                        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                          {EDITORS.map((editor) => (
+                            <button
+                              key={editor.id}
+                              type="button"
+                              onClick={() => setEditorForCollection(collectionId, editor.id)}
+                              className={`p-3 border text-center transition-all ${
+                                currentEditor === editor.id
+                                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                                  : 'border-border hover:border-foreground-tertiary'
+                              }`}
+                            >
+                              <div className="font-mono text-lg mb-1">{editor.icon}</div>
+                              <div className="font-mono text-xs font-medium text-foreground">
+                                {editor.name}
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </fieldset>
+
+              <div className="flex justify-between mt-6">
+                <Button variant="outline" onClick={() => setStep('collections')}>
+                  Back
+                </Button>
+                <Button
+                  size="lg"
+                  variant="default"
+                  onClick={generateInstallCommand}
+                  disabled={isGenerating}
+                >
+                  {isGenerating ? 'Generating...' : 'Generate Install Command'}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: Copy Command */}
+          {step === 'command' && (
+            <div>
+              <fieldset className="border border-dashed border-border p-6 md:p-8">
+                <legend className="font-mono text-sm text-foreground-secondary px-3 lowercase">
+                  your install command
+                </legend>
+
+                <p className="text-sm text-foreground-secondary mb-6">
+                  Run this in your terminal to configure all selected editors. The token expires in
+                  1 hour and can only be used once.
+                </p>
+
+                <div className="relative">
+                  <div className="p-4 bg-background border border-border font-mono text-sm overflow-x-auto">
+                    <code className="text-foreground break-all">{installCommand}</code>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={copyCommand}
+                    className="absolute top-3 right-3 p-2 text-foreground-tertiary hover:text-foreground transition-colors border border-border bg-surface"
+                  >
+                    <Icon icon={copied ? 'check' : 'copy'} size="xs" />
+                  </button>
+                </div>
+
+                {apiKeyCreated && (
+                  <div className="mt-4 p-4 border border-dashed border-primary/30 bg-primary/5">
+                    <div className="flex items-start gap-3">
+                      <Icon icon="key" size="sm" className="text-primary mt-0.5 flex-shrink-0" />
+                      <div>
+                        <p className="font-mono text-xs font-medium text-foreground mb-1 lowercase">
+                          api key auto-created
+                        </p>
+                        <p className="font-mono text-xs text-foreground-secondary">
+                          A TPMJS API key was created for authentication. It&apos;s embedded in the
+                          setup token and will be configured in your editors automatically.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Summary */}
+                <div className="mt-6 p-4 border border-border bg-surface">
+                  <h3 className="font-mono text-sm font-medium text-foreground mb-3 lowercase">
+                    what this will configure
+                  </h3>
+                  <div className="space-y-2">
+                    {Array.from(selectedCollections).map((collectionId) => {
+                      const collection = collections.find((c) => c.id === collectionId);
+                      const editor = EDITORS.find((e) => e.id === mappings.get(collectionId));
+                      if (!collection || !editor) return null;
+                      return (
+                        <div
+                          key={collectionId}
+                          className="flex items-center gap-3 font-mono text-xs"
+                        >
+                          <span className="text-foreground">{collection.name}</span>
+                          <span className="text-foreground-tertiary">→</span>
+                          <span className="text-primary">{editor.name}</span>
+                          <span className="text-foreground-tertiary">
+                            ({collection.toolCount} tool{collection.toolCount !== 1 ? 's' : ''})
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </fieldset>
+
+              <div className="flex justify-between mt-6">
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setStep('editors');
+                    setInstallCommand('');
+                    setApiKeyCreated(null);
+                  }}
+                >
+                  Back
+                </Button>
+                <Button variant="outline" onClick={() => copyCommand()}>
+                  <Icon icon={copied ? 'check' : 'copy'} size="xs" className="mr-2" />
+                  {copied ? 'Copied!' : 'Copy Command'}
+                </Button>
+              </div>
+            </div>
+          )}
+        </Container>
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/components/home/GetStartedSection.tsx
+++ b/apps/web/src/components/home/GetStartedSection.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { Button } from '@tpmjs/ui/Button/Button';
+import { Container } from '@tpmjs/ui/Container/Container';
+import { Icon } from '@tpmjs/ui/Icon/Icon';
+import Link from 'next/link';
+import { useState } from 'react';
+
+const INSTALL_CMD = 'curl -fsSL https://tpmjs.com/install.sh | bash';
+
+function CopyButton({ text, className }: { text: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className={`p-1.5 text-foreground-tertiary hover:text-foreground transition-colors ${className || ''}`}
+      aria-label="Copy to clipboard"
+    >
+      <Icon icon={copied ? 'check' : 'copy'} size="xs" />
+    </button>
+  );
+}
+
+export function GetStartedSection(): React.ReactElement {
+  return (
+    <section className="py-20 bg-surface border-t border-border relative overflow-hidden">
+      {/* Subtle diagonal lines background */}
+      <div className="absolute inset-0 opacity-[0.02]">
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: `repeating-linear-gradient(
+              -45deg,
+              currentColor,
+              currentColor 1px,
+              transparent 1px,
+              transparent 20px
+            )`,
+          }}
+        />
+      </div>
+
+      <Container size="xl" padding="lg" className="relative z-10">
+        {/* Section Header */}
+        <div className="text-center mb-16">
+          <p className="font-mono text-xs text-primary uppercase tracking-widest mb-3">
+            get started in 60 seconds
+          </p>
+          <h2 className="font-mono text-3xl md:text-4xl font-semibold mb-4 text-foreground lowercase">
+            one command. every editor.
+          </h2>
+          <p className="text-base text-foreground-secondary max-w-xl mx-auto font-sans">
+            Configure your AI tools across Claude Code, Cursor, Windsurf, and more with a single
+            install command. Choose your collections, pick your editors, run the script.
+          </p>
+        </div>
+
+        {/* 3-Step Flow */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-4 mb-16">
+          {/* Step 1 */}
+          <div className="group p-6 border border-dashed border-border bg-background hover:border-primary hover:bg-primary/5 transition-all duration-200">
+            <div className="w-12 h-12 flex items-center justify-center mb-4 border border-dashed border-border bg-surface group-hover:border-primary group-hover:bg-primary/10 transition-all duration-200">
+              <span className="font-mono text-lg text-primary">1</span>
+            </div>
+            <h3 className="font-mono text-sm font-medium text-foreground mb-2 lowercase">
+              pick your collections
+            </h3>
+            <p className="font-sans text-xs text-foreground-secondary leading-relaxed">
+              Select which tool collections you want in your editors. Your collections, or any
+              public collection.
+            </p>
+          </div>
+
+          {/* Step 2 */}
+          <div className="group p-6 border border-dashed border-border bg-background hover:border-primary hover:bg-primary/5 transition-all duration-200">
+            <div className="w-12 h-12 flex items-center justify-center mb-4 border border-dashed border-border bg-surface group-hover:border-primary group-hover:bg-primary/10 transition-all duration-200">
+              <span className="font-mono text-lg text-primary">2</span>
+            </div>
+            <h3 className="font-mono text-sm font-medium text-foreground mb-2 lowercase">
+              choose your editors
+            </h3>
+            <p className="font-sans text-xs text-foreground-secondary leading-relaxed">
+              Map each collection to Claude Code, Cursor, Windsurf, or Claude Desktop. Different
+              collections for different editors.
+            </p>
+          </div>
+
+          {/* Step 3 */}
+          <div className="group p-6 border border-dashed border-border bg-background hover:border-primary hover:bg-primary/5 transition-all duration-200">
+            <div className="w-12 h-12 flex items-center justify-center mb-4 border border-dashed border-border bg-surface group-hover:border-primary group-hover:bg-primary/10 transition-all duration-200">
+              <span className="font-mono text-lg text-primary">3</span>
+            </div>
+            <h3 className="font-mono text-sm font-medium text-foreground mb-2 lowercase">
+              run one command
+            </h3>
+            <p className="font-sans text-xs text-foreground-secondary leading-relaxed">
+              Paste in your terminal. The script auto-configures MCP servers in every selected
+              editor. Done.
+            </p>
+          </div>
+        </div>
+
+        {/* Command Box */}
+        <fieldset className="border border-dashed border-border p-6 md:p-8 max-w-2xl mx-auto mb-12">
+          <legend className="font-mono text-sm text-foreground-secondary px-3 lowercase">
+            install script
+          </legend>
+
+          <div className="relative">
+            <div className="p-4 bg-background border border-border font-mono text-sm overflow-x-auto">
+              <div className="flex items-center gap-3">
+                <span className="text-primary font-bold select-none">$</span>
+                <pre className="text-foreground whitespace-pre">{INSTALL_CMD}</pre>
+              </div>
+            </div>
+            <CopyButton text={INSTALL_CMD} className="absolute top-3 right-3" />
+          </div>
+
+          <div className="mt-4 flex items-start gap-3 p-3 bg-background border border-dashed border-border">
+            <span className="font-mono text-xs text-primary mt-0.5">tip</span>
+            <p className="font-mono text-xs text-foreground-secondary">
+              visit{' '}
+              <Link href="/setup" className="text-primary hover:underline">
+                tpmjs.com/setup
+              </Link>{' '}
+              first to select your collections and get a personalized command with your setup token
+              included.
+            </p>
+          </div>
+        </fieldset>
+
+        {/* Supported Editors */}
+        <div className="flex flex-wrap justify-center gap-4 mb-12">
+          {[
+            { icon: '>_', name: 'Claude Code' },
+            { icon: 'C', name: 'Claude Desktop' },
+            { icon: '{;}', name: 'Cursor' },
+            { icon: 'W', name: 'Windsurf' },
+          ].map((editor) => (
+            <div
+              key={editor.name}
+              className="flex items-center gap-2 px-4 py-2 border border-border bg-background font-mono text-sm"
+            >
+              <span className="text-primary font-bold">{editor.icon}</span>
+              <span className="text-foreground-secondary">{editor.name}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* CTA */}
+        <div className="text-center">
+          <div className="inline-flex flex-col sm:flex-row gap-4">
+            <Link href="/setup">
+              <Button size="lg" variant="default">
+                Configure Your Setup
+              </Button>
+            </Link>
+            <Link href="/collections">
+              <Button size="lg" variant="outline">
+                Browse Collections
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -429,6 +429,7 @@ model User {
   memories         Memory[]
   customMcpServers CustomMcpServer[]
   workflows        Workflow[]
+  setupTokens      SetupToken[]
 
   @@index([username])
   @@map("users")
@@ -2337,4 +2338,34 @@ model WorkflowNodeExecution {
   @@index([executionId])
   @@index([nodeId])
   @@map("workflow_node_executions")
+}
+
+/// SetupToken - one-time tokens for the install.sh setup flow
+/// Created from the web UI, redeemed by the install script to configure editors
+model SetupToken {
+  id        String   @id @default(cuid())
+
+  // Owner
+  userId    String   @map("user_id")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // Token (unique, short-lived)
+  token     String   @unique @db.VarChar(64)
+
+  // Configuration payload (collections + editors mapping)
+  config    Json     @db.JsonB
+  // config shape: { mappings: [{ collectionId, collectionSlug, collectionName, editor }], apiKey?: string }
+
+  // Status
+  redeemed    Boolean   @default(false)
+  redeemedAt  DateTime? @map("redeemed_at")
+  expiresAt   DateTime  @map("expires_at")
+
+  // Timestamps
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([token])
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("setup_tokens")
 }


### PR DESCRIPTION
## Summary

- Adds a complete **setup wizard** at `/setup` where users select collections, map them to editors (Claude Code, Cursor, Windsurf, Claude Desktop), and get a personalized `curl | bash` install command
- Adds a **"Get Started" homepage section** (positioned right after the hero/search) with the 3-step flow and install command
- The install script auto-configures MCP servers in all selected editors via a one-time setup token

### What's included

**Database:**
- `SetupToken` model — one-time tokens with 1hr TTL, stores collection→editor mappings + optional API key

**API Routes:**
- `POST /api/setup/create-token` — session-authenticated, creates token + optional TPMJS API key
- `GET /api/setup/redeem/[token]` — redeems token from install.sh, returns config payload
- `GET /api/setup/install.sh` — serves the bash script (also available at `tpmjs.com/install.sh` via Next.js rewrite)

**Frontend:**
- `/setup` page — 3-step wizard (select collections → assign editors → copy command)
- `GetStartedSection` — new homepage section showing the 3-step flow + install command box

**Install script capabilities:**
- Detects available editors (checks for `claude` CLI, cursor/windsurf/claude-desktop config paths)
- Claude Code: uses `claude mcp add-json` CLI command
- Cursor/Windsurf/Claude Desktop: merges into respective JSON config files using Node.js
- Colorized output with success/failure summary

### Flow
1. User visits `tpmjs.com/setup` (must be logged in)
2. Selects collections and maps each to an editor
3. Clicks "Generate Install Command" → creates a setup token with 1hr TTL
4. Copies `curl -fsSL https://tpmjs.com/install.sh | bash -s -- --token=<token>`
5. Runs in terminal → script redeems token, configures all editors, prints summary

## Test plan
- [ ] Visit `/setup` logged out — shows sign-in prompt
- [ ] Visit `/setup` logged in — loads user's collections
- [ ] Select collections, assign editors, generate command
- [ ] Verify the install command copies to clipboard
- [ ] Run install.sh with a valid token — configures Claude Code via `claude mcp add-json`
- [ ] Run install.sh with expired/used token — shows appropriate error
- [ ] Verify homepage shows the new "Get Started" section after the hero
- [ ] Verify `tpmjs.com/install.sh` serves the bash script (rewrite rule)