### PR TITLE
fix(db): make registry counters upsert-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Prove fresh migration history
         run: pnpm --filter @tpmjs/web exec prisma migrate deploy --schema ../../packages/db/prisma/schema.prisma
 
+      - name: Prove registry counter invariants
+        run: pnpm --filter @tpmjs/db db:verify-counter-invariants
+
       - name: Reject schema drift
         run: >-
           pnpm --filter @tpmjs/web exec prisma migrate diff

--- a/apps/web/src/app/api/sync/stats-snapshot/route.ts
+++ b/apps/web/src/app/api/sync/stats-snapshot/route.ts
@@ -19,8 +19,9 @@ export async function POST(request: NextRequest) {
   if (unauthorized) return unauthorized;
 
   try {
-    // Self-heal the trigger-maintained registry counters from the source tables
-    // before snapshotting, so historical stats never inherit counter drift.
+    // Audit and exactly reconcile the trigger-maintained projection before the
+    // daily historical snapshot. Normal reads/writes remain O(1); this bounded
+    // backstop catches any future trigger regression before it enters history.
     await prisma.$executeRawUnsafe('SELECT tpmjs_reconcile_counters()');
 
     // Get today's date at midnight UTC

--- a/docs/BOUNDED_MAINTENANCE.md
+++ b/docs/BOUNDED_MAINTENANCE.md
@@ -40,13 +40,19 @@ updated in the same transaction as their source event:
 - execution events update execution counters;
 - conversation/message writes update agent counters;
 - registry writes update totals and low-cardinality distributions in
-  `registry_counters`.
+  `registry_counters` using `AFTER` row triggers, so an
+  `INSERT ... ON CONFLICT DO UPDATE` contributes exactly one real operation;
 - daily use-case generation selects only five due scenarios; rank refresh uses
   one 500-row dirty slice rather than loading and updating every use case.
 
-The daily stats snapshot reads those projections and only scans explicitly
-time-bounded event windows. View and execution rollup endpoints remain as
-cheap compatibility responses; they no longer perform work.
+The daily stats snapshot first reconciles the small current registry from a
+single locked source snapshot, then reads those projections and scans only
+explicitly time-bounded event windows. This is a defensive audit, not the
+normal read path: registry reads and writes remain O(1). Before an eventual
+registry size makes a complete audit exceed its maintenance window, the same
+check must become partitioned or replica-backed rather than being removed.
+View and execution rollup endpoints remain cheap compatibility responses; they
+no longer perform work.
 
 ## Migration discipline
 
@@ -83,5 +89,8 @@ FROM tools t JOIN packages p ON p.id = t.package_id
 WHERE t.quality_metrics_version < p.metrics_version;
 ```
 
-Correctness is checked against source rows after deployment. A projection
-reconciliation is a diagnostic, not a recurring cron job.
+Correctness is checked against source rows after deployment. CI also executes
+real package/tool upserts, dimension changes, and cascade deletion inside a
+rolled-back transaction; it rejects both double-counting and silent counter
+underflow. The daily exact reconciliation remains a backstop while its measured
+source scan is comfortably inside the maintenance window.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,6 +10,7 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
+    "db:verify-counter-invariants": "tsx scripts/verify-counter-invariants.ts",
     "db:studio": "prisma studio",
     "db:seed": "tsx prisma/seed.ts",
     "db:backfill-usernames": "tsx prisma/backfill-usernames.ts",

--- a/packages/db/prisma/migrations/20260721130000_fix_counter_upsert_drift/migration.sql
+++ b/packages/db/prisma/migrations/20260721130000_fix_counter_upsert_drift/migration.sql
@@ -1,0 +1,225 @@
+-- Make registry-counter projections safe for PostgreSQL upserts.
+--
+-- Row-level BEFORE INSERT triggers run before ON CONFLICT arbitration. The
+-- previous triggers therefore counted every Prisma upsert as an INSERT even
+-- when PostgreSQL ultimately updated the existing package or tool. AFTER row
+-- triggers observe only the operation that actually happened.
+
+DROP TRIGGER IF EXISTS tpmjs_package_counters ON packages;
+CREATE TRIGGER tpmjs_package_counters
+AFTER INSERT OR UPDATE OR DELETE ON packages
+FOR EACH ROW EXECUTE FUNCTION tpmjs_count_package();
+
+DROP TRIGGER IF EXISTS tpmjs_tool_counters ON tools;
+CREATE TRIGGER tpmjs_tool_counters
+AFTER INSERT OR UPDATE OR DELETE ON tools
+FOR EACH ROW EXECUTE FUNCTION tpmjs_count_tool();
+
+DROP TRIGGER IF EXISTS tpmjs_collection_counter ON collections;
+CREATE TRIGGER tpmjs_collection_counter
+AFTER INSERT OR UPDATE OR DELETE ON collections
+FOR EACH ROW EXECUTE FUNCTION tpmjs_count_collection();
+
+DROP TRIGGER IF EXISTS tpmjs_agent_counter ON agents;
+CREATE TRIGGER tpmjs_agent_counter
+AFTER INSERT OR UPDATE OR DELETE ON agents
+FOR EACH ROW EXECUTE FUNCTION tpmjs_count_agent();
+
+DROP TRIGGER IF EXISTS tpmjs_simulation_counter ON simulations;
+CREATE TRIGGER tpmjs_simulation_counter
+AFTER INSERT OR DELETE ON simulations
+FOR EACH ROW EXECUTE FUNCTION tpmjs_count_simulation();
+
+-- Counter underflow is an invariant violation. Clamping it to zero hid a lost
+-- decrement and made every later increment permanently wrong; fail the source
+-- transaction instead so drift cannot silently become durable state.
+CREATE OR REPLACE FUNCTION tpmjs_counter_add(
+  p_metric text,
+  p_dimension text,
+  p_delta bigint
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF p_delta = 0 THEN RETURN; END IF;
+
+  IF p_delta < 0 THEN
+    UPDATE registry_counters
+    SET value = value + p_delta,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE metric = p_metric
+      AND dimension = COALESCE(p_dimension, '');
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'cannot decrement missing registry counter (% / %) by %',
+        p_metric, COALESCE(p_dimension, ''), p_delta;
+    END IF;
+  ELSE
+    INSERT INTO registry_counters(metric, dimension, value, updated_at)
+    VALUES (p_metric, COALESCE(p_dimension, ''), p_delta, CURRENT_TIMESTAMP)
+    ON CONFLICT (metric, dimension) DO UPDATE
+    SET value = registry_counters.value + EXCLUDED.value,
+        updated_at = CURRENT_TIMESTAMP;
+  END IF;
+END;
+$$;
+
+-- Replace every projection row from one locked source snapshot. Taking source
+-- locks before touching the projection avoids losing a concurrent write
+-- between DELETE and re-seed. This is a repair/audit path; normal writes stay
+-- O(1) through the triggers above.
+CREATE OR REPLACE FUNCTION tpmjs_reconcile_counters()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Keep the lock order identical to trigger write dependencies: package
+  -- mutations can update package + tool dimensions, while tool mutations only
+  -- touch their own projection. A single deterministic order avoids deadlocks
+  -- if this audit overlaps application traffic.
+  LOCK TABLE packages, tools, collections, agents, simulations IN SHARE MODE;
+
+  DELETE FROM registry_counters;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT metric, dimension, value, CURRENT_TIMESTAMP
+  FROM (
+    SELECT 'total_packages'::text AS metric, ''::text AS dimension, count(*)::bigint AS value FROM packages
+    UNION ALL SELECT 'official_packages', '', count(*) FROM packages WHERE is_official
+    UNION ALL SELECT 'total_tools', '', count(*) FROM tools
+    UNION ALL SELECT 'official_tools', '', count(*) FROM tools t JOIN packages p ON p.id = t.package_id WHERE p.is_official
+    UNION ALL SELECT 'tools_with_schema', '', count(*) FROM tools WHERE schema_source = 'extracted'
+    UNION ALL SELECT 'total_npm_downloads', '', COALESCE(sum(npm_downloads_last_month), 0) FROM packages
+    UNION ALL SELECT 'total_github_stars', '', COALESCE(sum(github_stars), 0) FROM packages
+    UNION ALL SELECT 'public_collections', '', count(*) FROM collections WHERE is_public
+    UNION ALL SELECT 'public_agents', '', count(*) FROM agents WHERE is_public
+    UNION ALL SELECT 'total_simulations', '', count(*) FROM simulations
+  ) fixed;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'tier_packages', tier, count(*), CURRENT_TIMESTAMP
+  FROM packages
+  GROUP BY tier;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'package_tools', package_id, count(*), CURRENT_TIMESTAMP
+  FROM tools
+  GROUP BY package_id;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'category_tools', COALESCE(p.category, ''), count(*), CURRENT_TIMESTAMP
+  FROM tools t
+  JOIN packages p ON p.id = t.package_id
+  GROUP BY p.category;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'import_health', COALESCE(import_health::text, 'UNKNOWN'), count(*), CURRENT_TIMESTAMP
+  FROM tools
+  GROUP BY COALESCE(import_health::text, 'UNKNOWN');
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'execution_health', COALESCE(execution_health::text, 'UNKNOWN'), count(*), CURRENT_TIMESTAMP
+  FROM tools
+  GROUP BY COALESCE(execution_health::text, 'UNKNOWN');
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'quality_bucket', tpmjs_quality_bucket(quality_score), count(*), CURRENT_TIMESTAMP
+  FROM tools
+  GROUP BY tpmjs_quality_bucket(quality_score);
+END;
+$$;
+
+-- First restore the projection exactly, including the metrics omitted by the
+-- earlier partial reconciler, then make future underflow impossible to hide.
+SELECT tpmjs_reconcile_counters();
+
+ALTER TABLE registry_counters
+ADD CONSTRAINT registry_counters_value_nonnegative CHECK (value >= 0);
+
+-- Repair the two daily snapshots written while the broken triggers were live.
+-- This is intentionally guarded by the known-good 2026-07-19 bookend, the
+-- unchanged source population, and the inflated-total signature. Downloads,
+-- stars, and the real quality buckets remain untouched because they legitimately
+-- vary over time; only the synthetic unscored excess is removed.
+WITH actual AS (
+  SELECT
+    (SELECT count(*)::integer FROM packages) AS total_packages,
+    (SELECT count(*)::integer FROM packages WHERE is_official) AS official_packages,
+    (SELECT count(*)::integer FROM tools) AS total_tools,
+    (
+      SELECT count(*)::integer
+      FROM tools t
+      JOIN packages p ON p.id = t.package_id
+      WHERE p.is_official
+    ) AS official_tools,
+    (SELECT count(*)::integer FROM packages WHERE tier = 'minimal') AS tiers_minimal,
+    (SELECT count(*)::integer FROM packages WHERE tier = 'rich') AS tiers_rich
+),
+category_counts AS (
+  SELECT p.category, count(*)::integer AS value
+  FROM tools t
+  JOIN packages p ON p.id = t.package_id
+  GROUP BY p.category
+),
+current_categories AS (
+  SELECT COALESCE(jsonb_object_agg(category, value ORDER BY category), '{}'::jsonb) AS value
+  FROM category_counts
+)
+UPDATE stats_snapshots s
+SET total_packages = a.total_packages,
+    official_packages = a.official_packages,
+    total_tools = a.total_tools,
+    official_tools = a.official_tools,
+    tiers_minimal = a.tiers_minimal,
+    tiers_rich = a.tiers_rich,
+    categories = categories.value,
+    import_unknown = GREATEST(a.total_tools - s.import_healthy - s.import_broken, 0),
+    execution_unknown = GREATEST(
+      a.total_tools - s.execution_healthy - s.execution_broken,
+      0
+    ),
+    quality_distribution = (
+      SELECT CASE
+        WHEN a.total_tools > q.non_unscored THEN
+          jsonb_set(
+            COALESCE(s.quality_distribution, '{}'::jsonb) - 'unscored',
+            '{unscored}',
+            to_jsonb(a.total_tools - q.non_unscored),
+            true
+          )
+        ELSE COALESCE(s.quality_distribution, '{}'::jsonb) - 'unscored'
+      END
+      FROM (
+        SELECT COALESCE(sum(value::integer), 0)::integer AS non_unscored
+        FROM jsonb_each_text(COALESCE(s.quality_distribution, '{}'::jsonb))
+        WHERE key <> 'unscored'
+      ) q
+    )
+FROM actual a
+CROSS JOIN current_categories categories
+WHERE s.date BETWEEN DATE '2026-07-20' AND DATE '2026-07-21'
+  AND s.total_packages > a.total_packages
+  AND s.total_tools > a.total_tools
+  AND NOT EXISTS (
+    SELECT 1 FROM packages WHERE created_at >= TIMESTAMP '2026-07-18 00:00:00'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM tools WHERE created_at >= TIMESTAMP '2026-07-18 00:00:00'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM stats_snapshots good
+    WHERE good.date = DATE '2026-07-19'
+      AND good.total_packages = a.total_packages
+      AND good.official_packages = a.official_packages
+      AND good.total_tools = a.total_tools
+      AND good.official_tools = a.official_tools
+      AND good.tiers_minimal = a.tiers_minimal
+      AND good.tiers_rich = a.tiers_rich
+      AND (
+        SELECT COALESCE(jsonb_object_agg(entry.key, entry.value ORDER BY entry.key), '{}'::jsonb)
+        FROM jsonb_each(COALESCE(good.categories, '{}'::jsonb)) entry
+        WHERE (entry.value #>> '{}')::integer > 0
+      ) = categories.value
+  );

--- a/packages/db/scripts/verify-counter-invariants.ts
+++ b/packages/db/scripts/verify-counter-invariants.ts
@@ -1,0 +1,281 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { Prisma, PrismaClient } from '../src/index';
+
+const prisma = new PrismaClient();
+
+type CounterReader = Pick<Prisma.TransactionClient, 'registryCounter'>;
+type CounterKey = readonly [metric: string, dimension: string];
+type CounterSnapshot = Map<string, bigint>;
+
+class ExpectedRollback extends Error {}
+
+function serializeKey([metric, dimension]: CounterKey): string {
+  return JSON.stringify([metric, dimension]);
+}
+
+async function readCounters(client: CounterReader, keys: CounterKey[]): Promise<CounterSnapshot> {
+  const rows = await client.registryCounter.findMany({
+    where: {
+      OR: keys.map(([metric, dimension]) => ({ metric, dimension })),
+    },
+    select: { metric: true, dimension: true, value: true },
+  });
+  const values = new Map(rows.map((row) => [serializeKey([row.metric, row.dimension]), row.value]));
+
+  return new Map(keys.map((key) => [serializeKey(key), values.get(serializeKey(key)) ?? 0n]));
+}
+
+function withDeltas(
+  baseline: CounterSnapshot,
+  deltas: Array<readonly [CounterKey, bigint]>
+): CounterSnapshot {
+  const expected = new Map(baseline);
+  for (const [key, delta] of deltas) {
+    const serialized = serializeKey(key);
+    expected.set(serialized, (expected.get(serialized) ?? 0n) + delta);
+  }
+  return expected;
+}
+
+function assertSnapshot(actual: CounterSnapshot, expected: CounterSnapshot, phase: string): void {
+  assert.deepEqual(Object.fromEntries(actual), Object.fromEntries(expected), phase);
+}
+
+async function verifyUpsertAndCascadeBalance(): Promise<void> {
+  const suffix = randomUUID();
+  const packageId = `counter-probe-package-${suffix}`;
+  const toolId = `counter-probe-tool-${suffix}`;
+  const packageName = `@tpmjs/counter-probe-${suffix}`;
+  const categoryA = `probe-a-${suffix.slice(0, 8)}`;
+  const categoryB = `probe-b-${suffix.slice(0, 8)}`;
+
+  const keys: CounterKey[] = [
+    ['total_packages', ''],
+    ['official_packages', ''],
+    ['total_tools', ''],
+    ['official_tools', ''],
+    ['tier_packages', 'minimal'],
+    ['tier_packages', 'rich'],
+    ['total_npm_downloads', ''],
+    ['total_github_stars', ''],
+    ['total_simulations', ''],
+    ['package_tools', packageId],
+    ['category_tools', categoryA],
+    ['category_tools', categoryB],
+    ['tools_with_schema', ''],
+    ['import_health', 'UNKNOWN'],
+    ['import_health', 'HEALTHY'],
+    ['execution_health', 'UNKNOWN'],
+    ['execution_health', 'BROKEN'],
+    ['quality_bucket', 'unscored'],
+    ['quality_bucket', 'high'],
+  ];
+
+  const committedBaseline = await readCounters(prisma, keys);
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      const baseline = await readCounters(tx, keys);
+
+      await tx.package.create({
+        data: {
+          id: packageId,
+          npmPackageName: packageName,
+          npmVersion: '1.0.0',
+          npmPublishedAt: new Date(),
+          category: categoryA,
+          tier: 'minimal',
+          discoveryMethod: 'counter-probe',
+          isOfficial: false,
+          npmDownloadsLastMonth: 7,
+          githubStars: 3,
+        },
+      });
+      await tx.tool.create({
+        data: {
+          id: toolId,
+          packageId,
+          name: 'probe',
+          description: 'Counter invariant probe',
+        },
+      });
+
+      const afterInsert = await readCounters(tx, keys);
+      const expectedAfterInsert = withDeltas(baseline, [
+        [['total_packages', ''], 1n],
+        [['total_tools', ''], 1n],
+        [['tier_packages', 'minimal'], 1n],
+        [['total_npm_downloads', ''], 7n],
+        [['total_github_stars', ''], 3n],
+        [['package_tools', packageId], 1n],
+        [['category_tools', categoryA], 1n],
+        [['import_health', 'UNKNOWN'], 1n],
+        [['execution_health', 'UNKNOWN'], 1n],
+        [['quality_bucket', 'unscored'], 1n],
+      ]);
+      assertSnapshot(afterInsert, expectedAfterInsert, 'real inserts must increment once');
+
+      await tx.package.upsert({
+        where: { npmPackageName: packageName },
+        create: {
+          id: packageId,
+          npmPackageName: packageName,
+          npmVersion: '1.0.1',
+          npmPublishedAt: new Date(),
+          category: categoryA,
+          tier: 'minimal',
+          discoveryMethod: 'counter-probe',
+          isOfficial: false,
+          npmDownloadsLastMonth: 7,
+          githubStars: 3,
+        },
+        update: { npmVersion: '1.0.1' },
+      });
+      await tx.tool.upsert({
+        where: { packageId_name: { packageId, name: 'probe' } },
+        create: {
+          id: toolId,
+          packageId,
+          name: 'probe',
+          description: 'Updated counter invariant probe',
+        },
+        update: { description: 'Updated counter invariant probe' },
+      });
+
+      assertSnapshot(
+        await readCounters(tx, keys),
+        expectedAfterInsert,
+        'conflicting upserts must not increment inserts'
+      );
+
+      await tx.package.update({
+        where: { id: packageId },
+        data: {
+          category: categoryB,
+          tier: 'rich',
+          isOfficial: true,
+          npmDownloadsLastMonth: 11,
+          githubStars: 5,
+        },
+      });
+      await tx.tool.update({
+        where: { id: toolId },
+        data: {
+          schemaSource: 'extracted',
+          importHealth: 'HEALTHY',
+          executionHealth: 'BROKEN',
+          qualityScore: new Prisma.Decimal('0.75'),
+        },
+      });
+
+      const expectedAfterUpdate = withDeltas(expectedAfterInsert, [
+        [['official_packages', ''], 1n],
+        [['official_tools', ''], 1n],
+        [['tier_packages', 'minimal'], -1n],
+        [['tier_packages', 'rich'], 1n],
+        [['total_npm_downloads', ''], 4n],
+        [['total_github_stars', ''], 2n],
+        [['category_tools', categoryA], -1n],
+        [['category_tools', categoryB], 1n],
+        [['tools_with_schema', ''], 1n],
+        [['import_health', 'UNKNOWN'], -1n],
+        [['import_health', 'HEALTHY'], 1n],
+        [['execution_health', 'UNKNOWN'], -1n],
+        [['execution_health', 'BROKEN'], 1n],
+        [['quality_bucket', 'unscored'], -1n],
+        [['quality_bucket', 'high'], 1n],
+      ]);
+      assertSnapshot(
+        await readCounters(tx, keys),
+        expectedAfterUpdate,
+        'dimension changes must move, not duplicate, projected counts'
+      );
+
+      const driftedKeys: CounterKey[] = [
+        ['total_packages', ''],
+        ['tier_packages', 'rich'],
+        ['total_npm_downloads', ''],
+        ['total_github_stars', ''],
+        ['total_simulations', ''],
+        ['category_tools', categoryB],
+        ['quality_bucket', 'high'],
+      ];
+      for (const [metric, dimension] of driftedKeys) {
+        await tx.$executeRaw`SELECT tpmjs_counter_add(${metric}, ${dimension}, ${5n}::bigint)`;
+      }
+      assertSnapshot(
+        await readCounters(tx, keys),
+        withDeltas(
+          expectedAfterUpdate,
+          driftedKeys.map((key) => [key, 5n])
+        ),
+        'the probe must create detectable drift before reconciliation'
+      );
+
+      await tx.$executeRawUnsafe('SELECT tpmjs_reconcile_counters()');
+      assertSnapshot(
+        await readCounters(tx, keys),
+        expectedAfterUpdate,
+        'exact reconciliation must repair every projected metric family'
+      );
+
+      await tx.package.delete({ where: { id: packageId } });
+      assertSnapshot(
+        await readCounters(tx, keys),
+        baseline,
+        'package cascade deletion must restore every counter'
+      );
+
+      throw new ExpectedRollback('rollback counter invariant probe');
+    });
+  } catch (error) {
+    if (!(error instanceof ExpectedRollback)) throw error;
+  }
+
+  assert.equal(
+    await prisma.package.count({ where: { id: packageId } }),
+    0,
+    'probe package must not persist'
+  );
+  assert.equal(
+    await prisma.tool.count({ where: { id: toolId } }),
+    0,
+    'probe tool must not persist'
+  );
+  assertSnapshot(
+    await readCounters(prisma, keys),
+    committedBaseline,
+    'rolled-back probe must leave committed counters unchanged'
+  );
+}
+
+async function verifyUnderflowFailsLoudly(): Promise<void> {
+  const metric = `underflow_probe_${randomUUID().slice(0, 8)}`;
+  const dimension = randomUUID();
+
+  await assert.rejects(
+    prisma.$executeRaw`SELECT tpmjs_counter_add(${metric}, ${dimension}, ${-1n}::bigint)`,
+    'a missing decrement must fail instead of being clamped to zero'
+  );
+  assert.equal(
+    await prisma.registryCounter.count({ where: { metric, dimension } }),
+    0,
+    'failed underflow must not persist a projection row'
+  );
+}
+
+async function main(): Promise<void> {
+  await verifyUpsertAndCascadeBalance();
+  await verifyUnderflowFailsLoudly();
+  console.log('registry counter invariants: pass');
+}
+
+main()
+  .catch((error) => {
+    console.error('registry counter invariants: fail', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## What changed

- replace registry counter triggers with AFTER row triggers so PostgreSQL ON CONFLICT updates are counted as updates, not phantom inserts
- make counter underflow fail loudly instead of clamping and hiding drift
- make reconciliation exact across every registry metric family from one locked source snapshot
- add a rolled-back invariant probe covering inserts, Prisma upserts, dimension moves, deliberate drift repair, cascades, and underflow
- run that invariant probe in the migration CI job
- repair only the guarded July 20–21 historical snapshot inflation while preserving genuinely time-varying download, star, health, and quality data

## Root cause

PostgreSQL fires row-level BEFORE INSERT triggers before ON CONFLICT arbitration. The prior package and tool triggers incremented insert counters even when Prisma upserts ultimately took DO UPDATE. Ten recent sync runs processed 2,100 records against only 237 packages, producing the observed multiplier.

## Data safety

- verified custom-format production backup: `/mnt/donto-data/backups/tpmjs-pre-counter-fix-20260721T113208Z.dump`
- SHA-256: `252fa87bfb27b3a04a993e00467b99474ff1e19721dd7f97ca9963b1718663ac`
- rehearsed all migrations from empty PostgreSQL 17 + pgvector
- restored production into a disposable clone, applied this migration, and verified exact current counters plus guarded snapshot repair
- no source package/tool rows are deleted or rewritten

## Verification

- `pnpm test` — 22/22 tasks; 1,015 assertions passed; 12 expected credential skips
- affected dependency-graph type-check — pass
- DB type-check, Biome, route ESLint, and `git diff --check` — pass
- fresh migration history + invariant probe + Prisma schema-drift check — pass
- production-clone migration + invariant probe + schema-drift check — pass

Closes #124
