### PR TITLE
fix(web): parse playground SSE streams safely

### DIFF
--- a/apps/web/src/components/ToolPlayground.tsx
+++ b/apps/web/src/components/ToolPlayground.tsx
@@ -15,6 +15,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { TokenBreakdown as TokenData } from '@/lib/ai-agent/tool-executor-agent';
 import { createPlaygroundOutcomeRecorder } from '~/lib/analytics';
+import { createServerSentEventParser, type ServerSentEvent } from '~/lib/server-sent-events';
 import { TokenBreakdown } from './TokenBreakdown';
 
 interface ToolPlaygroundProps {
@@ -84,82 +85,77 @@ export function ToolPlayground({ tool }: ToolPlaygroundProps): React.ReactElemen
         throw new Error('No response body');
       }
 
-      let buffer = '';
+      const parser = createServerSentEventParser();
+
+      const handleEvents = (events: ServerSentEvent[]) => {
+        for (const { event, data: serializedData } of events) {
+          const data = JSON.parse(serializedData);
+
+          switch (event) {
+            case 'chunk':
+              setOutput((prev) => prev + data.text);
+              setLogs((prev) => [
+                ...prev,
+                {
+                  level: 'info',
+                  message: `Streaming: ${data.text.slice(0, 50)}${data.text.length > 50 ? '...' : ''}`,
+                  timestamp: new Date(),
+                },
+              ]);
+              break;
+
+            case 'tokens':
+              setTokens(data as TokenData);
+              setLogs((prev) => [
+                ...prev,
+                {
+                  level: 'debug',
+                  message: `Token update: ${data.totalTokens || 0} total tokens`,
+                  timestamp: new Date(),
+                },
+              ]);
+              break;
+
+            case 'complete':
+              // Keep the accumulated streamed output rather than replacing it.
+              setTokens(data.tokenBreakdown);
+              setLogs((prev) => [
+                ...prev,
+                {
+                  level: 'info',
+                  message: `Execution completed in ${data.executionTimeMs}ms with ${data.agentSteps} agent steps`,
+                  timestamp: new Date(),
+                },
+              ]);
+              recordTerminalOutcome('success');
+              break;
+
+            case 'error':
+              setError(data.message);
+              setLogs((prev) => [
+                ...prev,
+                {
+                  level: 'error',
+                  message: data.message,
+                  timestamp: new Date(),
+                },
+              ]);
+              recordTerminalOutcome('failure');
+              break;
+          }
+        }
+      };
 
       while (true) {
         const { done, value } = await reader.read();
 
         if (done) break;
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-
-        for (const line of lines) {
-          if (line.startsWith('event:')) {
-            const event = line.slice(6).trim();
-            const nextLine = lines.shift();
-
-            if (nextLine?.startsWith('data:')) {
-              const data = JSON.parse(nextLine.slice(5).trim());
-
-              switch (event) {
-                case 'chunk':
-                  setOutput((prev) => prev + data.text);
-                  setLogs((prev) => [
-                    ...prev,
-                    {
-                      level: 'info',
-                      message: `Streaming: ${data.text.slice(0, 50)}${data.text.length > 50 ? '...' : ''}`,
-                      timestamp: new Date(),
-                    },
-                  ]);
-                  break;
-
-                case 'tokens':
-                  setTokens(data as TokenData);
-                  setLogs((prev) => [
-                    ...prev,
-                    {
-                      level: 'debug',
-                      message: `Token update: ${data.totalTokens || 0} total tokens`,
-                      timestamp: new Date(),
-                    },
-                  ]);
-                  break;
-
-                case 'complete':
-                  // Don't replace output - keep the streamed text
-                  // setOutput(data.output); // Removed: this was overwriting streamed content
-                  setTokens(data.tokenBreakdown);
-                  setLogs((prev) => [
-                    ...prev,
-                    {
-                      level: 'info',
-                      message: `Execution completed in ${data.executionTimeMs}ms with ${data.agentSteps} agent steps`,
-                      timestamp: new Date(),
-                    },
-                  ]);
-                  recordTerminalOutcome('success');
-                  break;
-
-                case 'error':
-                  setError(data.message);
-                  setLogs((prev) => [
-                    ...prev,
-                    {
-                      level: 'error',
-                      message: data.message,
-                      timestamp: new Date(),
-                    },
-                  ]);
-                  recordTerminalOutcome('failure');
-                  break;
-              }
-            }
-          }
-        }
+        handleEvents(parser.push(decoder.decode(value, { stream: true })));
       }
+
+      handleEvents(parser.push(decoder.decode()));
+      handleEvents(parser.finish());
 
       // A clean stream close without a terminal event is still an incomplete execution.
       recordTerminalOutcome('failure');

--- a/apps/web/src/lib/server-sent-events.test.ts
+++ b/apps/web/src/lib/server-sent-events.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { createServerSentEventParser } from './server-sent-events';
+
+describe('createServerSentEventParser', () => {
+  it('parses a complete event', () => {
+    const parser = createServerSentEventParser();
+
+    expect(parser.push('event: complete\ndata: {"ok":true}\n\n')).toEqual([
+      { event: 'complete', data: '{"ok":true}' },
+    ]);
+  });
+
+  it('retains state across arbitrary network chunk boundaries', () => {
+    const parser = createServerSentEventParser();
+
+    expect(parser.push('eve')).toEqual([]);
+    expect(parser.push('nt: complete\nda')).toEqual([]);
+    expect(parser.push('ta: {"ok":true}\n')).toEqual([]);
+    expect(parser.push('\n')).toEqual([{ event: 'complete', data: '{"ok":true}' }]);
+  });
+
+  it('parses multiple events from one chunk without dropping adjacent lines', () => {
+    const parser = createServerSentEventParser();
+
+    expect(
+      parser.push(
+        'event: chunk\ndata: {"text":"hello"}\n\nevent: tokens\ndata: {"totalTokens":1}\n\nevent: complete\ndata: {"agentSteps":1}\n\n'
+      )
+    ).toEqual([
+      { event: 'chunk', data: '{"text":"hello"}' },
+      { event: 'tokens', data: '{"totalTokens":1}' },
+      { event: 'complete', data: '{"agentSteps":1}' },
+    ]);
+  });
+
+  it('supports CRLF, comments, and multi-line data fields', () => {
+    const parser = createServerSentEventParser();
+
+    expect(
+      parser.push(': keep-alive\r\nevent: message\r\ndata: first\r\ndata: second\r\n\r\n')
+    ).toEqual([{ event: 'message', data: 'first\nsecond' }]);
+  });
+
+  it('flushes a final event when the stream closes without a blank line', () => {
+    const parser = createServerSentEventParser();
+
+    expect(parser.push('event: complete\ndata: {"ok":true}')).toEqual([]);
+    expect(parser.finish()).toEqual([{ event: 'complete', data: '{"ok":true}' }]);
+  });
+
+  it('does not dispatch event metadata without a data field', () => {
+    const parser = createServerSentEventParser();
+
+    expect(parser.push('event: complete\n\n')).toEqual([]);
+    expect(parser.finish()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/server-sent-events.ts
+++ b/apps/web/src/lib/server-sent-events.ts
@@ -1,0 +1,93 @@
+export interface ServerSentEvent {
+  event: string;
+  data: string;
+}
+
+export interface ServerSentEventParser {
+  push(chunk: string): ServerSentEvent[];
+  finish(): ServerSentEvent[];
+}
+
+/**
+ * Incrementally parses the subset of the Server-Sent Events protocol used by
+ * the playground. State is retained across network chunks, so field names,
+ * values, and event boundaries do not need to align with reader reads.
+ */
+export function createServerSentEventParser(): ServerSentEventParser {
+  let buffer = '';
+  let eventName = 'message';
+  let dataLines: string[] = [];
+
+  const dispatch = (): ServerSentEvent[] => {
+    const event = dataLines.length > 0 ? [{ event: eventName, data: dataLines.join('\n') }] : [];
+
+    eventName = 'message';
+    dataLines = [];
+
+    return event;
+  };
+
+  const processLine = (line: string): ServerSentEvent[] => {
+    if (line === '') {
+      return dispatch();
+    }
+
+    if (line.startsWith(':')) {
+      return [];
+    }
+
+    const separator = line.indexOf(':');
+    const field = separator === -1 ? line : line.slice(0, separator);
+    let value = separator === -1 ? '' : line.slice(separator + 1);
+
+    if (value.startsWith(' ')) {
+      value = value.slice(1);
+    }
+
+    if (field === 'event') {
+      eventName = value;
+    } else if (field === 'data') {
+      dataLines.push(value);
+    }
+
+    return [];
+  };
+
+  const processCompleteLines = (): ServerSentEvent[] => {
+    const events: ServerSentEvent[] = [];
+    let newline = buffer.indexOf('\n');
+
+    while (newline !== -1) {
+      let line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+
+      if (line.endsWith('\r')) {
+        line = line.slice(0, -1);
+      }
+
+      events.push(...processLine(line));
+      newline = buffer.indexOf('\n');
+    }
+
+    return events;
+  };
+
+  return {
+    push(chunk) {
+      buffer += chunk;
+      return processCompleteLines();
+    },
+    finish() {
+      const events = processCompleteLines();
+
+      if (buffer.length > 0) {
+        const finalLine = buffer.endsWith('\r') ? buffer.slice(0, -1) : buffer;
+        buffer = '';
+        events.push(...processLine(finalLine));
+      }
+
+      events.push(...dispatch());
+      return events;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- replace the playground's mutating line-array SSE loop with a stateful incremental parser
- preserve events across arbitrary reader chunk boundaries and support CRLF, comments, adjacent events, multi-line data, and EOF flushing
- keep terminal analytics exactly-once while correctly distinguishing complete vs incomplete streams

## Verification

- 6 focused SSE parser tests
- 133 web tests passed (12 expected skips)
- 18/18 dependency-aware type-check tasks passed
- ESLint and Biome passed on all touched files
- pre-commit gates passed
- pre-push monorepo suite passed 22/22 tasks
- forced production build passed 9/9 tasks and generated 101/101 static pages

Closes #128