### PR TITLE
fix(playground): harden dynamic tool execution

### DIFF
--- a/apps/playground/next.config.ts
+++ b/apps/playground/next.config.ts
@@ -3,9 +3,6 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   transpilePackages: ['@tpmjs/ui', '@tpmjs/utils', '@tpmjs/types', '@tpmjs/env'],
   reactStrictMode: true,
-  experimental: {
-    urlImports: ['https://esm.sh/', 'https://cdn.jsdelivr.net/npm/'],
-  },
 };
 
 export default nextConfig;

--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -1,7 +1,15 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { searchTpmjsToolsTool } from '@tpmjs/search-registry';
-import { convertToModelMessages, stepCountIs, streamText, type UIMessage } from 'ai';
+import {
+  convertToModelMessages,
+  safeValidateUIMessages,
+  stepCountIs,
+  streamText,
+  type Tool,
+  type UIMessage,
+} from 'ai';
 import type { NextRequest } from 'next/server';
+import { z } from 'zod';
 import { env } from '~/env';
 import {
   addConversationTools,
@@ -10,20 +18,33 @@ import {
 } from '~/lib/dynamic-tool-loader';
 import { loadAllTools, sanitizeToolName } from '~/lib/tool-loader';
 
-interface ToolSearchResult {
-  query: string;
-  matchCount: number;
-  // biome-ignore lint/suspicious/noExplicitAny: Dynamic tool registry result type - tools have varying shapes
-  tools: any[];
-}
+const ChatRequestSchema = z.object({
+  messages: z.unknown().optional().default([]),
+  conversationId: z.string().trim().min(1).optional().default('default'),
+  env: z.record(z.string(), z.string()).optional().default({}),
+});
+
+const ToolSearchResultSchema = z.object({
+  query: z.string(),
+  matchCount: z.number().int().nonnegative(),
+  tools: z.array(
+    z.object({
+      packageName: z.string().min(1),
+      name: z.string().min(1),
+      version: z.string().min(1),
+      importUrl: z.string().url().optional(),
+    })
+  ),
+});
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300; // 5 minutes for complex tool loading
 
 // Add conversation state tracking (in-memory for MVP)
-// biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex
-const conversationStates = new Map<string, { loadedTools: Record<string, any> }>();
+type RuntimeToolSet = Record<string, Tool>;
+
+const conversationStates = new Map<string, { loadedTools: RuntimeToolSet }>();
 
 /**
  * POST /api/chat
@@ -32,13 +53,38 @@ const conversationStates = new Map<string, { loadedTools: Record<string, any> }>
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex chat handler with tool loading requires this complexity
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    console.log('📥 Request body:', JSON.stringify(body, null, 2));
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return Response.json(
+        { success: false, error: 'Request body must be valid JSON.' },
+        { status: 400 }
+      );
+    }
 
-    const messages: UIMessage[] = body.messages || [];
-    const conversationId: string = body.conversationId || 'default';
-    const clientEnv: Record<string, string> = body.env || {};
+    const parsedBody = ChatRequestSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return Response.json(
+        { success: false, error: 'Request body has an invalid chat payload.' },
+        { status: 400 }
+      );
+    }
 
+    const validatedMessages = await safeValidateUIMessages<UIMessage>({
+      messages: parsedBody.data.messages,
+    });
+    if (!validatedMessages.success) {
+      return Response.json(
+        { success: false, error: 'Request body contains invalid chat messages.' },
+        { status: 400 }
+      );
+    }
+
+    const messages = validatedMessages.data;
+    const { conversationId, env: clientEnv } = parsedBody.data;
+
+    console.log(`📥 Received ${messages.length} chat messages`);
     console.log(`🔑 Conversation ID: ${conversationId}`);
     console.log(
       `🔐 Client env vars: ${Object.keys(clientEnv).length} keys`,
@@ -97,9 +143,7 @@ export async function POST(request: NextRequest) {
     let userQuery = '';
     if (lastMessage?.role === 'user') {
       // Extract text from message parts
-      // biome-ignore lint/suspicious/noExplicitAny: UIMessage.parts type varies by AI SDK version
-      const parts = (lastMessage as any).parts || [];
-      for (const part of parts) {
+      for (const part of lastMessage.parts) {
         if (part.type === 'text') {
           userQuery = part.text;
           break;
@@ -113,9 +157,7 @@ export async function POST(request: NextRequest) {
       .slice(-3)
       .map((msg) => {
         // Extract text from parts
-        // biome-ignore lint/suspicious/noExplicitAny: UIMessage.parts type varies by AI SDK version
-        const parts = (msg as any).parts || [];
-        for (const part of parts) {
+        for (const part of msg.parts) {
           if (part.type === 'text') {
             return part.text;
           }
@@ -127,39 +169,44 @@ export async function POST(request: NextRequest) {
     console.log(`💬 User query: "${userQuery}"`);
     console.log(`📝 Recent messages: ${recentUserMessages.length}`);
 
+    const modelMessages = await convertToModelMessages(messages);
+
     // 3. Automatically search for relevant tools based on the user's message
     if (userQuery && userQuery.trim().length > 0) {
       console.log('🔎 Searching for relevant tools...');
 
       try {
-        // biome-ignore lint/style/noNonNullAssertion: Tool created with tool() always has execute
-        const result = await searchTpmjsToolsTool.execute!(
+        const executeSearch = searchTpmjsToolsTool.execute;
+        if (!executeSearch) {
+          throw new Error('The TPMJS search tool is not executable.');
+        }
+
+        const result = await executeSearch(
           {
             query: userQuery,
             limit: 5, // Get top 5 relevant tools
             recentMessages: recentUserMessages,
           },
-          // biome-ignore lint/suspicious/noExplicitAny: AI SDK execute context type is complex
-          {} as any
+          {
+            toolCallId: `playground-search-${crypto.randomUUID()}`,
+            messages: modelMessages,
+          }
         );
 
-        // Type assertion: searchTpmjsToolsTool returns direct result, not AsyncIterable
-        const searchResult = result as ToolSearchResult;
+        const searchResult = ToolSearchResultSchema.parse(result);
 
         console.log(`📦 Found ${searchResult.matchCount} matching tools`);
 
         if (searchResult.tools && searchResult.tools.length > 0) {
           console.log(
             '🔧 Tools found:',
-            // biome-ignore lint/suspicious/noExplicitAny: Dynamic tool registry result type
-            searchResult.tools.map((t: any) => `${t.packageName}/${t.name}`)
+            searchResult.tools.map((tool) => `${tool.packageName}/${tool.name}`)
           );
 
           // Dynamically load tools from esm.sh
           console.log(`📥 Loading ${searchResult.tools.length} tools dynamically...`);
 
-          // biome-ignore lint/suspicious/noExplicitAny: Dynamic tool registry result type
-          const toolsToLoad = searchResult.tools.map((meta: any) => ({
+          const toolsToLoad = searchResult.tools.map((meta) => ({
             packageName: meta.packageName,
             name: meta.name,
             version: meta.version,
@@ -192,8 +239,7 @@ export async function POST(request: NextRequest) {
     }
 
     // 4. Merge with conversation's dynamically loaded tools
-    // biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex
-    const allTools: Record<string, any> = { ...staticTools, ...state.loadedTools };
+    const allTools: RuntimeToolSet = { ...staticTools, ...state.loadedTools };
 
     // 5. Build system prompt with available tools
     const toolsList = Object.keys(allTools)
@@ -237,7 +283,7 @@ Remember: Your value is in EXECUTING tools to get real results, not just describ
     const result = streamText({
       model: openai('gpt-4o-mini'),
       system,
-      messages: await convertToModelMessages(messages),
+      messages: modelMessages,
       tools: allTools,
       stopWhen: stepCountIs(5), // Allow model to call tools AND generate text response
     });

--- a/apps/playground/src/components/chat/MessageBubble.tsx
+++ b/apps/playground/src/components/chat/MessageBubble.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge } from '@tpmjs/ui/Badge/Badge';
-import type { UIMessage } from 'ai';
+import { getToolName, isToolUIPart, type UIMessage } from 'ai';
 import { useEffect, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
 
@@ -16,11 +16,26 @@ interface MessageBubbleProps {
   isStreaming?: boolean;
 }
 
+type MessagePart = UIMessage['parts'][number];
+
 function formatDuration(ms: number): string {
   if (ms < 1000) {
     return `${ms}ms`;
   }
   return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function getPartKey(part: MessagePart, index: number): string {
+  return isToolUIPart(part) ? part.toolCallId : `${part.type}-${index}`;
+}
+
+function isCompleteToolPart(part: MessagePart): boolean {
+  return (
+    isToolUIPart(part) &&
+    (part.state === 'output-available' ||
+      part.state === 'output-error' ||
+      part.state === 'output-denied')
+  );
 }
 
 export function MessageBubble({
@@ -38,12 +53,11 @@ export function MessageBubble({
     if (!message.parts || isUser) return;
 
     const currentPartsKey = JSON.stringify(
-      // biome-ignore lint/suspicious/noExplicitAny: UIMessage.parts type varies by AI SDK version
-      message.parts.map((p: any) => ({
-        type: p.type,
-        id: p.toolCallId || p.type,
-        state: p.state,
-        textLen: p.text?.length,
+      message.parts.map((part, index) => ({
+        type: part.type,
+        id: getPartKey(part, index),
+        state: 'state' in part ? part.state : undefined,
+        textLen: 'text' in part && typeof part.text === 'string' ? part.text.length : undefined,
       }))
     );
 
@@ -57,10 +71,8 @@ export function MessageBubble({
     setPartTimings((prev) => {
       const updated = new Map(prev);
 
-      // biome-ignore lint/suspicious/noExplicitAny: UIMessage.parts type varies by AI SDK version
-      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex part timing logic for streaming messages
-      message.parts?.forEach((part: any, idx: number) => {
-        const partKey = part.toolCallId || `${part.type}-${idx}`;
+      message.parts?.forEach((part, idx) => {
+        const partKey = getPartKey(part, idx);
         const existing = updated.get(partKey);
 
         // Skip step-start markers
@@ -71,7 +83,7 @@ export function MessageBubble({
           updated.set(partKey, { startTime: now });
         } else if (!existing.endTime) {
           // Check if part is complete
-          const isToolComplete = part.type.startsWith('tool-') && part.state === 'result';
+          const isToolComplete = isCompleteToolPart(part);
           const isTextComplete = part.type === 'text' && !isStreaming;
 
           if (isToolComplete || isTextComplete) {
@@ -89,9 +101,8 @@ export function MessageBubble({
   }, [message.parts, isStreaming, isUser]);
 
   // Get timing for a specific part
-  // biome-ignore lint/suspicious/noExplicitAny: UIMessage.parts type varies by AI SDK version
-  const getPartTiming = (part: any, idx: number): PartTiming | undefined => {
-    const partKey = part.toolCallId || `${part.type}-${idx}`;
+  const getPartTiming = (part: MessagePart, idx: number): PartTiming | undefined => {
+    const partKey = getPartKey(part, idx);
     return partTimings.get(partKey);
   };
 
@@ -142,18 +153,24 @@ export function MessageBubble({
                 );
               }
 
-              // Render tool calls (type starts with 'tool-')
-              if (part.type.startsWith('tool-')) {
-                const toolName = part.type.replace('tool-', '');
-                // biome-ignore lint/suspicious/noExplicitAny: Tool part properties vary by AI SDK version
-                const toolPart = part as any;
+              // Render static and dynamic tool calls using the AI SDK's discriminated union.
+              if (isToolUIPart(part)) {
+                const toolName = getToolName(part);
                 const timing = getPartTiming(part, idx);
-                const isResult = toolPart.state === 'result';
-                const hasError = toolPart.errorText || toolPart.error;
+                const isResult = part.state === 'output-available';
+                const hasError = part.state === 'output-error';
+                const stateLabel =
+                  part.state === 'output-available'
+                    ? 'result'
+                    : part.state === 'output-error'
+                      ? 'error'
+                      : part.state === 'output-denied'
+                        ? 'denied'
+                        : part.state.replace('-', ' ');
 
                 return (
                   <div
-                    key={toolPart.toolCallId || idx}
+                    key={part.toolCallId}
                     className={`rounded-lg border p-3 ${
                       hasError
                         ? 'border-red-500/30 bg-red-500/5'
@@ -167,7 +184,7 @@ export function MessageBubble({
                         variant={hasError ? 'error' : isResult ? 'success' : 'secondary'}
                         size="sm"
                       >
-                        {hasError ? 'error' : toolPart.state || 'running'}
+                        {stateLabel}
                       </Badge>
                       {timing?.duration && (
                         <span className="ml-auto text-xs text-foreground-tertiary">
@@ -177,25 +194,25 @@ export function MessageBubble({
                     </div>
 
                     {/* Tool Input */}
-                    {toolPart.input && (
+                    {part.input !== undefined && (
                       <details className="group">
                         <summary className="cursor-pointer text-xs font-medium text-foreground-secondary hover:text-foreground">
                           Input
                         </summary>
                         <pre className="mt-2 overflow-x-auto rounded-md bg-surface p-2 text-xs text-foreground-secondary">
-                          {JSON.stringify(toolPart.input, null, 2)}
+                          {JSON.stringify(part.input, null, 2)}
                         </pre>
                       </details>
                     )}
 
                     {/* Tool Output */}
-                    {toolPart.output && (
+                    {isResult && part.output !== undefined && (
                       <details className="group mt-2" open>
                         <summary className="cursor-pointer text-xs font-medium text-foreground-secondary hover:text-foreground">
                           Output
                         </summary>
                         <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-surface p-2 text-xs text-foreground-secondary">
-                          {JSON.stringify(toolPart.output, null, 2)}
+                          {JSON.stringify(part.output, null, 2)}
                         </pre>
                       </details>
                     )}
@@ -205,9 +222,7 @@ export function MessageBubble({
                       <div className="mt-2">
                         <div className="mb-1 text-xs font-medium text-red-500">Error</div>
                         <pre className="overflow-x-auto rounded-md bg-red-500/10 p-2 text-xs text-red-400">
-                          {typeof (toolPart.errorText || toolPart.error) === 'string'
-                            ? toolPart.errorText || toolPart.error
-                            : JSON.stringify(toolPart.errorText || toolPart.error, null, 2)}
+                          {part.errorText}
                         </pre>
                       </div>
                     )}

--- a/apps/playground/src/lib/dynamic-tool-loader.ts
+++ b/apps/playground/src/lib/dynamic-tool-loader.ts
@@ -1,8 +1,11 @@
-import { jsonSchema, tool } from 'ai';
+import { jsonSchema, type Tool, tool } from 'ai';
+import { z } from 'zod';
 
 // Cache for tool wrappers (process-level)
-// biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex
-const moduleCache = new Map<string, any>();
+type RuntimeTool = Tool;
+type RuntimeToolSet = Record<string, RuntimeTool>;
+
+const moduleCache = new Map<string, Map<string, RuntimeTool>>();
 
 // Cache for per-conversation active tools
 const conversationTools = new Map<string, Set<string>>();
@@ -14,11 +17,50 @@ const conversationEnv = new Map<string, Record<string, string>>();
 const RAILWAY_SERVICE_URL =
   process.env.RAILWAY_SERVICE_URL || process.env.SANDBOX_EXECUTOR_URL || 'http://localhost:3001';
 
+const LoadToolResponseSchema = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+    tool: z.object({
+      description: z.string(),
+      inputSchema: z.unknown().optional(),
+    }),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string().optional(),
+  }),
+]);
+
+const ExecuteToolResponseSchema = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+    output: z.unknown(),
+    executionTimeMs: z.number().optional(),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string().optional(),
+  }),
+]);
+
 /**
- * Generate cache key for a tool
+ * Generate the stable logical key used to expose a tool to the model.
  */
-function getCacheKey(packageName: string, name: string): string {
+function getToolKey(packageName: string, name: string): string {
   return `${packageName}::${name}`;
+}
+
+/**
+ * Generate the exact artifact key used by the executable-wrapper cache.
+ * A package update or alternate import URL must create a fresh wrapper.
+ */
+function getCacheKey(
+  packageName: string,
+  name: string,
+  version: string,
+  importUrl: string | undefined
+): string {
+  return JSON.stringify([packageName, name, version, importUrl ?? null]);
 }
 
 /**
@@ -37,6 +79,119 @@ function getConversationEnv(conversationId: string): Record<string, string> {
   return conversationEnv.get(conversationId) || {};
 }
 
+interface RemoteToolDescription {
+  description: string;
+  inputSchema?: unknown;
+}
+
+async function fetchToolDescription(
+  packageName: string,
+  name: string,
+  version: string,
+  importUrl: string | undefined,
+  env: Record<string, string>
+): Promise<RemoteToolDescription> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 120_000);
+
+  try {
+    const response = await fetch(`${RAILWAY_SERVICE_URL}/load-and-describe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        packageName,
+        name,
+        version,
+        importUrl: importUrl || `https://esm.sh/${packageName}@${version}`,
+        env,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Railway returned HTTP ${response.status}: ${errorText}`);
+    }
+
+    const rawData: unknown = await response.json();
+    const parsedData = LoadToolResponseSchema.safeParse(rawData);
+    if (!parsedData.success) {
+      throw new Error('Railway returned a malformed tool description');
+    }
+    if (!parsedData.data.success) {
+      throw new Error(parsedData.data.error || 'Railway could not load the tool');
+    }
+    return parsedData.data.tool;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Railway request timed out after 120s for ${packageName}/${name}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function executeRemoteTool(
+  packageName: string,
+  name: string,
+  version: string,
+  importUrl: string | undefined,
+  conversationId: string,
+  params: unknown
+): Promise<unknown> {
+  const currentEnv = getConversationEnv(conversationId);
+  console.log(`🔐 Using ${Object.keys(currentEnv).length} env vars for ${conversationId}`);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 120_000);
+
+  try {
+    const response = await fetch(`${RAILWAY_SERVICE_URL}/execute-tool`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        packageName,
+        name,
+        version,
+        importUrl: importUrl || `https://esm.sh/${packageName}@${version}`,
+        params,
+        env: currentEnv,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Tool executor returned HTTP ${response.status}`);
+    }
+
+    const rawResult: unknown = await response.json();
+    const parsedResult = ExecuteToolResponseSchema.safeParse(rawResult);
+    if (!parsedResult.success) {
+      throw new Error('Tool executor returned a malformed response');
+    }
+    if (!parsedResult.data.success) {
+      throw new Error(parsedResult.data.error || 'Tool execution failed');
+    }
+
+    console.log(
+      `✅ Tool executed successfully in ${parsedResult.data.executionTimeMs ?? 'unknown'}ms`
+    );
+    return parsedResult.data.output;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Tool execution timed out after 120s for ${packageName}/${name}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /**
  * Dynamically load a tool via Railway service
  * Railway service runs with --experimental-network-imports and can import from esm.sh
@@ -48,127 +203,50 @@ export async function loadToolDynamically(
   conversationId: string,
   importUrl?: string,
   env?: Record<string, string>
-  // biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex
-): Promise<any | null> {
-  const cacheKey = getCacheKey(packageName, name);
+): Promise<RuntimeTool | null> {
+  const toolKey = getToolKey(packageName, name);
+  const cacheKey = getCacheKey(packageName, name, version, importUrl);
+  let toolCache = moduleCache.get(conversationId);
+  if (!toolCache) {
+    toolCache = new Map();
+    moduleCache.set(conversationId, toolCache);
+  }
 
-  // Check cache first
-  if (moduleCache.has(cacheKey)) {
-    console.log(`✅ Cache hit: ${cacheKey}`);
-    return moduleCache.get(cacheKey);
+  // Tool wrappers close over a conversation ID, so they must never be shared
+  // across conversations (which would route one conversation through another's env).
+  const cachedTool = toolCache.get(cacheKey);
+  if (cachedTool) {
+    console.log(`✅ Cache hit: ${toolKey}@${version}`);
+    return cachedTool;
   }
 
   try {
     console.log(`📦 Loading from Railway: ${packageName}/${name}`);
     console.log(`🔗 Railway URL: ${RAILWAY_SERVICE_URL}`);
 
-    // Call Railway service to load and describe tool
-    // 120 second timeout per tool to handle large dependency downloads
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 120000);
+    const description = await fetchToolDescription(
+      packageName,
+      name,
+      version,
+      importUrl,
+      env || {}
+    );
+    console.log(`✅ Tool loaded from Railway: ${toolKey}@${version}`);
+    console.log(`📋 Description: ${description.description}`);
 
-    let response: Response | undefined;
-    let data:
-      | { success: boolean; tool?: { description: string; inputSchema?: unknown }; error?: string }
-      | undefined;
-
-    try {
-      response = await fetch(`${RAILWAY_SERVICE_URL}/load-and-describe`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          packageName,
-          name,
-          version,
-          importUrl: importUrl || `https://esm.sh/${packageName}@${version}`,
-          env: env || {},
-        }),
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeout);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error(`❌ Railway service error (${response.status}): ${errorText}`);
-        return null;
-      }
-
-      data = await response.json();
-
-      if (!data || !data.success) {
-        const errorMsg = data?.error || 'Unknown error';
-        console.error(`❌ Failed to load tool: ${errorMsg}`);
-        return null;
-      }
-    } catch (fetchError) {
-      clearTimeout(timeout);
-
-      if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-        console.error(`❌ Railway request timeout after 120s for ${packageName}/${name}`);
-        return null;
-      }
-
-      throw fetchError;
-    }
-
-    // Type guard - data and data.tool are guaranteed after successful response
-    if (!data?.tool) {
-      console.error('❌ Invalid response from Railway: missing tool data');
-      return null;
-    }
-
-    console.log(`✅ Tool loaded from Railway: ${cacheKey}`);
-    console.log(`📋 Description: ${data.tool.description}`);
-
-    // Create a proper AI SDK tool wrapper that executes remotely
-    // Railway returns plain JSON Schema - wrap it with jsonSchema() for AI SDK
     const toolWrapper = tool({
-      description: data.tool.description,
-      inputSchema: data.tool.inputSchema
-        ? jsonSchema(data.tool.inputSchema)
+      description: description.description,
+      inputSchema: description.inputSchema
+        ? jsonSchema(description.inputSchema)
         : jsonSchema({ type: 'object', properties: {}, additionalProperties: false }),
-      // biome-ignore lint/suspicious/noExplicitAny: Tool params are dynamic
-      execute: async (params: any) => {
+      execute: async (params: unknown) => {
         console.log(`🚀 Executing ${packageName}/${name} remotely with params:`, params);
-
-        // Get the latest env vars for this conversation (not from closure!)
-        const currentEnv = getConversationEnv(conversationId);
-        console.log(
-          `🔐 Using env vars for conversation ${conversationId}:`,
-          Object.keys(currentEnv)
-        );
-
-        const execResponse = await fetch(`${RAILWAY_SERVICE_URL}/execute-tool`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            packageName,
-            name,
-            version,
-            importUrl: importUrl || `https://esm.sh/${packageName}@${version}`,
-            params,
-            env: currentEnv,
-          }),
-        });
-
-        const result = await execResponse.json();
-
-        if (!result.success) {
-          console.error(`❌ Tool execution failed: ${result.error}`);
-          throw new Error(result.error || 'Tool execution failed');
-        }
-
-        // Health status is reported by the Railway executor
-        console.log(`✅ Tool executed successfully in ${result.executionTimeMs}ms`);
-        return result.output;
+        return executeRemoteTool(packageName, name, version, importUrl, conversationId, params);
       },
     });
 
-    // Cache the wrapper
-    moduleCache.set(cacheKey, toolWrapper);
-    console.log(`✅ Cached tool wrapper: ${cacheKey}`);
-
+    toolCache.set(cacheKey, toolWrapper);
+    console.log(`✅ Cached tool wrapper: ${toolKey}@${version}`);
     return toolWrapper;
   } catch (error) {
     console.error(`❌ Failed to load ${packageName}#${name}:`, error);
@@ -189,8 +267,7 @@ export async function loadToolsBatch(
   }>,
   conversationId: string,
   env?: Record<string, string>
-  // biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex
-): Promise<Record<string, any>> {
+): Promise<RuntimeToolSet> {
   console.log(`📦 Loading ${toolMetadata.length} tools for conversation ${conversationId}`);
   console.log('🔑 Env vars being passed:', Object.keys(env || {}));
 
@@ -205,7 +282,7 @@ export async function loadToolsBatch(
     ).then((tool) => ({
       packageName: meta.packageName,
       name: meta.name,
-      key: getCacheKey(meta.packageName, meta.name),
+      key: getToolKey(meta.packageName, meta.name),
       tool,
       success: tool !== null,
     }))
@@ -218,9 +295,9 @@ export async function loadToolsBatch(
   const failed = results.filter((r) => !r.success);
 
   // Build tools object
-  // biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex
-  const tools: Record<string, any> = {};
+  const tools: RuntimeToolSet = {};
   for (const result of successful) {
+    if (!result.tool) continue;
     tools[result.key] = result.tool;
   }
 
@@ -266,6 +343,8 @@ export function getConversationTools(conversationId: string): string[] {
  */
 export function clearConversationTools(conversationId: string): void {
   conversationTools.delete(conversationId);
+  conversationEnv.delete(conversationId);
+  moduleCache.delete(conversationId);
 }
 
 /**
@@ -273,7 +352,10 @@ export function clearConversationTools(conversationId: string): void {
  */
 export function getCacheStats() {
   return {
-    moduleCacheSize: moduleCache.size,
+    moduleCacheSize: Array.from(moduleCache.values()).reduce(
+      (toolCount, cache) => toolCount + cache.size,
+      0
+    ),
     conversationCount: conversationTools.size,
   };
 }

--- a/apps/playground/src/lib/tool-loader.ts
+++ b/apps/playground/src/lib/tool-loader.ts
@@ -1,11 +1,21 @@
 // Static imports for tools (required for Next.js/webpack)
 import { helloNameTool, helloWorldTool } from '@tpmjs/hello';
+import type { Tool } from 'ai';
+
+type RuntimeTool = Tool;
+type RuntimeToolSet = Record<string, RuntimeTool>;
+
+function isRuntimeTool(value: unknown): value is RuntimeTool {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return 'inputSchema' in candidate && typeof candidate.execute === 'function';
+}
 
 /**
  * Tool registry mapping package names + export names to actual tool functions
  * This is a static mapping required for Next.js/webpack bundling
  */
-const TOOL_REGISTRY: Record<string, Record<string, any>> = {
+const TOOL_REGISTRY: Record<string, Record<string, unknown>> = {
   '@tpmjs/hello': {
     helloWorldTool,
     helloNameTool,
@@ -16,8 +26,10 @@ const TOOL_REGISTRY: Record<string, Record<string, any>> = {
  * Load a specific TPMJS tool by package name and export name
  * Uses static imports to work with Next.js/webpack bundling
  */
-// biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex and using any is appropriate here
-export async function loadTpmjsTool(packageName: string, name: string): Promise<any | null> {
+export async function loadTpmjsTool(
+  packageName: string,
+  name: string
+): Promise<RuntimeTool | null> {
   try {
     // Look up the package in the registry
     const packageTools = TOOL_REGISTRY[packageName];
@@ -27,8 +39,8 @@ export async function loadTpmjsTool(packageName: string, name: string): Promise<
     }
 
     // Look up the specific tool export
-    const tool = packageTools[name];
-    if (!tool) {
+    const candidate = packageTools[name];
+    if (!candidate) {
       console.warn(
         `Export '${name}' not found in package ${packageName}. Available exports:`,
         Object.keys(packageTools)
@@ -36,7 +48,12 @@ export async function loadTpmjsTool(packageName: string, name: string): Promise<
       return null;
     }
 
-    return tool;
+    if (!isRuntimeTool(candidate)) {
+      console.warn(`Export '${name}' from ${packageName} is not an executable AI SDK tool.`);
+      return null;
+    }
+
+    return candidate;
   } catch (error) {
     console.error(`Failed to load tool ${packageName}/${name}:`, error);
     return null;
@@ -58,17 +75,20 @@ export function sanitizeToolName(name: string): string {
  * Load all installed TPMJS tools
  * Returns a flat object with all tools keyed by sanitized packageName-name
  */
-// biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex and using any is appropriate here
-export async function loadAllTools(): Promise<Record<string, any>> {
-  // biome-ignore lint/suspicious/noExplicitAny: Tool types from AI SDK are complex and using any is appropriate here
-  const tools: Record<string, any> = {};
+export async function loadAllTools(): Promise<RuntimeToolSet> {
+  const tools: RuntimeToolSet = {};
 
   // Iterate through all registered packages
   for (const [packageName, packageTools] of Object.entries(TOOL_REGISTRY)) {
-    for (const [name, tool] of Object.entries(packageTools)) {
+    for (const [name, candidate] of Object.entries(packageTools)) {
+      if (!isRuntimeTool(candidate)) {
+        console.warn(`Skipping non-tool export '${name}' from ${packageName}.`);
+        continue;
+      }
+
       // Create a unique, sanitized key for this tool
       const toolKey = sanitizeToolName(`${packageName}-${name}`);
-      tools[toolKey] = tool;
+      tools[toolKey] = candidate;
     }
   }
 


### PR DESCRIPTION
## Summary

- validate chat payloads and AI SDK UI messages at the route boundary without logging request bodies
- use AI SDK 6 tool-part discriminants and current completion states so dynamic tools, outputs, errors, denials, and falsey values render correctly
- validate remote loader/executor responses, bound both network paths to 120 seconds, and remove unsafe `any` casts
- isolate executable wrappers by conversation and exact package artifact so credentials and cached versions cannot cross conversations
- clear environment and wrapper state with conversation cleanup
- remove the ignored Next.js `experimental.urlImports` option

## Validation

- `pnpm --filter @tpmjs/playground lint`
- `pnpm --filter @tpmjs/playground type-check`
- focused Biome check on all five changed files
- `pnpm --filter @tpmjs/playground build`
- direct Next request smoke: malformed JSON, invalid messages, and missing API key return the expected HTTP 400 contracts
- mocked executor smoke: conversation environment isolation, version-aware cache invalidation, cache hits, and cleanup all pass
- `pnpm test` — 22/22 Turbo tasks green; 1,015 assertions passed and 12 credential-dependent assertions skipped

`pnpm check-architecture` still reports the three existing generated-file/executor-test resolution errors when run before the full repo build; none originate in the changed files. The hosted architecture job remains a required merge gate.

No package versions, lockfiles, database state, or production services changed.