### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/refresh-vercel-openapi.md
+++ b/.changeset/refresh-vercel-openapi.md
@@ -1,5 +1,0 @@
----
-'@tpmjs/tools-vercel': minor
----
-
-Ship the 167-tool Vercel API surface, update stale routes and request shapes against the current official OpenAPI contract, and add automated upstream contract-drift verification.

--- a/.changeset/restore-unsandbox-contracts.md
+++ b/.changeset/restore-unsandbox-contracts.md
@@ -1,5 +1,0 @@
----
-'@tpmjs/tools-unsandbox': patch
----
-
-Restore the complete 85-tool Unsandbox API surface and add author-declared health-check and cleanup contracts for safe registry monitoring.

--- a/packages/tools/official/unsandbox/CHANGELOG.md
+++ b/packages/tools/official/unsandbox/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-unsandbox
+
+## 0.1.5
+
+### Patch Changes
+
+- d87c927: Restore the complete 85-tool Unsandbox API surface and add author-declared health-check and cleanup contracts for safe registry monitoring.

--- a/packages/tools/official/unsandbox/package.json
+++ b/packages/tools/official/unsandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpmjs/tools-unsandbox",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Execute code in a secure sandbox environment. Supports 42+ programming languages with async execution, input files, and compiled artifacts.",
   "type": "module",
   "keywords": [

--- a/packages/tools/official/vercel/CHANGELOG.md
+++ b/packages/tools/official/vercel/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-vercel
+
+## 0.3.0
+
+### Minor Changes
+
+- d87c927: Ship the 167-tool Vercel API surface, update stale routes and request shapes against the current official OpenAPI contract, and add automated upstream contract-drift verification.

--- a/packages/tools/official/vercel/package.json
+++ b/packages/tools/official/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpmjs/tools-vercel",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Vercel platform API tools for AI agents. Manage projects, deployments, domains, DNS, teams, edge config, environment variables, and more.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Release plan

- publish `@tpmjs/tools-unsandbox@0.1.5` (patch)
- publish `@tpmjs/tools-vercel@0.3.0` (minor)

This is the reviewed Changesets output from #126. The fail-closed registry audit reports 213 current packages, exactly these 2 publish candidates, and 0 unsafe entries.

The automated release job successfully passed build and provenance verification, but the organization policy prevents `GITHUB_TOKEN` from creating pull requests. This maintainer-created PR contains the exact six-file Changesets output; publication remains gated on this PR and its CI.