### PR TITLE
build(release): replace expired npm token with OIDC trust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Test
         run: |
           pnpm release:audit:test
+          pnpm release:auth:test
           pnpm verify:vercel-api:test
           pnpm test
 

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Test release policy and external contracts
         run: |
           pnpm release:audit:test
+          pnpm release:auth:test
           pnpm verify:vercel-api:test
           pnpm verify:vercel-api
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -31,15 +32,37 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test release policy and external contracts
+        run: |
+          pnpm release:audit:test
+          pnpm release:auth:test
+          pnpm verify:vercel-api:test
+
+      - name: Audit release provenance
+        run: pnpm release:audit --format json --output release-audit.json
+
+      - name: Verify npm trusted-publishing authorization
+        run: pnpm release:auth --audit release-audit.json --output release-auth.json
+
+      - name: Upload release preflight evidence
+        if: ${{ always() && hashFiles('release-audit.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-preflight-${{ github.sha }}
+          path: |
+            release-audit.json
+            release-auth.json
+          if-no-files-found: error
+
+      - name: Verify live external contracts
+        run: |
+          pnpm verify:vercel-api
+
       - name: Build
         run: pnpm build
 
-      - name: Verify release provenance and external contracts
-        run: |
-          pnpm release:audit:test
-          pnpm verify:vercel-api:test
-          pnpm verify:vercel-api
-          pnpm release:audit
+      - name: Install OIDC-capable npm client
+        run: npm install --global npm@11.18.0
 
       - name: Create Release Pull Request or Publish
         id: changesets
@@ -51,5 +74,3 @@ jobs:
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for ver
 - Comprehensive style guide and missing UI components
 - Auto-close and auto-merge pipelines for CI
 - Fail-closed registry release audit with machine-readable CI evidence
+- Package-scoped npm Trusted Publishing preflight with short-lived GitHub OIDC credentials
 - Weekly Vercel OpenAPI contract-drift verification for all 167 Vercel tools
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,7 +20,7 @@ How TPMJS packages get versioned and published to npm. The goals: **every releas
 
 3. **Review the version PR.** It shows exactly which packages bump to which versions and why. This is the human gate.
 
-4. **Merge the version PR.** On merge, the Release workflow runs `pnpm changeset:publish` and publishes the bumped packages to npm using the `NPM_TOKEN` repository secret. Only packages whose source version is ahead of npm are published.
+4. **Merge the version PR.** On merge, the Release workflow proves package-level publish authority through npm Trusted Publishing, runs `pnpm changeset:publish`, and publishes the bumped packages. Only packages whose source version is ahead of npm are published.
 
 > [!IMPORTANT]
 > **Every push to `main` runs `changeset publish`.** When there are no pending changesets, the Release workflow still runs the publish step to catch up any package whose source `version` is **ahead of npm** — and it *will* publish it. In other words: **bumping a package's `version` in `package.json` and pushing to `main` publishes it.** Always bump versions through changesets (never by hand on `main`), and run `pnpm release:preview` first to see exactly what is ahead of npm. New non-published packages (examples, demos, internal tooling) must be marked `"private": true` so they're never picked up.
@@ -43,6 +43,34 @@ The registry audit is fail-closed and machine-readable. It blocks when:
 - a workspace contains an invalid semantic version.
 
 `pnpm release:audit --format json` emits the complete plan for automation, while `--format markdown` produces a review summary. Pass `--json-output <path>` to persist the full JSON evidence alongside any selected display format without refetching npm. The manual **Release Preview** workflow uploads its status, human summary, and package-by-package JSON audit as immutable run artifacts. The Release workflow runs the same audit immediately before Changesets can publish.
+
+## npm authentication
+
+TPMJS publishes through [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) rather than a rotating registry token. The Release job has GitHub's `id-token: write` permission and uses npm 11.18.0. Before the monorepo build, `pnpm release:auth` requests an identity token with the exact `npm:registry.npmjs.org` audience and exchanges it with npm independently for every package in the audited publish set. The short-lived exchange tokens are checked in memory and discarded; release evidence contains only package names, versions, and expiry times.
+
+Every existing npm package must trust this exact publisher:
+
+```text
+GitHub owner/repository: tpmjs/tpmjs
+Workflow filename:       release.yml
+Allowed action:          npm publish
+Environment:             (none)
+```
+
+An npm maintainer with an interactive session and 2FA can configure a package with npm 11.18.0:
+
+```bash
+npm trust github @tpmjs/PACKAGE --file release.yml --repo tpmjs/tpmjs --allow-publish
+```
+
+Trusted Publishing cannot bootstrap a name that does not exist on npm. A genuinely new package must be published once by a maintainer, then configured with the command above before normal automated releases. The preflight fails explicitly for that state.
+
+During the July 2026 migration, the required commands for the pending releases are:
+
+```bash
+npm trust github @tpmjs/tools-unsandbox --file release.yml --repo tpmjs/tpmjs --allow-publish
+npm trust github @tpmjs/tools-vercel --file release.yml --repo tpmjs/tpmjs --allow-publish
+```
 
 ## Changelogs
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "release:status": "changeset status --verbose",
     "release:audit": "tsx scripts/release-audit.ts",
     "release:audit:test": "tsx --test scripts/release-audit.test.ts",
+    "release:auth": "tsx scripts/release-auth.ts",
+    "release:auth:test": "tsx --test scripts/release-auth.test.ts",
     "release:preview": "pnpm release:status && pnpm release:audit",
     "verify:vercel-api": "tsx scripts/verify-vercel-api.ts",
     "verify:vercel-api:test": "tsx --test scripts/vercel-contract.test.ts scripts/vercel-tools.test.ts",

--- a/scripts/release-auth-lib.ts
+++ b/scripts/release-auth-lib.ts
@@ -1,0 +1,141 @@
+export type ReleaseCandidateState = 'publish' | 'new-package';
+
+export interface ReleaseCandidate {
+  name: string;
+  version: string;
+  state: ReleaseCandidateState;
+}
+
+export interface OidcEnvironment {
+  requestUrl: string;
+  requestToken: string;
+}
+
+export interface OidcAuthorization {
+  name: string;
+  version: string;
+  expires: string;
+}
+
+type Fetcher = typeof fetch;
+
+function asRecord(value: unknown, description: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${description} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requiredString(record: Record<string, unknown>, key: string, description: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${description}.${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+export function releaseCandidates(audit: unknown): ReleaseCandidate[] {
+  const document = asRecord(audit, 'Release audit');
+  const summary = asRecord(document.summary, 'Release audit summary');
+  if (summary.safe !== true) {
+    throw new Error('Release audit is not safe; refusing to authorize publishing');
+  }
+  if (!Number.isInteger(summary.publishCount) || Number(summary.publishCount) < 0) {
+    throw new Error('Release audit summary.publishCount must be a non-negative integer');
+  }
+  if (!Array.isArray(document.packages)) {
+    throw new Error('Release audit packages must be an array');
+  }
+
+  const candidates: ReleaseCandidate[] = [];
+  for (const [index, value] of document.packages.entries()) {
+    const entry = asRecord(value, `Release audit package ${index}`);
+    if (entry.safe !== true) {
+      throw new Error(`Release audit package ${index} is not safe`);
+    }
+    if (entry.state !== 'publish' && entry.state !== 'new-package') continue;
+    candidates.push({
+      name: requiredString(entry, 'name', `Release audit package ${index}`),
+      version: requiredString(entry, 'version', `Release audit package ${index}`),
+      state: entry.state,
+    });
+  }
+
+  if (candidates.length !== summary.publishCount) {
+    throw new Error(
+      `Release audit publish count mismatch: summary=${summary.publishCount}, packages=${candidates.length}`
+    );
+  }
+  return candidates;
+}
+
+export function githubOidcUrl(requestUrl: string): string {
+  const url = new URL(requestUrl);
+  url.searchParams.set('audience', 'npm:registry.npmjs.org');
+  return url.toString();
+}
+
+export function npmOidcExchangeUrl(packageName: string): string {
+  return `https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(packageName)}`;
+}
+
+async function responseMessage(response: Response): Promise<string> {
+  try {
+    const value: unknown = await response.json();
+    const record = asRecord(value, 'Error response');
+    for (const key of ['message', 'error']) {
+      if (typeof record[key] === 'string') return record[key];
+    }
+  } catch {
+    // The status remains sufficient when a remote endpoint does not return JSON.
+  }
+  return response.statusText || 'request failed';
+}
+
+export async function requestGitHubOidcToken(
+  environment: OidcEnvironment,
+  fetcher: Fetcher = fetch
+): Promise<string> {
+  const response = await fetcher(githubOidcUrl(environment.requestUrl), {
+    headers: { Authorization: `Bearer ${environment.requestToken}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub OIDC request failed with HTTP ${response.status}: ${await responseMessage(response)}`
+    );
+  }
+  const document = asRecord(await response.json(), 'GitHub OIDC response');
+  return requiredString(document, 'value', 'GitHub OIDC response');
+}
+
+export async function authorizeNpmPackage(
+  candidate: ReleaseCandidate,
+  oidcToken: string,
+  fetcher: Fetcher = fetch
+): Promise<OidcAuthorization> {
+  const response = await fetcher(npmOidcExchangeUrl(candidate.name), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${oidcToken}`,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (response.status !== 201) {
+    throw new Error(
+      `npm trusted publishing rejected ${candidate.name}@${candidate.version} with HTTP ${response.status}: ${await responseMessage(response)}`
+    );
+  }
+
+  const document = asRecord(await response.json(), 'npm OIDC exchange response');
+  requiredString(document, 'token', 'npm OIDC exchange response');
+  if (document.token_type !== 'oidc') {
+    throw new Error('npm OIDC exchange response.token_type must be oidc');
+  }
+  return {
+    name: candidate.name,
+    version: candidate.version,
+    expires: requiredString(document, 'expires', 'npm OIDC exchange response'),
+  };
+}

--- a/scripts/release-auth.test.ts
+++ b/scripts/release-auth.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  authorizeNpmPackage,
+  githubOidcUrl,
+  npmOidcExchangeUrl,
+  releaseCandidates,
+  requestGitHubOidcToken,
+} from './release-auth-lib';
+
+const audit = {
+  summary: { safe: true, publishCount: 2 },
+  packages: [
+    { name: '@tpmjs/current', version: '1.0.0', state: 'current', safe: true },
+    { name: '@tpmjs/existing', version: '1.1.0', state: 'publish', safe: true },
+    { name: '@tpmjs/new', version: '0.1.0', state: 'new-package', safe: true },
+  ],
+};
+
+test('extracts only safe publish candidates and preserves their state', () => {
+  assert.deepEqual(releaseCandidates(audit), [
+    { name: '@tpmjs/existing', version: '1.1.0', state: 'publish' },
+    { name: '@tpmjs/new', version: '0.1.0', state: 'new-package' },
+  ]);
+});
+
+test('fails closed on an unsafe audit or inconsistent publish count', () => {
+  assert.throws(
+    () => releaseCandidates({ ...audit, summary: { safe: false, publishCount: 2 } }),
+    /not safe/
+  );
+  assert.throws(
+    () => releaseCandidates({ ...audit, summary: { safe: true, publishCount: 1 } }),
+    /publish count mismatch/
+  );
+});
+
+test('constructs exact GitHub audience and encoded npm package URLs', () => {
+  assert.equal(
+    githubOidcUrl('https://actions.example/token?api-version=1'),
+    'https://actions.example/token?api-version=1&audience=npm%3Aregistry.npmjs.org'
+  );
+  assert.equal(
+    npmOidcExchangeUrl('@tpmjs/tools-vercel'),
+    'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40tpmjs%2Ftools-vercel'
+  );
+});
+
+test('requests the npm audience without exposing the GitHub bearer token', async () => {
+  let request: { url: string; authorization: string | null } | null = null;
+  const fetcher: typeof fetch = async (input, init) => {
+    request = {
+      url: String(input),
+      authorization: new Headers(init?.headers).get('authorization'),
+    };
+    return Response.json({ value: 'short-lived-github-identity' });
+  };
+  const token = await requestGitHubOidcToken(
+    { requestUrl: 'https://actions.example/token', requestToken: 'runner-secret' },
+    fetcher
+  );
+  assert.equal(token, 'short-lived-github-identity');
+  assert.deepEqual(request, {
+    url: 'https://actions.example/token?audience=npm%3Aregistry.npmjs.org',
+    authorization: 'Bearer runner-secret',
+  });
+});
+
+test('verifies package-scoped npm exchange and retains no registry token', async () => {
+  let request: { url: string; method: string | undefined; authorization: string | null } | null =
+    null;
+  const fetcher: typeof fetch = async (input, init) => {
+    request = {
+      url: String(input),
+      method: init?.method,
+      authorization: new Headers(init?.headers).get('authorization'),
+    };
+    return Response.json(
+      { token_type: 'oidc', token: 'discard-me', expires: '2026-07-21T11:00:00.000Z' },
+      { status: 201 }
+    );
+  };
+  const authorization = await authorizeNpmPackage(
+    { name: '@tpmjs/tools-vercel', version: '0.3.0', state: 'publish' },
+    'github-identity',
+    fetcher
+  );
+  assert.deepEqual(authorization, {
+    name: '@tpmjs/tools-vercel',
+    version: '0.3.0',
+    expires: '2026-07-21T11:00:00.000Z',
+  });
+  assert.deepEqual(request, {
+    url: 'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40tpmjs%2Ftools-vercel',
+    method: 'POST',
+    authorization: 'Bearer github-identity',
+  });
+});
+
+test('reports package identity and HTTP status when npm rejects trust', async () => {
+  const fetcher: typeof fetch = async () =>
+    Response.json({ message: 'trusted publisher not configured' }, { status: 401 });
+  await assert.rejects(
+    authorizeNpmPackage(
+      { name: '@tpmjs/tools-vercel', version: '0.3.0', state: 'publish' },
+      'github-identity',
+      fetcher
+    ),
+    /@tpmjs\/tools-vercel@0\.3\.0.*HTTP 401.*trusted publisher not configured/
+  );
+});

--- a/scripts/release-auth.ts
+++ b/scripts/release-auth.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env tsx
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  authorizeNpmPackage,
+  type OidcAuthorization,
+  releaseCandidates,
+  requestGitHubOidcToken,
+} from './release-auth-lib';
+
+interface CliOptions {
+  audit: string;
+  output: string | null;
+}
+
+function optionValue(args: readonly string[], index: number, option: string): string {
+  const value = args[index + 1];
+  if (!value) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+function parseOptions(args: readonly string[]): CliOptions {
+  let audit = 'release-audit.json';
+  let output: string | null = null;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    switch (argument) {
+      case '--audit':
+        audit = optionValue(args, index, argument);
+        index += 1;
+        break;
+      case '--output':
+        output = optionValue(args, index, argument);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return { audit, output };
+}
+
+function appendGithubFile(path: string | undefined, content: string): void {
+  if (path) appendFileSync(path, content);
+}
+
+function writeEvidence(
+  options: CliOptions,
+  mode: 'none' | 'oidc',
+  authorizations: readonly OidcAuthorization[]
+): void {
+  const evidence = {
+    checkedAt: new Date().toISOString(),
+    mode,
+    repository: process.env.GITHUB_REPOSITORY ?? null,
+    workflow: process.env.GITHUB_WORKFLOW_REF ?? null,
+    packages: authorizations,
+  };
+  if (options.output) writeFileSync(options.output, `${JSON.stringify(evidence, null, 2)}\n`);
+  appendGithubFile(
+    process.env.GITHUB_OUTPUT,
+    `mode=${mode}\npublish-count=${authorizations.length}\n`
+  );
+
+  const lines = [
+    '## npm publish authorization',
+    '',
+    mode === 'none'
+      ? 'No unpublished package versions were found; npm authorization was not needed.'
+      : `Trusted publishing authorized ${authorizations.length} package${authorizations.length === 1 ? '' : 's'} through GitHub OIDC.`,
+  ];
+  if (authorizations.length > 0) {
+    lines.push('', '| Package | Version | Exchange expires |', '| --- | --- | --- |');
+    for (const authorization of authorizations) {
+      lines.push(`| ${authorization.name} | ${authorization.version} | ${authorization.expires} |`);
+    }
+  }
+  appendGithubFile(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const candidates = releaseCandidates(JSON.parse(readFileSync(options.audit, 'utf8')));
+  if (candidates.length === 0) {
+    writeEvidence(options, 'none', []);
+    console.log('npm authorization: not needed (nothing would publish)');
+    return;
+  }
+
+  const newPackages = candidates.filter((candidate) => candidate.state === 'new-package');
+  if (newPackages.length > 0) {
+    throw new Error(
+      `Trusted publishing cannot bootstrap an unpublished package. Publish once interactively, then configure npm trust for: ${newPackages.map((candidate) => candidate.name).join(', ')}`
+    );
+  }
+
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  if (!requestUrl || !requestToken) {
+    throw new Error(
+      'GitHub OIDC is unavailable. The release job must run on a GitHub-hosted runner with permissions.id-token=write.'
+    );
+  }
+
+  const oidcToken = await requestGitHubOidcToken({ requestUrl, requestToken });
+  const authorizations: OidcAuthorization[] = [];
+  for (const candidate of candidates) {
+    authorizations.push(await authorizeNpmPackage(candidate, oidcToken));
+  }
+  writeEvidence(options, 'oidc', authorizations);
+  console.log(
+    `npm authorization: OIDC trusted publishing verified for ${authorizations.map((entry) => `${entry.name}@${entry.version}`).join(', ')}`
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Outcome

Replaces TPMJS's necessarily expired long-lived npm write token with package-scoped npm Trusted Publishing, and proves publish authority before the expensive monorepo build.

The July 21 release selected exactly `@tpmjs/tools-unsandbox@0.1.5` and `@tpmjs/tools-vercel@0.3.0`, but npm rejected both PUTs. Neither version was published. The repository secret was last updated 2025-12-11; npm write tokens have a hard 90-day maximum, so that credential cannot still be valid.

## What changes

- grants the Release job `id-token: write` and removes `NPM_TOKEN` / `NODE_AUTH_TOKEN` from publishing;
- requests a GitHub OIDC token for the exact `npm:registry.npmjs.org` audience;
- exchanges it with npm independently for every audited publish candidate;
- fails before the build when package trust is absent or malformed;
- never logs or persists either exchanged token;
- uploads package/version/expiry preflight evidence;
- pins the publish client to OIDC-capable npm 11.18.0;
- fails explicitly for a genuinely new package, which npm trust cannot configure before its first publish;
- documents the exact npm trust configuration and migration commands.

## Validation

- `pnpm release:auth:test`: 6/6
- `pnpm release:audit:test`: 8/8
- current registry audit: SAFE, 215 workspaces, 213 current, exactly 2 publish candidates
- full `pnpm lint`: green (existing warnings only)
- full `pnpm type-check`: 238/238
- full `pnpm format:check`: 2,046 files, no fixes
- workflow YAML parsed successfully
- local non-GitHub execution fails closed with the intended missing-OIDC error
- no lockfile changes

## Activation

An npm maintainer must configure these two existing packages for `tpmjs/tpmjs`, workflow `release.yml`, action `npm publish`:

```bash
npm trust github @tpmjs/tools-unsandbox --file release.yml --repo tpmjs/tpmjs --allow-publish
npm trust github @tpmjs/tools-vercel --file release.yml --repo tpmjs/tpmjs --allow-publish
```

The first main-branch Release run will perform the real package-specific exchange before it can build or publish.
