### PR TITLE
feat(web): complete activation funnel analytics

### DIFF
--- a/apps/web/src/app/(auth)/sign-up/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/page.tsx
@@ -7,6 +7,7 @@ import { Input } from '@tpmjs/ui/Input/Input';
 import { Label } from '@tpmjs/ui/Label/Label';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
+import { trackSignup } from '~/lib/analytics';
 import { signUp } from '~/lib/auth-client';
 
 interface UsernameCheckResult {
@@ -99,6 +100,7 @@ export default function SignUpPage() {
       return;
     }
 
+    trackSignup('started');
     setLoading(true);
 
     try {
@@ -116,6 +118,9 @@ export default function SignUpPage() {
       }
 
       if (data) {
+        // Better Auth has durably created the account; profile setup is a separate milestone.
+        trackSignup('completed');
+
         // Account created - now set the username (REQUIRED)
         let usernameSet = false;
         let retries = 3;

--- a/apps/web/src/app/(profile)/[username]/collections/[slug]/CollectionDetailClient.tsx
+++ b/apps/web/src/app/(profile)/[username]/collections/[slug]/CollectionDetailClient.tsx
@@ -15,6 +15,7 @@ import { ShareButton } from '~/components/ShareButton';
 import { SkillsSection } from '~/components/skills/SkillsSection';
 import { UseCasesSection } from '~/components/UseCasesSection';
 import { useTrackView } from '~/hooks/useTrackView';
+import { trackCollectionMcpCopy } from '~/lib/analytics';
 import { useSession } from '~/lib/auth-client';
 
 /**
@@ -106,10 +107,12 @@ export interface PublicCollection {
 }
 
 function McpUrlSection({
+  collectionId,
   username,
   slug,
   isOwner,
 }: {
+  collectionId: string;
   username: string;
   slug: string;
   isOwner: boolean;
@@ -124,6 +127,7 @@ function McpUrlSection({
 
   const copyToClipboard = async (url: string, type: 'http' | 'sse') => {
     await navigator.clipboard.writeText(url);
+    trackCollectionMcpCopy(collectionId, `${type}_url`);
     setCopiedUrl(type);
     setTimeout(() => setCopiedUrl(null), 2000);
   };
@@ -245,7 +249,10 @@ const response = await fetch("${httpUrl}", {
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => navigator.clipboard.writeText(claudeCodeCommand)}
+            onClick={async () => {
+              await navigator.clipboard.writeText(claudeCodeCommand);
+              trackCollectionMcpCopy(collectionId, 'claude_code');
+            }}
             className="absolute top-1.5 right-1.5"
           >
             <Icon icon="copy" className="w-3.5 h-3.5" />
@@ -269,7 +276,11 @@ const response = await fetch("${httpUrl}", {
 
         {showConfig && (
           <div className="mt-3">
-            <CodeBlock language="json" code={configSnippet} />
+            <CodeBlock
+              language="json"
+              code={configSnippet}
+              onCopy={() => trackCollectionMcpCopy(collectionId, 'claude_config')}
+            />
           </div>
         )}
 
@@ -286,7 +297,11 @@ const response = await fetch("${httpUrl}", {
 
             {showApiExample && (
               <div className="mt-3">
-                <CodeBlock language="typescript" code={apiExampleSnippet} />
+                <CodeBlock
+                  language="typescript"
+                  code={apiExampleSnippet}
+                  onCopy={() => trackCollectionMcpCopy(collectionId, 'api_example')}
+                />
               </div>
             )}
           </>
@@ -405,7 +420,12 @@ export function CollectionDetailClient({
           </div>
 
           {/* MCP Server URLs - Available to everyone (non-owners must provide their own credentials) */}
-          <McpUrlSection username={username} slug={collection.slug} isOwner={!!isOwner} />
+          <McpUrlSection
+            collectionId={collection.id}
+            username={username}
+            slug={collection.slug}
+            isOwner={!!isOwner}
+          />
 
           {/* Tools */}
           {collection.tools.length > 0 ? (

--- a/apps/web/src/app/collections/[id]/page.tsx
+++ b/apps/web/src/app/collections/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { AppHeader } from '~/components/AppHeader';
 import { LikeButton } from '~/components/LikeButton';
+import { trackCollectionMcpCopy } from '~/lib/analytics';
 
 interface CollectionTool {
   id: string;
@@ -46,7 +47,15 @@ interface PublicCollection {
   tools: CollectionTool[];
 }
 
-function McpUrlSection({ username, slug }: { username: string; slug: string }) {
+function McpUrlSection({
+  collectionId,
+  username,
+  slug,
+}: {
+  collectionId: string;
+  username: string;
+  slug: string;
+}) {
   const [copiedUrl, setCopiedUrl] = useState<'http' | 'sse' | null>(null);
   const [showConfig, setShowConfig] = useState(false);
 
@@ -56,6 +65,7 @@ function McpUrlSection({ username, slug }: { username: string; slug: string }) {
 
   const copyToClipboard = async (url: string, type: 'http' | 'sse') => {
     await navigator.clipboard.writeText(url);
+    trackCollectionMcpCopy(collectionId, `${type}_url`);
     setCopiedUrl(type);
     setTimeout(() => setCopiedUrl(null), 2000);
   };
@@ -152,8 +162,9 @@ function McpUrlSection({ username, slug }: { username: string; slug: string }) {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {
-                navigator.clipboard.writeText(configSnippet);
+              onClick={async () => {
+                await navigator.clipboard.writeText(configSnippet);
+                trackCollectionMcpCopy(collectionId, 'claude_config');
                 setCopiedUrl('http');
                 setTimeout(() => setCopiedUrl(null), 2000);
               }}
@@ -312,7 +323,11 @@ export default function PublicCollectionDetailPage(): React.ReactElement {
 
         {/* MCP URLs */}
         {collection.createdBy?.username && collection.slug && (
-          <McpUrlSection username={collection.createdBy.username} slug={collection.slug} />
+          <McpUrlSection
+            collectionId={collection.id}
+            username={collection.createdBy.username}
+            slug={collection.slug}
+          />
         )}
 
         {/* Tools */}

--- a/apps/web/src/app/collections/page.tsx
+++ b/apps/web/src/app/collections/page.tsx
@@ -14,6 +14,7 @@ import { TableVirtuoso } from 'react-virtuoso';
 import { AppHeader } from '~/components/AppHeader';
 import { CopyDropdown, getCollectionCopyOptions } from '~/components/CopyDropdown';
 import { LikeButton } from '~/components/LikeButton';
+import { trackCollectionMcpCopy } from '~/lib/analytics';
 
 interface PublicCollection {
   id: string;
@@ -201,6 +202,9 @@ export default function PublicCollectionsPage(): React.ReactElement {
                 collection.name
               )}
               buttonLabel="Copy"
+              onCopy={(option) => {
+                if (option.id) trackCollectionMcpCopy(collection.id, option.id);
+              }}
             />
           )}
         </td>

--- a/apps/web/src/app/tool/[...slug]/ToolDetailClient.tsx
+++ b/apps/web/src/app/tool/[...slug]/ToolDetailClient.tsx
@@ -19,7 +19,7 @@ import { Markdown } from '~/components/Markdown';
 import { Rating } from '~/components/Rating';
 import { ToolPlayground } from '~/components/ToolPlayground';
 import { useTrackView } from '~/hooks/useTrackView';
-import { trackEvent } from '~/lib/analytics';
+import { type InstallSurface, trackEvent, trackInstallCommandCopy } from '~/lib/analytics';
 import {
   isPersistentlyImportBroken,
   PERSISTENT_IMPORT_FAILURE_THRESHOLD,
@@ -99,18 +99,19 @@ interface ToolDetailClientProps {
 export function ToolDetailClient({ tool, slug }: ToolDetailClientProps): React.ReactElement {
   const [recheckLoading, setRecheckLoading] = useState(false);
   const [extractSchemaLoading, setExtractSchemaLoading] = useState(false);
-  const [surface, setSurface] = useState<'sdk' | 'mcp' | 'rest' | 'cli' | 'skill'>('sdk');
+  const [surface, setSurface] = useState<InstallSurface>('sdk');
 
   // Track page view
   useTrackView('tool', tool.id);
 
   const pkg = tool.package;
+  const toolAnalyticsId = tool.id;
   const isPersistentlyBroken = isPersistentlyImportBroken(tool.consecutiveImportFailures);
 
   // Activation-funnel analytics: this tool was viewed.
   useEffect(() => {
-    trackEvent('tool_view', { tool: `${pkg.npmPackageName}::${tool.name}` });
-  }, [pkg.npmPackageName, tool.name]);
+    trackEvent('tool_view', { tool: toolAnalyticsId });
+  }, [toolAnalyticsId]);
   const authorName = typeof pkg.npmAuthor === 'string' ? pkg.npmAuthor : pkg.npmAuthor?.name;
 
   // Generate JSON-LD structured data for SEO
@@ -407,11 +408,11 @@ export function ToolDetailClient({ tool, slug }: ToolDetailClientProps): React.R
                   ]}
                   activeTab={surface}
                   onTabChange={(id) => {
-                    const next = id as typeof surface;
+                    const next = id as InstallSurface;
                     setSurface(next);
                     trackEvent('install_surface', {
                       surface: next,
-                      tool: `${pkg.npmPackageName}::${tool.name}`,
+                      tool: toolAnalyticsId,
                     });
                   }}
                 />
@@ -425,6 +426,7 @@ export function ToolDetailClient({ tool, slug }: ToolDetailClientProps): React.R
                       code={`npm install ${pkg.npmPackageName}`}
                       language="bash"
                       showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
                     />
                     <CodeBlock
                       code={`import { generateText } from 'ai';
@@ -438,6 +440,7 @@ const result = await generateText({
 });`}
                       language="typescript"
                       showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
                     />
                     <p className="text-xs text-foreground-tertiary">
                       Prefer no install? Load it from the registry with <code>@tpmjs/compose</code>:{' '}
@@ -457,11 +460,13 @@ const result = await generateText({
   https://tpmjs.com/api/mcp/registry/http -t http`}
                       language="bash"
                       showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
                     />
                     <CodeBlock
                       code={`{ "toolId": "${pkg.npmPackageName}::${tool.name}", "params": { /* see Parameters */ } }`}
                       language="json"
                       showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
                     />
                   </div>
                 )}
@@ -477,6 +482,7 @@ const result = await generateText({
   -d '{"toolId":"${pkg.npmPackageName}::${tool.name}","params":{}}'`}
                       language="bash"
                       showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
                     />
                   </div>
                 )}
@@ -486,12 +492,18 @@ const result = await generateText({
                     <p className="text-sm text-foreground-secondary">
                       Use the <code>tpm</code> command line (from <code>@tpmjs/cli</code>).
                     </p>
-                    <CodeBlock code={`npm install -g @tpmjs/cli`} language="bash" showCopy={true} />
+                    <CodeBlock
+                      code={`npm install -g @tpmjs/cli`}
+                      language="bash"
+                      showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
+                    />
                     <CodeBlock
                       code={`tpm tool info ${pkg.npmPackageName} ${tool.name}
 tpm tool execute ${tool.name} --input '{}'`}
                       language="bash"
                       showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
                     />
                   </div>
                 )}
@@ -510,6 +522,7 @@ tpm tool execute ${tool.name} --input '{}'`}
                       code={`GET https://tpmjs.com/@<user>/collections/<slug>/skills`}
                       language="bash"
                       showCopy={true}
+                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
                     />
                   </div>
                 )}

--- a/apps/web/src/components/CopyDropdown.tsx
+++ b/apps/web/src/components/CopyDropdown.tsx
@@ -5,7 +5,9 @@ import { Icon } from '@tpmjs/ui/Icon/Icon';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-interface CopyOption {
+export interface CopyOption {
+  /** Stable identifier for consumers such as analytics; never derived from the label. */
+  id?: string;
   label: string;
   value: string;
   description?: string;
@@ -15,12 +17,14 @@ interface CopyDropdownProps {
   options: CopyOption[];
   buttonLabel?: string;
   className?: string;
+  onCopy?: (option: CopyOption) => void;
 }
 
 export function CopyDropdown({
   options,
   buttonLabel = 'Copy',
   className = '',
+  onCopy,
 }: CopyDropdownProps): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -35,15 +39,23 @@ export function CopyDropdown({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const handleCopy = useCallback(async (option: CopyOption) => {
-    try {
-      await navigator.clipboard.writeText(option.value);
-      toast.success(`${option.label} copied to clipboard`);
-      setIsOpen(false);
-    } catch {
-      toast.error('Failed to copy');
-    }
-  }, []);
+  const handleCopy = useCallback(
+    async (option: CopyOption) => {
+      try {
+        await navigator.clipboard.writeText(option.value);
+        toast.success(`${option.label} copied to clipboard`);
+        setIsOpen(false);
+        try {
+          onCopy?.(option);
+        } catch {
+          // Follow-up observers must never turn a successful copy into a UI failure.
+        }
+      } catch {
+        toast.error('Failed to copy');
+      }
+    },
+    [onCopy]
+  );
 
   return (
     <div className={`relative ${className}`} ref={dropdownRef}>
@@ -112,9 +124,10 @@ export function getCollectionCopyOptions(
   );
 
   return [
-    { label: 'MCP URL (HTTP)', value: mcpUrlHttp, description: mcpUrlHttp },
-    { label: 'MCP URL (SSE)', value: mcpUrlSse, description: mcpUrlSse },
+    { id: 'http_url', label: 'MCP URL (HTTP)', value: mcpUrlHttp, description: mcpUrlHttp },
+    { id: 'sse_url', label: 'MCP URL (SSE)', value: mcpUrlSse, description: mcpUrlSse },
     {
+      id: 'claude_config',
       label: 'Claude Config',
       value: claudeConfig,
       description: 'JSON for claude_desktop_config.json',

--- a/apps/web/src/components/ToolPlayground.tsx
+++ b/apps/web/src/components/ToolPlayground.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { TokenBreakdown as TokenData } from '@/lib/ai-agent/tool-executor-agent';
+import { createPlaygroundOutcomeRecorder } from '~/lib/analytics';
 import { TokenBreakdown } from './TokenBreakdown';
 
 interface ToolPlaygroundProps {
@@ -42,6 +43,8 @@ export function ToolPlayground({ tool }: ToolPlaygroundProps): React.ReactElemen
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: SSE stream handling requires sequential logic
   const handleExecute = async () => {
     if (!prompt.trim() || isExecuting) return;
+
+    const recordTerminalOutcome = createPlaygroundOutcomeRecorder(tool.id);
 
     setIsExecuting(true);
     setOutput('');
@@ -137,6 +140,7 @@ export function ToolPlayground({ tool }: ToolPlaygroundProps): React.ReactElemen
                       timestamp: new Date(),
                     },
                   ]);
+                  recordTerminalOutcome('success');
                   break;
 
                 case 'error':
@@ -149,12 +153,16 @@ export function ToolPlayground({ tool }: ToolPlaygroundProps): React.ReactElemen
                       timestamp: new Date(),
                     },
                   ]);
+                  recordTerminalOutcome('failure');
                   break;
               }
             }
           }
         }
       }
+
+      // A clean stream close without a terminal event is still an incomplete execution.
+      recordTerminalOutcome('failure');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       setError(message);
@@ -166,6 +174,7 @@ export function ToolPlayground({ tool }: ToolPlaygroundProps): React.ReactElemen
           timestamp: new Date(),
         },
       ]);
+      recordTerminalOutcome('failure');
     } finally {
       setIsExecuting(false);
     }

--- a/apps/web/src/lib/analytics.test.ts
+++ b/apps/web/src/lib/analytics.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPlaygroundOutcomeRecorder,
+  trackCollectionMcpCopy,
+  trackEvent,
+  trackInstallCommandCopy,
+  trackPlaygroundExecution,
+  trackSignup,
+} from './analytics';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('activation-funnel analytics', () => {
+  it('is a no-op during server rendering', () => {
+    vi.stubGlobal('window', undefined);
+    expect(() => trackEvent('tool_view', { tool: 'pkg::tool' })).not.toThrow();
+  });
+
+  it('is fail-open before Umami loads or when it throws', () => {
+    vi.stubGlobal('window', {});
+    expect(() => trackEvent('tool_view')).not.toThrow();
+
+    vi.stubGlobal('window', {
+      umami: {
+        track: () => {
+          throw new Error('analytics unavailable');
+        },
+      },
+    });
+    expect(() => trackEvent('tool_view')).not.toThrow();
+  });
+
+  it('emits privacy-safe, stable activation events', () => {
+    const track = vi.fn();
+    vi.stubGlobal('window', { umami: { track } });
+
+    trackInstallCommandCopy('tool-id', 'mcp');
+    trackPlaygroundExecution('tool-id', 'success');
+    trackCollectionMcpCopy('collection-id', 'http_url');
+    trackSignup('started');
+    trackSignup('completed');
+
+    expect(track.mock.calls).toEqual([
+      ['install_command_copy', { tool: 'tool-id', surface: 'mcp' }],
+      ['playground_execute', { tool: 'tool-id', outcome: 'success' }],
+      ['collection_mcp_copy', { collection: 'collection-id', format: 'http_url' }],
+      ['signup_started', { method: 'email' }],
+      ['signup_completed', { method: 'email' }],
+    ]);
+  });
+
+  it('records exactly one terminal outcome for each playground attempt', () => {
+    const track = vi.fn();
+    vi.stubGlobal('window', { umami: { track } });
+    const recordOutcome = createPlaygroundOutcomeRecorder('tool-id');
+
+    recordOutcome('success');
+    recordOutcome('failure');
+
+    expect(track).toHaveBeenCalledOnce();
+    expect(track).toHaveBeenCalledWith('playground_execute', {
+      tool: 'tool-id',
+      outcome: 'success',
+    });
+  });
+});

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -7,6 +7,9 @@
  */
 type UmamiApi = { track?: (name: string, data?: Record<string, unknown>) => void };
 
+export type InstallSurface = 'sdk' | 'mcp' | 'rest' | 'cli' | 'skill';
+export type PlaygroundOutcome = 'success' | 'failure';
+
 export function trackEvent(name: string, data?: Record<string, unknown>): void {
   if (typeof window === 'undefined') return;
   try {
@@ -15,4 +18,36 @@ export function trackEvent(name: string, data?: Record<string, unknown>): void {
   } catch {
     // analytics must never break the page
   }
+}
+
+/** Record a successful copy without sending the copied command itself. */
+export function trackInstallCommandCopy(tool: string, surface: InstallSurface): void {
+  trackEvent('install_command_copy', { tool, surface });
+}
+
+/** Record only the terminal outcome; prompts, output, and errors stay private. */
+export function trackPlaygroundExecution(tool: string, outcome: PlaygroundOutcome): void {
+  trackEvent('playground_execute', { tool, outcome });
+}
+
+/** Build an attempt-scoped recorder so every execution emits exactly one terminal outcome. */
+export function createPlaygroundOutcomeRecorder(
+  tool: string
+): (outcome: PlaygroundOutcome) => void {
+  let recorded = false;
+  return (outcome) => {
+    if (recorded) return;
+    recorded = true;
+    trackPlaygroundExecution(tool, outcome);
+  };
+}
+
+/** Record the stable copy surface without sending the collection URL or config. */
+export function trackCollectionMcpCopy(collection: string, format: string): void {
+  trackEvent('collection_mcp_copy', { collection, format });
+}
+
+/** Record signup milestones without attaching user-entered identity data. */
+export function trackSignup(stage: 'started' | 'completed'): void {
+  trackEvent(`signup_${stage}`, { method: 'email' });
 }

--- a/packages/ui/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/ui/src/CodeBlock/CodeBlock.test.tsx
@@ -165,6 +165,29 @@ describe('CodeBlock', () => {
       });
     });
 
+    it('calls onCopy only after the clipboard write succeeds', async () => {
+      const onCopy = vi.fn();
+      render(<CodeBlock code="test code" onCopy={onCopy} />);
+      screen.getByTestId('copy-button').click();
+
+      await waitFor(() => {
+        expect(onCopy).toHaveBeenCalledOnce();
+      });
+    });
+
+    it('keeps a successful copy successful when onCopy throws', async () => {
+      const onCopy = vi.fn(() => {
+        throw new Error('observer unavailable');
+      });
+      render(<CodeBlock code="test code" onCopy={onCopy} />);
+      const button = screen.getByTestId('copy-button');
+      button.click();
+
+      await waitFor(() => {
+        expect(button).toHaveAttribute('aria-label', 'Copied!');
+      });
+    });
+
     it('shows check icon after successful copy', async () => {
       render(<CodeBlock code="test code" data-testid="codeblock" />);
       const button = screen.getByTestId('copy-button');
@@ -233,16 +256,18 @@ describe('CodeBlock', () => {
 
     it('handles clipboard API errors gracefully', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const onCopy = vi.fn();
       mockClipboard.writeText.mockRejectedValueOnce(new Error('Clipboard not available'));
 
       try {
-        render(<CodeBlock code="test code" />);
+        render(<CodeBlock code="test code" onCopy={onCopy} />);
         const button = screen.getByTestId('copy-button');
         button.click();
 
         await waitFor(
           () => {
             expect(consoleErrorSpy).toHaveBeenCalled();
+            expect(onCopy).not.toHaveBeenCalled();
           },
           { timeout: 1000 }
         );

--- a/packages/ui/src/CodeBlock/CodeBlock.tsx
+++ b/packages/ui/src/CodeBlock/CodeBlock.tsx
@@ -62,7 +62,10 @@ function useDarkMode(): boolean {
  * ```
  */
 export const CodeBlock = forwardRef<HTMLDivElement, CodeBlockProps>(
-  ({ className, code, language = 'text', size = 'md', showCopy = true, theme, ...props }, ref) => {
+  (
+    { className, code, language = 'text', size = 'md', showCopy = true, theme, onCopy, ...props },
+    ref
+  ) => {
     const [copied, setCopied] = useState(false);
     const isDarkMode = useDarkMode();
 
@@ -77,6 +80,13 @@ export const CodeBlock = forwardRef<HTMLDivElement, CodeBlockProps>(
       } catch (err) {
         // Silently fail if clipboard API is not available
         console.error('Failed to copy code:', err);
+        return;
+      }
+
+      try {
+        onCopy?.();
+      } catch {
+        // Follow-up observers must never turn a successful copy into a UI failure.
       }
     };
 

--- a/packages/ui/src/CodeBlock/types.ts
+++ b/packages/ui/src/CodeBlock/types.ts
@@ -28,6 +28,11 @@ export interface CodeBlockProps extends Omit<HTMLAttributes<HTMLDivElement>, 'ch
   showCopy?: boolean;
 
   /**
+   * Called after the clipboard write succeeds.
+   */
+  onCopy?: () => void;
+
+  /**
    * Color theme for syntax highlighting
    * If not provided, auto-detects from .dark class on html element
    */


### PR DESCRIPTION
Closes #128

## What changed
- completes the Umami activation funnel across successful install copies, playground terminal outcomes, collection MCP copies, and signup milestones
- uses durable tool and collection IDs plus stable surface/format dimensions
- keeps prompts, outputs, errors, copied values, credentials, and identity fields out of analytics
- makes copy observers fail-open and emits exactly one terminal playground outcome per attempt

## Validation
- full UI suite: 858 passed
- full web suite: 127 passed, 12 expected skips
- monorepo pre-push suite: 22/22 tasks successful
- dependency-aware type checks: green
- production Next.js build: 9/9 tasks successful; 101 static pages generated
- Biome and git diff checks: green (three pre-existing warnings remain in touched legacy surfaces)