### PR TITLE
ci: move workflow actions to native Node 24 runtimes

### DIFF
--- a/.github/workflows/auto-close-published.yml
+++ b/.github/workflows/auto-close-published.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Close published issues older than 24h
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: issues } = await github.rest.issues.listForRepo({

--- a/.github/workflows/build-omega-mac.yml
+++ b/.github/workflows/build-omega-mac.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository_owner == 'tpmjs'
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
@@ -67,7 +67,7 @@ jobs:
           codesign --force --sign - OmegaMac.app
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OmegaMac
           path: apps/omega-mac/OmegaMac.app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -42,13 +42,13 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -62,13 +62,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -103,13 +103,13 @@ jobs:
       DATABASE_URL: postgresql://tpmjs:tpmjs@127.0.0.1:5432/tpmjs_ci
       DATABASE_URL_UNPOOLED: postgresql://tpmjs:tpmjs@127.0.0.1:5432/tpmjs_ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -130,13 +130,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -150,13 +150,13 @@ jobs:
   architecture:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -170,13 +170,13 @@ jobs:
   deadcode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Check for retry loop
         id: loop-check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueNumber = context.issue?.number || ${{ inputs.issue_number || 0 }};
@@ -70,7 +70,7 @@ jobs:
 
       - name: Add working label
         if: steps.loop-check.outputs.should_continue == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueNumber = context.issue?.number || ${{ inputs.issue_number || 0 }};
@@ -84,7 +84,7 @@ jobs:
       - name: Build prompt from issue
         if: steps.loop-check.outputs.should_continue == 'true'
         id: build-prompt
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueNumber = context.issue?.number || ${{ inputs.issue_number || 0 }};
@@ -120,7 +120,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.loop-check.outputs.should_continue == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -139,7 +139,7 @@ jobs:
 
       - name: Notify Discord
         if: always() && steps.loop-check.outputs.should_continue == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -42,4 +42,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       actions: read        # Read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -56,13 +56,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Get prompt from issue comments
         id: get-prompt
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,15 +30,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-test-results
           path: |
@@ -114,15 +114,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -13,13 +13,13 @@ jobs:
     name: Preview what would publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload machine-readable release evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-preview-${{ github.sha }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload release preflight evidence
         if: ${{ always() && hashFiles('release-audit.json') != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-preflight-${{ github.sha }}
           path: |

--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build sandbox Docker image
         run: docker build -t tpmjs-sandbox:test templates/agent-sandbox/
@@ -63,12 +63,12 @@ jobs:
           exit 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -117,15 +117,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/sync-manual.yml
+++ b/.github/workflows/sync-manual.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/tool-request.yml
+++ b/.github/workflows/tool-request.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Add working label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueNumber = context.issue?.number || ${{ inputs.issue_number || 0 }};
@@ -32,7 +32,7 @@ jobs:
             });
 
       - name: Comment to trigger Claude
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueNumber = context.issue?.number || ${{ inputs.issue_number || 0 }};
@@ -75,7 +75,7 @@ jobs:
       issues: write
     steps:
       - name: Schedule auto-close
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/update-timeline.yml
+++ b/.github/workflows/update-timeline.yml
@@ -16,11 +16,11 @@ jobs:
   update-timeline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/vercel-api-contract.yml
+++ b/.github/workflows/vercel-api-contract.yml
@@ -21,13 +21,13 @@ jobs:
     if: github.repository_owner == 'tpmjs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.14.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` to v7 and `actions/setup-node` to v7 across every workflow
- upgrade `pnpm/action-setup` to v6, including the stale v2 manual-sync workflow
- upgrade artifact uploads to v7 and GitHub Script to v9
- remove all action references currently generating GitHub's forced Node 20 → Node 24 compatibility warning

## Why

GitHub now warns on every core CI job that the old action builds target deprecated Node 20 and are being forced onto Node 24. Current upstream majors run natively on Node 24. This keeps workflow behavior explicit and removes reliance on the compatibility shim.

The GitHub Script v9 breaking-change surface was audited: TPMJS does not `require('@actions/github')` and does not redeclare `getOctokit`.

## Verification

- [x] all 22 workflow YAML documents parse
- [x] no remaining old `checkout`, `setup-node`, `pnpm/action-setup`, `upload-artifact`, or `github-script` runtime references
- [x] `git diff --check`
- [x] official upstream action manifests checked: all selected majors use `node24`
- [ ] GitHub Actions CI proves the updated actions on hosted runners

No package, lockfile, source, database, or deployment changes.
