### PR TITLE
build(release): report every missing npm trust grant

### DIFF
--- a/scripts/release-auth-lib.ts
+++ b/scripts/release-auth-lib.ts
@@ -17,6 +17,17 @@ export interface OidcAuthorization {
   expires: string;
 }
 
+export interface OidcDenial {
+  name: string;
+  version: string;
+  error: string;
+}
+
+export interface OidcAuthorizationReport {
+  authorized: OidcAuthorization[];
+  denied: OidcDenial[];
+}
+
 type Fetcher = typeof fetch;
 
 function asRecord(value: unknown, description: string): Record<string, unknown> {
@@ -138,4 +149,24 @@ export async function authorizeNpmPackage(
     version: candidate.version,
     expires: requiredString(document, 'expires', 'npm OIDC exchange response'),
   };
+}
+
+export async function authorizeNpmPackages(
+  candidates: readonly ReleaseCandidate[],
+  oidcToken: string,
+  fetcher: Fetcher = fetch
+): Promise<OidcAuthorizationReport> {
+  const report: OidcAuthorizationReport = { authorized: [], denied: [] };
+  for (const candidate of candidates) {
+    try {
+      report.authorized.push(await authorizeNpmPackage(candidate, oidcToken, fetcher));
+    } catch (error) {
+      report.denied.push({
+        name: candidate.name,
+        version: candidate.version,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return report;
 }

--- a/scripts/release-auth.test.ts
+++ b/scripts/release-auth.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   authorizeNpmPackage,
+  authorizeNpmPackages,
   githubOidcUrl,
   npmOidcExchangeUrl,
   releaseCandidates,
@@ -108,4 +109,27 @@ test('reports package identity and HTTP status when npm rejects trust', async ()
     ),
     /@tpmjs\/tools-vercel@0\.3\.0.*HTTP 401.*trusted publisher not configured/
   );
+});
+
+test('checks every publish candidate and reports all denied trust grants', async () => {
+  const attempted: string[] = [];
+  const fetcher: typeof fetch = async (input) => {
+    const packageName = decodeURIComponent(String(input).split('/').at(-1) ?? '');
+    attempted.push(packageName);
+    return Response.json({ message: 'trusted publisher not configured' }, { status: 404 });
+  };
+  const report = await authorizeNpmPackages(
+    [
+      { name: '@tpmjs/tools-unsandbox', version: '0.1.5', state: 'publish' },
+      { name: '@tpmjs/tools-vercel', version: '0.3.0', state: 'publish' },
+    ],
+    'github-identity',
+    fetcher
+  );
+
+  assert.deepEqual(attempted, ['@tpmjs/tools-unsandbox', '@tpmjs/tools-vercel']);
+  assert.deepEqual(report.authorized, []);
+  assert.equal(report.denied.length, 2);
+  assert.match(report.denied[0].error, /@tpmjs\/tools-unsandbox@0\.1\.5.*HTTP 404/);
+  assert.match(report.denied[1].error, /@tpmjs\/tools-vercel@0\.3\.0.*HTTP 404/);
 });

--- a/scripts/release-auth.ts
+++ b/scripts/release-auth.ts
@@ -2,8 +2,9 @@
 
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
 import {
-  authorizeNpmPackage,
+  authorizeNpmPackages,
   type OidcAuthorization,
+  type OidcDenial,
   releaseCandidates,
   requestGitHubOidcToken,
 } from './release-auth-lib';
@@ -44,37 +45,66 @@ function appendGithubFile(path: string | undefined, content: string): void {
   if (path) appendFileSync(path, content);
 }
 
-function writeEvidence(
-  options: CliOptions,
-  mode: 'none' | 'oidc',
-  authorizations: readonly OidcAuthorization[]
-): void {
-  const evidence = {
-    checkedAt: new Date().toISOString(),
-    mode,
-    repository: process.env.GITHUB_REPOSITORY ?? null,
-    workflow: process.env.GITHUB_WORKFLOW_REF ?? null,
-    packages: authorizations,
-  };
-  if (options.output) writeFileSync(options.output, `${JSON.stringify(evidence, null, 2)}\n`);
-  appendGithubFile(
-    process.env.GITHUB_OUTPUT,
-    `mode=${mode}\npublish-count=${authorizations.length}\n`
-  );
+function evidenceSummary(
+  mode: 'none' | 'oidc' | 'denied',
+  authorizedCount: number,
+  deniedCount: number
+): string {
+  if (mode === 'none') {
+    return 'No unpublished package versions were found; npm authorization was not needed.';
+  }
+  if (mode === 'oidc') {
+    return `Trusted publishing authorized ${authorizedCount} package${authorizedCount === 1 ? '' : 's'} through GitHub OIDC.`;
+  }
+  return `Trusted publishing denied ${deniedCount} package${deniedCount === 1 ? '' : 's'}; nothing was built or published.`;
+}
 
-  const lines = [
-    '## npm publish authorization',
-    '',
-    mode === 'none'
-      ? 'No unpublished package versions were found; npm authorization was not needed.'
-      : `Trusted publishing authorized ${authorizations.length} package${authorizations.length === 1 ? '' : 's'} through GitHub OIDC.`,
-  ];
+function evidenceTables(
+  authorizations: readonly OidcAuthorization[],
+  denials: readonly OidcDenial[]
+): string[] {
+  const lines: string[] = [];
   if (authorizations.length > 0) {
     lines.push('', '| Package | Version | Exchange expires |', '| --- | --- | --- |');
     for (const authorization of authorizations) {
       lines.push(`| ${authorization.name} | ${authorization.version} | ${authorization.expires} |`);
     }
   }
+  if (denials.length > 0) {
+    lines.push('', '| Denied package | Version | Reason |', '| --- | --- | --- |');
+    for (const denial of denials) {
+      lines.push(`| ${denial.name} | ${denial.version} | ${denial.error} |`);
+    }
+  }
+  return lines;
+}
+
+function writeEvidence(
+  options: CliOptions,
+  mode: 'none' | 'oidc' | 'denied',
+  authorizations: readonly OidcAuthorization[],
+  denials: readonly OidcDenial[]
+): void {
+  const evidence = {
+    checkedAt: new Date().toISOString(),
+    mode,
+    repository: process.env.GITHUB_REPOSITORY ?? null,
+    workflow: process.env.GITHUB_WORKFLOW_REF ?? null,
+    authorized: authorizations,
+    denied: denials,
+  };
+  if (options.output) writeFileSync(options.output, `${JSON.stringify(evidence, null, 2)}\n`);
+  appendGithubFile(
+    process.env.GITHUB_OUTPUT,
+    `mode=${mode}\nauthorized-count=${authorizations.length}\ndenied-count=${denials.length}\n`
+  );
+
+  const lines = [
+    '## npm publish authorization',
+    '',
+    evidenceSummary(mode, authorizations.length, denials.length),
+    ...evidenceTables(authorizations, denials),
+  ];
   appendGithubFile(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
 }
 
@@ -82,7 +112,7 @@ async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
   const candidates = releaseCandidates(JSON.parse(readFileSync(options.audit, 'utf8')));
   if (candidates.length === 0) {
-    writeEvidence(options, 'none', []);
+    writeEvidence(options, 'none', [], []);
     console.log('npm authorization: not needed (nothing would publish)');
     return;
   }
@@ -103,13 +133,16 @@ async function main(): Promise<void> {
   }
 
   const oidcToken = await requestGitHubOidcToken({ requestUrl, requestToken });
-  const authorizations: OidcAuthorization[] = [];
-  for (const candidate of candidates) {
-    authorizations.push(await authorizeNpmPackage(candidate, oidcToken));
+  const report = await authorizeNpmPackages(candidates, oidcToken);
+  if (report.denied.length > 0) {
+    writeEvidence(options, 'denied', report.authorized, report.denied);
+    throw new Error(
+      `npm trusted publishing preflight denied ${report.denied.length} package${report.denied.length === 1 ? '' : 's'}:\n${report.denied.map((denial) => `- ${denial.error}`).join('\n')}`
+    );
   }
-  writeEvidence(options, 'oidc', authorizations);
+  writeEvidence(options, 'oidc', report.authorized, []);
   console.log(
-    `npm authorization: OIDC trusted publishing verified for ${authorizations.map((entry) => `${entry.name}@${entry.version}`).join(', ')}`
+    `npm authorization: OIDC trusted publishing verified for ${report.authorized.map((entry) => `${entry.name}@${entry.version}`).join(', ')}`
   );
 }
 


### PR DESCRIPTION
## Outcome

Uses the first live OIDC preflight result to make release diagnostics complete in one run.

The initial main-branch proof stopped correctly before build/publish, but stopped after npm denied the first candidate. This follow-up checks every audited publish candidate, retaining bounded sequential requests, and reports all missing trusted-publisher grants together.

## Changes

- aggregates package-scoped npm OIDC exchange results instead of throwing on the first denial;
- still fails closed if any candidate is denied;
- persists sanitized denied package/version/reason evidence alongside successful exchanges;
- writes a complete GitHub step-summary table;
- never stores either the GitHub identity token or npm exchange tokens.

## Validation

- `pnpm release:auth:test`: 7/7 (new test proves both candidates are attempted and reported)
- focused TypeScript compilation: green
- focused Biome formatting/lint: green
- no lockfile or package changes

This is rebased on top of `8f1a393e`; it preserves the independently landed tool-surface work.
