### PR TITLE
feat(web): server-render discovery pages

### DIFF
--- a/apps/web/src/app/collections/CollectionsClient.tsx
+++ b/apps/web/src/app/collections/CollectionsClient.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { Badge } from '@tpmjs/ui/Badge/Badge';
+import { EmptyState } from '@tpmjs/ui/EmptyState/EmptyState';
+import { ErrorState } from '@tpmjs/ui/ErrorState/ErrorState';
+import { Icon } from '@tpmjs/ui/Icon/Icon';
+import { Input } from '@tpmjs/ui/Input/Input';
+import { LoadingState } from '@tpmjs/ui/LoadingState/LoadingState';
+import { PageHeader } from '@tpmjs/ui/PageHeader/PageHeader';
+import { Select } from '@tpmjs/ui/Select/Select';
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { TableVirtuoso } from 'react-virtuoso';
+import { AppHeader } from '~/components/AppHeader';
+import { CopyDropdown, getCollectionCopyOptions } from '~/components/CopyDropdown';
+import { LikeButton } from '~/components/LikeButton';
+import { trackCollectionMcpCopy } from '~/lib/analytics';
+import type { PublicCollection } from '~/lib/discovery/types';
+
+type SortOption = 'likes' | 'recent' | 'tools';
+
+function sortCollections(collections: PublicCollection[], sortBy: SortOption): PublicCollection[] {
+  return [...collections].sort((a, b) => {
+    switch (sortBy) {
+      case 'likes':
+        return b.likeCount - a.likeCount;
+      case 'recent':
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      case 'tools':
+        return b.toolCount - a.toolCount;
+      default:
+        return 0;
+    }
+  });
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength).trim()}...`;
+}
+
+function subscribeToHydration(): () => void {
+  return () => undefined;
+}
+
+function useIsHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribeToHydration,
+    () => true,
+    () => false
+  );
+}
+
+interface CollectionsClientProps {
+  initialCollections: PublicCollection[];
+  initialHasMore: boolean;
+  initialLoadFailed: boolean;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: cohesive collection discovery state and rendering
+export function CollectionsClient({
+  initialCollections,
+  initialHasMore,
+  initialLoadFailed,
+}: CollectionsClientProps): React.ReactElement {
+  const isHydrated = useIsHydrated();
+  const [collections, setCollections] = useState<PublicCollection[]>(initialCollections);
+  const [isLoading, setIsLoading] = useState(initialLoadFailed);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<SortOption>('likes');
+  const loadingMore = useRef(false);
+
+  const fetchCollections = useCallback(
+    async (offset: number, resetList = false) => {
+      try {
+        if (loadingMore.current && !resetList) return;
+        loadingMore.current = true;
+
+        const params = new URLSearchParams({
+          limit: '50',
+          offset: String(offset),
+          sort,
+        });
+
+        const response = await fetch(`/api/public/collections?${params}`);
+        const data = await response.json();
+
+        if (data.success) {
+          if (resetList || offset === 0) {
+            setCollections(data.data);
+          } else {
+            setCollections((prev) => [...prev, ...data.data]);
+          }
+          setHasMore(data.pagination.hasMore);
+        } else {
+          setError(data.error?.message || 'Failed to fetch collections');
+        }
+      } catch (err) {
+        console.error('Failed to fetch collections:', err);
+        setError('Failed to fetch collections');
+      } finally {
+        setIsLoading(false);
+        loadingMore.current = false;
+      }
+    },
+    [sort]
+  );
+
+  useEffect(() => {
+    if (initialLoadFailed || sort !== 'likes') setIsLoading(true);
+    fetchCollections(0, true);
+  }, [fetchCollections, initialLoadFailed, sort]);
+
+  const loadMore = useCallback(() => {
+    if (!hasMore || loadingMore.current) return;
+    fetchCollections(collections.length);
+  }, [hasMore, collections.length, fetchCollections]);
+
+  // Filter and sort collections
+  const filteredCollections = useMemo(() => {
+    let result = collections;
+
+    if (search) {
+      const query = search.toLowerCase();
+      result = result.filter(
+        (c) => c.name.toLowerCase().includes(query) || c.description?.toLowerCase().includes(query)
+      );
+    }
+
+    return sortCollections(result, sort);
+  }, [collections, search, sort]);
+
+  const TableHeader = useCallback(
+    () => (
+      <tr className="bg-surface-secondary text-left text-xs font-semibold uppercase tracking-wider text-foreground-secondary border-b border-border">
+        <th className="px-4 py-3 w-[250px]">Name</th>
+        <th className="px-4 py-3 w-[250px]">Description</th>
+        <th className="px-4 py-3 w-[80px] text-center">Tools</th>
+        <th className="px-4 py-3 w-[70px] text-center">Forks</th>
+        <th className="px-4 py-3 w-[80px] text-center">Likes</th>
+        <th className="px-4 py-3 w-[150px]">Creator</th>
+        <th className="px-4 py-3 w-[100px] text-right">Copy</th>
+      </tr>
+    ),
+    []
+  );
+
+  const TableRow = useCallback((_index: number, collection: PublicCollection) => {
+    return (
+      <>
+        <td className="px-4 py-3">
+          <Link
+            href={
+              collection.createdBy.username && collection.slug
+                ? `/${collection.createdBy.username}/collections/${collection.slug}`
+                : `/collections/${collection.id}`
+            }
+            className="font-semibold text-foreground hover:text-primary group-hover:text-primary transition-colors"
+          >
+            {collection.name}
+          </Link>
+        </td>
+        <td className="px-4 py-3 text-sm text-foreground-secondary">
+          {collection.description ? truncateText(collection.description, 60) : '—'}
+        </td>
+        <td className="px-4 py-3 text-center">
+          <Badge variant="secondary" size="sm">
+            {collection.toolCount}
+          </Badge>
+        </td>
+        <td className="px-4 py-3 text-center text-sm text-foreground-secondary">
+          {collection.forkCount > 0 ? collection.forkCount : '—'}
+        </td>
+        <td className="px-4 py-3 text-center">
+          <LikeButton
+            entityType="collection"
+            entityId={collection.id}
+            initialCount={collection.likeCount}
+            size="sm"
+            showCount={true}
+          />
+        </td>
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-2">
+            {collection.createdBy.image ? (
+              // biome-ignore lint/performance/noImgElement: user-controlled avatar hosts cannot be enumerated safely
+              <img
+                src={collection.createdBy.image}
+                alt={collection.createdBy.name}
+                className="w-5 h-5 rounded-full"
+              />
+            ) : (
+              <div className="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center">
+                <Icon icon="user" size="xs" className="text-primary" />
+              </div>
+            )}
+            <span className="text-sm text-foreground-secondary truncate max-w-[100px]">
+              {collection.createdBy.name}
+            </span>
+          </div>
+        </td>
+        <td className="px-4 py-3 text-right">
+          {collection.createdBy.username && collection.slug && (
+            <CopyDropdown
+              options={getCollectionCopyOptions(
+                collection.createdBy.username,
+                collection.slug,
+                collection.name
+              )}
+              buttonLabel="Copy"
+              onCopy={(option) => {
+                if (option.id) trackCollectionMcpCopy(collection.id, option.id);
+              }}
+            />
+          )}
+        </td>
+      </>
+    );
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <PageHeader
+          title="Public Collections"
+          description="Discover curated tool collections shared by the community"
+        />
+
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-4 mb-6">
+          <div className="flex-1">
+            <Input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search collections..."
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-foreground-secondary">Sort:</span>
+            <Select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as SortOption)}
+              options={[
+                { value: 'likes', label: 'Most Liked' },
+                { value: 'recent', label: 'Most Recent' },
+                { value: 'tools', label: 'Most Tools' },
+              ]}
+            />
+          </div>
+        </div>
+
+        {/* Content */}
+        {error ? (
+          <ErrorState message={error} onRetry={() => fetchCollections(0, true)} />
+        ) : isLoading ? (
+          <LoadingState message="Loading collections..." size="lg" />
+        ) : filteredCollections.length === 0 ? (
+          <EmptyState
+            icon="folder"
+            title="No collections found"
+            description={
+              search
+                ? 'Try adjusting your search terms'
+                : 'Be the first to share a public collection!'
+            }
+          />
+        ) : (
+          <>
+            <div className="border border-border rounded-lg overflow-hidden">
+              {isHydrated ? (
+                <TableVirtuoso
+                  style={{ height: 'calc(100vh - 350px)', minHeight: '400px' }}
+                  data={filteredCollections}
+                  overscan={30}
+                  endReached={loadMore}
+                  fixedHeaderContent={TableHeader}
+                  itemContent={TableRow}
+                  components={{
+                    Table: (props) => (
+                      <table
+                        {...props}
+                        className="w-full border-collapse text-sm"
+                        style={{ tableLayout: 'fixed' }}
+                      />
+                    ),
+                    TableHead: (props) => (
+                      <thead {...props} className="bg-surface-secondary sticky top-0 z-10" />
+                    ),
+                    TableBody: (props) => <tbody {...props} />,
+                    TableRow: (props) => (
+                      <tr
+                        {...props}
+                        className="border-b border-border bg-surface hover:bg-surface-secondary transition-all duration-150 group"
+                      />
+                    ),
+                  }}
+                />
+              ) : (
+                <table className="w-full border-collapse text-sm" style={{ tableLayout: 'fixed' }}>
+                  <thead className="bg-surface-secondary">{TableHeader()}</thead>
+                  <tbody>
+                    {filteredCollections.slice(0, 20).map((collection, index) => (
+                      <tr
+                        key={collection.id}
+                        className="border-b border-border bg-surface hover:bg-surface-secondary transition-all duration-150 group"
+                      >
+                        {TableRow(index, collection)}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+
+            <div className="mt-4 text-sm text-foreground-tertiary">
+              Showing {filteredCollections.length} collection
+              {filteredCollections.length !== 1 ? 's' : ''}
+              {search && ` matching "${search}"`}
+              {hasMore && ' (scroll for more)'}
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/collections/layout.tsx
+++ b/apps/web/src/app/collections/layout.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Public Collections | TPMJS',
+  title: 'Public Collections',
   description:
     'Browse tool collections on TPMJS. Collections group related AI tools into shareable workflow bundles with test scenarios.',
+  alternates: { canonical: '/collections' },
+  robots: { index: true, follow: true },
   openGraph: {
     title: 'Public Collections | TPMJS',
     description:

--- a/apps/web/src/app/collections/page.tsx
+++ b/apps/web/src/app/collections/page.tsx
@@ -1,308 +1,58 @@
-'use client';
+import { loadInitialCollections } from '~/lib/discovery/server';
+import type { PublicCollection } from '~/lib/discovery/types';
+import { CollectionsClient } from './CollectionsClient';
 
-import { Badge } from '@tpmjs/ui/Badge/Badge';
-import { EmptyState } from '@tpmjs/ui/EmptyState/EmptyState';
-import { ErrorState } from '@tpmjs/ui/ErrorState/ErrorState';
-import { Icon } from '@tpmjs/ui/Icon/Icon';
-import { Input } from '@tpmjs/ui/Input/Input';
-import { LoadingState } from '@tpmjs/ui/LoadingState/LoadingState';
-import { PageHeader } from '@tpmjs/ui/PageHeader/PageHeader';
-import { Select } from '@tpmjs/ui/Select/Select';
-import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { TableVirtuoso } from 'react-virtuoso';
-import { AppHeader } from '~/components/AppHeader';
-import { CopyDropdown, getCollectionCopyOptions } from '~/components/CopyDropdown';
-import { LikeButton } from '~/components/LikeButton';
-import { trackCollectionMcpCopy } from '~/lib/analytics';
+export const dynamic = 'force-dynamic';
 
-interface PublicCollection {
-  id: string;
-  slug: string;
-  name: string;
-  description: string | null;
-  likeCount: number;
-  forkCount: number;
-  toolCount: number;
-  createdAt: string;
-  createdBy: {
-    id: string;
-    name: string;
-    image: string | null;
-    username: string | null;
+function collectionUrl(collection: PublicCollection): string {
+  return collection.createdBy.username && collection.slug
+    ? `https://tpmjs.com/${collection.createdBy.username}/collections/${collection.slug}`
+    : `https://tpmjs.com/collections/${collection.id}`;
+}
+
+export default async function PublicCollectionsPage(): Promise<React.ReactElement> {
+  let initialCollections: PublicCollection[] = [];
+  let initialHasMore = false;
+  let initialLoadFailed = false;
+
+  try {
+    const initial = await loadInitialCollections();
+    initialCollections = initial.collections;
+    initialHasMore = initial.hasMore;
+  } catch (error) {
+    initialLoadFailed = true;
+    console.error('[Collections] Initial server load failed; client retry enabled:', error);
+  }
+
+  const itemList = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'TPMJS Public Collections',
+    numberOfItems: initialCollections.length,
+    itemListElement: initialCollections.map((collection, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: collectionUrl(collection),
+      name: collection.name,
+      description: collection.description,
+    })),
   };
-}
-
-type SortOption = 'likes' | 'recent' | 'tools';
-
-function sortCollections(collections: PublicCollection[], sortBy: SortOption): PublicCollection[] {
-  return [...collections].sort((a, b) => {
-    switch (sortBy) {
-      case 'likes':
-        return b.likeCount - a.likeCount;
-      case 'recent':
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-      case 'tools':
-        return b.toolCount - a.toolCount;
-      default:
-        return 0;
-    }
-  });
-}
-
-function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text;
-  return `${text.slice(0, maxLength).trim()}...`;
-}
-
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large page component with table rendering
-export default function PublicCollectionsPage(): React.ReactElement {
-  const [collections, setCollections] = useState<PublicCollection[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
-  const [search, setSearch] = useState('');
-  const [sort, setSort] = useState<SortOption>('likes');
-  const loadingMore = useRef(false);
-
-  const fetchCollections = useCallback(
-    async (offset: number, resetList = false) => {
-      try {
-        if (loadingMore.current && !resetList) return;
-        loadingMore.current = true;
-
-        const params = new URLSearchParams({
-          limit: '100',
-          offset: String(offset),
-          sort,
-        });
-
-        const response = await fetch(`/api/public/collections?${params}`);
-        const data = await response.json();
-
-        if (data.success) {
-          if (resetList || offset === 0) {
-            setCollections(data.data);
-          } else {
-            setCollections((prev) => [...prev, ...data.data]);
-          }
-          setHasMore(data.pagination.hasMore);
-        } else {
-          setError(data.error?.message || 'Failed to fetch collections');
-        }
-      } catch (err) {
-        console.error('Failed to fetch collections:', err);
-        setError('Failed to fetch collections');
-      } finally {
-        setIsLoading(false);
-        loadingMore.current = false;
-      }
-    },
-    [sort]
-  );
-
-  useEffect(() => {
-    setIsLoading(true);
-    fetchCollections(0, true);
-  }, [fetchCollections]);
-
-  const loadMore = useCallback(() => {
-    if (!hasMore || loadingMore.current) return;
-    fetchCollections(collections.length);
-  }, [hasMore, collections.length, fetchCollections]);
-
-  // Filter and sort collections
-  const filteredCollections = useMemo(() => {
-    let result = collections;
-
-    if (search) {
-      const query = search.toLowerCase();
-      result = result.filter(
-        (c) => c.name.toLowerCase().includes(query) || c.description?.toLowerCase().includes(query)
-      );
-    }
-
-    return sortCollections(result, sort);
-  }, [collections, search, sort]);
-
-  const TableHeader = useCallback(
-    () => (
-      <tr className="bg-surface-secondary text-left text-xs font-semibold uppercase tracking-wider text-foreground-secondary border-b border-border">
-        <th className="px-4 py-3 w-[250px]">Name</th>
-        <th className="px-4 py-3 w-[250px]">Description</th>
-        <th className="px-4 py-3 w-[80px] text-center">Tools</th>
-        <th className="px-4 py-3 w-[70px] text-center">Forks</th>
-        <th className="px-4 py-3 w-[80px] text-center">Likes</th>
-        <th className="px-4 py-3 w-[150px]">Creator</th>
-        <th className="px-4 py-3 w-[100px] text-right">Copy</th>
-      </tr>
-    ),
-    []
-  );
-
-  const TableRow = useCallback((_index: number, collection: PublicCollection) => {
-    return (
-      <>
-        <td className="px-4 py-3">
-          <Link
-            href={
-              collection.createdBy.username
-                ? `/${collection.createdBy.username}/collections/${collection.slug}`
-                : `/collections/${collection.id}`
-            }
-            className="font-semibold text-foreground hover:text-primary group-hover:text-primary transition-colors"
-          >
-            {collection.name}
-          </Link>
-        </td>
-        <td className="px-4 py-3 text-sm text-foreground-secondary">
-          {collection.description ? truncateText(collection.description, 60) : '—'}
-        </td>
-        <td className="px-4 py-3 text-center">
-          <Badge variant="secondary" size="sm">
-            {collection.toolCount}
-          </Badge>
-        </td>
-        <td className="px-4 py-3 text-center text-sm text-foreground-secondary">
-          {collection.forkCount > 0 ? collection.forkCount : '—'}
-        </td>
-        <td className="px-4 py-3 text-center">
-          <LikeButton
-            entityType="collection"
-            entityId={collection.id}
-            initialCount={collection.likeCount}
-            size="sm"
-            showCount={true}
-          />
-        </td>
-        <td className="px-4 py-3">
-          <div className="flex items-center gap-2">
-            {collection.createdBy.image ? (
-              <img
-                src={collection.createdBy.image}
-                alt={collection.createdBy.name}
-                className="w-5 h-5 rounded-full"
-              />
-            ) : (
-              <div className="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center">
-                <Icon icon="user" size="xs" className="text-primary" />
-              </div>
-            )}
-            <span className="text-sm text-foreground-secondary truncate max-w-[100px]">
-              {collection.createdBy.name}
-            </span>
-          </div>
-        </td>
-        <td className="px-4 py-3 text-right">
-          {collection.createdBy.username && (
-            <CopyDropdown
-              options={getCollectionCopyOptions(
-                collection.createdBy.username,
-                collection.slug,
-                collection.name
-              )}
-              buttonLabel="Copy"
-              onCopy={(option) => {
-                if (option.id) trackCollectionMcpCopy(collection.id, option.id);
-              }}
-            />
-          )}
-        </td>
-      </>
-    );
-  }, []);
 
   return (
-    <div className="min-h-screen bg-background">
-      <AppHeader />
-
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <PageHeader
-          title="Public Collections"
-          description="Discover curated tool collections shared by the community"
+    <>
+      {initialCollections.length > 0 && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(itemList).replace(/</g, '\\u003c'),
+          }}
         />
-
-        {/* Filters */}
-        <div className="flex flex-col sm:flex-row gap-4 mb-6">
-          <div className="flex-1">
-            <Input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search collections..."
-            />
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-foreground-secondary">Sort:</span>
-            <Select
-              value={sort}
-              onChange={(e) => setSort(e.target.value as SortOption)}
-              options={[
-                { value: 'likes', label: 'Most Liked' },
-                { value: 'recent', label: 'Most Recent' },
-                { value: 'tools', label: 'Most Tools' },
-              ]}
-            />
-          </div>
-        </div>
-
-        {/* Content */}
-        {error ? (
-          <ErrorState message={error} onRetry={() => fetchCollections(0, true)} />
-        ) : isLoading ? (
-          <LoadingState message="Loading collections..." size="lg" />
-        ) : filteredCollections.length === 0 ? (
-          <EmptyState
-            icon="folder"
-            title="No collections found"
-            description={
-              search
-                ? 'Try adjusting your search terms'
-                : 'Be the first to share a public collection!'
-            }
-          />
-        ) : (
-          <>
-            <div className="border border-border rounded-lg overflow-hidden">
-              <TableVirtuoso
-                style={{ height: 'calc(100vh - 350px)', minHeight: '400px' }}
-                data={filteredCollections}
-                overscan={30}
-                endReached={loadMore}
-                fixedHeaderContent={TableHeader}
-                itemContent={TableRow}
-                components={{
-                  Table: (props) => (
-                    <table
-                      {...props}
-                      className="w-full border-collapse text-sm"
-                      style={{ tableLayout: 'fixed' }}
-                    />
-                  ),
-                  TableHead: (props) => (
-                    <thead {...props} className="bg-surface-secondary sticky top-0 z-10" />
-                  ),
-                  TableBody: (props) => <tbody {...props} />,
-                  TableRow: (props) => (
-                    <tr
-                      {...props}
-                      className="border-b border-border bg-surface hover:bg-surface-secondary transition-all duration-150 group"
-                    />
-                  ),
-                }}
-              />
-            </div>
-
-            <div className="mt-4 text-sm text-foreground-tertiary">
-              Showing {filteredCollections.length} collection
-              {filteredCollections.length !== 1 ? 's' : ''}
-              {search && ` matching "${search}"`}
-              {hasMore && ' (scroll for more)'}
-            </div>
-          </>
-        )}
-      </main>
-    </div>
+      )}
+      <CollectionsClient
+        initialCollections={initialCollections}
+        initialHasMore={initialHasMore}
+        initialLoadFailed={initialLoadFailed}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/tool/tool-search/ToolSearchClient.tsx
+++ b/apps/web/src/app/tool/tool-search/ToolSearchClient.tsx
@@ -12,15 +12,7 @@ import { LoadingState } from '@tpmjs/ui/LoadingState/LoadingState';
 import { PageHeader } from '@tpmjs/ui/PageHeader/PageHeader';
 import { Select } from '@tpmjs/ui/Select/Select';
 import Link from 'next/link';
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from 'react';
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { TableVirtuoso } from 'react-virtuoso';
 import { AppHeader } from '~/components/AppHeader';
 import { CopyButton } from '~/components/CopyButton';
@@ -96,12 +88,6 @@ export function ToolSearchClient({
   const [healthFilter, setHealthFilter] = useState('all');
   const [sortBy, setSortBy] = useState<SortOption>('downloads');
   const [packageManager, setPackageManager] = usePackageManager();
-  // Keep a ref so TableRow callback stays stable and doesn't cause react-virtuoso
-  // to reconcile DOM nodes mid-render (which triggers null.removeChild errors).
-  const packageManagerRef = useRef(packageManager);
-  useLayoutEffect(() => {
-    packageManagerRef.current = packageManager;
-  });
 
   const hasDefaultFilters = categoryFilter === 'all' && healthFilter === 'all';
 
@@ -197,57 +183,57 @@ export function ToolSearchClient({
     []
   );
 
-  const TableRow = useCallback((_index: number, tool: Tool) => {
-    const isBroken = tool.importHealth === 'BROKEN' || tool.executionHealth === 'BROKEN';
-    const displayName = tool.name !== 'default' ? tool.name : tool.package.npmPackageName;
-    const installCommand = getInstallCommand(
-      tool.package.npmPackageName,
-      packageManagerRef.current
-    );
+  const TableRow = useCallback(
+    (_index: number, tool: Tool) => {
+      const isBroken = tool.importHealth === 'BROKEN' || tool.executionHealth === 'BROKEN';
+      const displayName = tool.name !== 'default' ? tool.name : tool.package.npmPackageName;
+      const installCommand = getInstallCommand(tool.package.npmPackageName, packageManager);
 
-    return (
-      <>
-        <td className="px-4 py-3">
-          <Link href={`/tool/${tool.package.npmPackageName}/${tool.name}`} className="block">
-            <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
-              {displayName}
-              {isBroken && (
-                <Badge variant="error" size="sm" className="ml-2">
-                  Broken
-                </Badge>
-              )}
-            </div>
-            <div className="text-xs text-foreground-tertiary truncate max-w-[230px]">
-              {tool.package.npmPackageName}
-            </div>
-          </Link>
-        </td>
-        <td className="px-4 py-3 text-sm text-foreground-secondary">
-          {tool.description ? truncateText(tool.description, 60) : '—'}
-        </td>
-        <td className="px-4 py-3">
-          <Badge variant="secondary" size="sm">
-            {tool.package.category}
-          </Badge>
-        </td>
-        <td className="px-4 py-3 text-right text-sm text-foreground-secondary tabular-nums">
-          {formatDownloads(tool.package.npmDownloadsLastMonth ?? 0)}
-        </td>
-        <td className="px-4 py-3 text-right">
-          <LikeButton
-            entityType="tool"
-            entityId={tool.id}
-            initialCount={tool.likeCount ?? 0}
-            size="sm"
-            showCount={true}
-          />
-        </td>
-        <td className="px-4 py-3 text-right">
-          <CopyButton text={installCommand} label="Copy" size="xs" />
-        </td>
-      </>
-    );
-  }, []);
+      return (
+        <>
+          <td className="px-4 py-3">
+            <Link href={`/tool/${tool.package.npmPackageName}/${tool.name}`} className="block">
+              <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+                {displayName}
+                {isBroken && (
+                  <Badge variant="error" size="sm" className="ml-2">
+                    Broken
+                  </Badge>
+                )}
+              </div>
+              <div className="text-xs text-foreground-tertiary truncate max-w-[230px]">
+                {tool.package.npmPackageName}
+              </div>
+            </Link>
+          </td>
+          <td className="px-4 py-3 text-sm text-foreground-secondary">
+            {tool.description ? truncateText(tool.description, 60) : '—'}
+          </td>
+          <td className="px-4 py-3">
+            <Badge variant="secondary" size="sm">
+              {tool.package.category}
+            </Badge>
+          </td>
+          <td className="px-4 py-3 text-right text-sm text-foreground-secondary tabular-nums">
+            {formatDownloads(tool.package.npmDownloadsLastMonth ?? 0)}
+          </td>
+          <td className="px-4 py-3 text-right">
+            <LikeButton
+              entityType="tool"
+              entityId={tool.id}
+              initialCount={tool.likeCount ?? 0}
+              size="sm"
+              showCount={true}
+            />
+          </td>
+          <td className="px-4 py-3 text-right">
+            <CopyButton text={installCommand} label="Copy" size="xs" />
+          </td>
+        </>
+      );
+    },
+    [packageManager]
+  );
 
   return (
     <div className="min-h-screen bg-background">
@@ -358,6 +344,9 @@ export function ToolSearchClient({
           <div className="border border-border rounded-lg overflow-hidden">
             {isHydrated ? (
               <TableVirtuoso
+                // Remount when install syntax changes. This keeps Virtuoso from
+                // reconciling table cells while its item renderer is changing.
+                key={packageManager}
                 style={{ height: 'calc(100vh - 400px)', minHeight: '400px' }}
                 data={filteredTools}
                 overscan={50}

--- a/apps/web/src/app/tool/tool-search/ToolSearchClient.tsx
+++ b/apps/web/src/app/tool/tool-search/ToolSearchClient.tsx
@@ -1,0 +1,481 @@
+'use client';
+
+import { Badge } from '@tpmjs/ui/Badge/Badge';
+import { Button } from '@tpmjs/ui/Button/Button';
+import { Card, CardContent } from '@tpmjs/ui/Card/Card';
+import { Container } from '@tpmjs/ui/Container/Container';
+import { EmptyState } from '@tpmjs/ui/EmptyState/EmptyState';
+import { ErrorState } from '@tpmjs/ui/ErrorState/ErrorState';
+import { Icon } from '@tpmjs/ui/Icon/Icon';
+import { Input } from '@tpmjs/ui/Input/Input';
+import { LoadingState } from '@tpmjs/ui/LoadingState/LoadingState';
+import { PageHeader } from '@tpmjs/ui/PageHeader/PageHeader';
+import { Select } from '@tpmjs/ui/Select/Select';
+import Link from 'next/link';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { TableVirtuoso } from 'react-virtuoso';
+import { AppHeader } from '~/components/AppHeader';
+import { CopyButton } from '~/components/CopyButton';
+import { LikeButton } from '~/components/LikeButton';
+import {
+  getInstallCommand,
+  PackageManagerSelector,
+  usePackageManager,
+} from '~/components/PackageManagerSelector';
+import { type Tool, useTools } from '~/hooks/useTools';
+import { trackEvent } from '~/lib/analytics';
+
+type SortOption = 'downloads' | 'likes' | 'recent' | 'name';
+
+function formatDownloads(count: number): string {
+  if (count >= 1000000) return `${(count / 1000000).toFixed(1)}M`;
+  if (count >= 1000) return `${(count / 1000).toFixed(1)}k`;
+  return count.toString();
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength).trim()}...`;
+}
+
+function subscribeToHydration(): () => void {
+  return () => undefined;
+}
+
+function useIsHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribeToHydration,
+    () => true,
+    () => false
+  );
+}
+
+function isBroken(tool: Tool): boolean {
+  return tool.importHealth === 'BROKEN' || tool.executionHealth === 'BROKEN';
+}
+
+const toolComparators: Record<SortOption, (a: Tool, b: Tool) => number> = {
+  downloads: (a, b) =>
+    (b.package.npmDownloadsLastMonth ?? 0) - (a.package.npmDownloadsLastMonth ?? 0),
+  likes: (a, b) => (b.likeCount ?? 0) - (a.likeCount ?? 0),
+  recent: (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  name: (a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+};
+
+/** Sort tools by criterion, pushing broken tools to the bottom */
+function sortTools(tools: Tool[], sortBy: SortOption): Tool[] {
+  return [...tools].sort((a, b) => {
+    const brokenOrder = Number(isBroken(a)) - Number(isBroken(b));
+    return brokenOrder || toolComparators[sortBy](a, b);
+  });
+}
+
+interface ToolSearchClientProps {
+  initialTools: Tool[];
+  initialQuery: string;
+  initialLoadFailed: boolean;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: cohesive interactive registry state and rendering
+export function ToolSearchClient({
+  initialTools,
+  initialQuery,
+  initialLoadFailed,
+}: ToolSearchClientProps): React.ReactElement {
+  const isHydrated = useIsHydrated();
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
+  const [categoryFilter, setCategoryFilter] = useState('all');
+  const [healthFilter, setHealthFilter] = useState('all');
+  const [sortBy, setSortBy] = useState<SortOption>('downloads');
+  const [packageManager, setPackageManager] = usePackageManager();
+  // Keep a ref so TableRow callback stays stable and doesn't cause react-virtuoso
+  // to reconcile DOM nodes mid-render (which triggers null.removeChild errors).
+  const packageManagerRef = useRef(packageManager);
+  useLayoutEffect(() => {
+    packageManagerRef.current = packageManager;
+  });
+
+  const hasDefaultFilters = categoryFilter === 'all' && healthFilter === 'all';
+
+  // The bounded server result makes the first response useful. SWR then
+  // refreshes it with the full registry and remains the source for filters.
+  const {
+    data: tools = [],
+    isLoading: swrLoading,
+    error: swrError,
+  } = useTools(
+    {
+      category: categoryFilter !== 'all' ? categoryFilter : undefined,
+      importHealth: healthFilter === 'healthy' ? 'HEALTHY' : undefined,
+      executionHealth: healthFilter === 'healthy' ? 'HEALTHY' : undefined,
+      broken: healthFilter === 'broken' ? true : undefined,
+    },
+    {
+      fallbackData: hasDefaultFilters && !initialLoadFailed ? initialTools : undefined,
+    }
+  );
+
+  // SWR intentionally reports fallbackData as loading until its first request
+  // finishes. The server result is already renderable, so only show the shell
+  // when neither source has any data.
+  const loading = swrLoading && tools.length === 0;
+  const error = swrError?.message ?? null;
+
+  // Extract unique categories from all tools
+  const availableCategories = useMemo(() => {
+    const categories = new Set<string>();
+    for (const tool of tools) {
+      if (tool.package.category) {
+        categories.add(tool.package.category);
+      }
+    }
+    return Array.from(categories).sort();
+  }, [tools]);
+
+  // Filter and sort tools
+  const filteredTools = useMemo(() => {
+    let result = tools;
+
+    // Apply search filter
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      result = result.filter(
+        (tool: Tool) =>
+          tool.name.toLowerCase().includes(query) ||
+          tool.package.npmPackageName.toLowerCase().includes(query) ||
+          tool.description.toLowerCase().includes(query)
+      );
+    }
+
+    // Sort tools
+    return sortTools(result, sortBy);
+  }, [tools, searchQuery, sortBy]);
+
+  // Activation-funnel analytics: a search was performed (debounced so we count
+  // intent, not keystrokes). Records the query and how many tools matched.
+  useEffect(() => {
+    const q = searchQuery.trim();
+    if (q.length < 2) return;
+    const timer = setTimeout(() => {
+      trackEvent('tool_search', { query: q, results: filteredTools.length });
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [searchQuery, filteredTools.length]);
+
+  // Keep the documented shareable-search contract in sync without triggering
+  // a second server navigation for each keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const url = new URL(window.location.href);
+      const query = searchQuery.trim();
+      if (query) url.searchParams.set('q', query);
+      else url.searchParams.delete('q');
+      window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  const TableHeader = useCallback(
+    () => (
+      <tr className="bg-surface-secondary text-left text-xs font-semibold uppercase tracking-wider text-foreground-secondary border-b border-border">
+        <th className="px-4 py-3 w-[250px]">Name</th>
+        <th className="px-4 py-3 w-[300px]">Description</th>
+        <th className="px-4 py-3 w-[100px]">Category</th>
+        <th className="px-4 py-3 w-[80px] text-right">Downloads</th>
+        <th className="px-4 py-3 w-[60px] text-right">Likes</th>
+        <th className="px-4 py-3 w-[100px] text-right">Install</th>
+      </tr>
+    ),
+    []
+  );
+
+  const TableRow = useCallback((_index: number, tool: Tool) => {
+    const isBroken = tool.importHealth === 'BROKEN' || tool.executionHealth === 'BROKEN';
+    const displayName = tool.name !== 'default' ? tool.name : tool.package.npmPackageName;
+    const installCommand = getInstallCommand(
+      tool.package.npmPackageName,
+      packageManagerRef.current
+    );
+
+    return (
+      <>
+        <td className="px-4 py-3">
+          <Link href={`/tool/${tool.package.npmPackageName}/${tool.name}`} className="block">
+            <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+              {displayName}
+              {isBroken && (
+                <Badge variant="error" size="sm" className="ml-2">
+                  Broken
+                </Badge>
+              )}
+            </div>
+            <div className="text-xs text-foreground-tertiary truncate max-w-[230px]">
+              {tool.package.npmPackageName}
+            </div>
+          </Link>
+        </td>
+        <td className="px-4 py-3 text-sm text-foreground-secondary">
+          {tool.description ? truncateText(tool.description, 60) : '—'}
+        </td>
+        <td className="px-4 py-3">
+          <Badge variant="secondary" size="sm">
+            {tool.package.category}
+          </Badge>
+        </td>
+        <td className="px-4 py-3 text-right text-sm text-foreground-secondary tabular-nums">
+          {formatDownloads(tool.package.npmDownloadsLastMonth ?? 0)}
+        </td>
+        <td className="px-4 py-3 text-right">
+          <LikeButton
+            entityType="tool"
+            entityId={tool.id}
+            initialCount={tool.likeCount ?? 0}
+            size="sm"
+            showCount={true}
+          />
+        </td>
+        <td className="px-4 py-3 text-right">
+          <CopyButton text={installCommand} label="Copy" size="xs" />
+        </td>
+      </>
+    );
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader />
+
+      <Container size="xl" padding="md" className="py-8">
+        <PageHeader
+          title="Tool Registry"
+          description="Search npm packages indexed as AI agent tools. Filter by category, health status, or keyword."
+          size="lg"
+        />
+
+        {/* Search and filters section */}
+        <div className="space-y-4 mb-6">
+          {/* Search input */}
+          <Input
+            placeholder="Search tools..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+
+          {/* Filter row */}
+          <div className="flex flex-col sm:flex-row flex-wrap gap-3 sm:gap-4 items-start sm:items-center">
+            {/* Category filter */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-foreground-secondary whitespace-nowrap">
+                Category:
+              </span>
+              <Select
+                value={categoryFilter}
+                onChange={(e) => setCategoryFilter(e.target.value)}
+                size="sm"
+                className="min-w-[150px]"
+                options={[
+                  { value: 'all', label: 'All Categories' },
+                  ...availableCategories.map((cat) => ({
+                    value: cat,
+                    label: cat.charAt(0).toUpperCase() + cat.slice(1),
+                  })),
+                ]}
+              />
+            </div>
+
+            {/* Health filter */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-foreground-secondary whitespace-nowrap">
+                Health:
+              </span>
+              <Select
+                value={healthFilter}
+                onChange={(e) => setHealthFilter(e.target.value)}
+                size="sm"
+                className="min-w-[130px]"
+                options={[
+                  { value: 'all', label: 'All Tools' },
+                  { value: 'healthy', label: 'Healthy Only' },
+                  { value: 'broken', label: 'Broken Only' },
+                ]}
+              />
+            </div>
+
+            {/* Sort dropdown */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-foreground-secondary whitespace-nowrap">
+                Sort:
+              </span>
+              <Select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as SortOption)}
+                size="sm"
+                className="min-w-[150px]"
+                options={[
+                  { value: 'downloads', label: 'Downloads' },
+                  { value: 'likes', label: 'Likes' },
+                  { value: 'recent', label: 'Recent' },
+                  { value: 'name', label: 'Name (A-Z)' },
+                ]}
+              />
+            </div>
+
+            {/* Clear filters button */}
+            {(categoryFilter !== 'all' || healthFilter !== 'all') && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setCategoryFilter('all');
+                  setHealthFilter('all');
+                }}
+              >
+                Clear Filters
+              </Button>
+            )}
+          </div>
+
+          {/* Package manager selector */}
+          <PackageManagerSelector value={packageManager} onChange={setPackageManager} />
+        </div>
+
+        {/* Loading state */}
+        {loading && <LoadingState message="Loading tools..." size="lg" />}
+
+        {/* Error state */}
+        {error && <ErrorState message={error} />}
+
+        {/* Tool table */}
+        {!loading && !error && filteredTools.length > 0 && (
+          <div className="border border-border rounded-lg overflow-hidden">
+            {isHydrated ? (
+              <TableVirtuoso
+                style={{ height: 'calc(100vh - 400px)', minHeight: '400px' }}
+                data={filteredTools}
+                overscan={50}
+                fixedHeaderContent={TableHeader}
+                itemContent={TableRow}
+                components={{
+                  Table: (props) => (
+                    <table
+                      {...props}
+                      className="w-full border-collapse text-sm"
+                      style={{ tableLayout: 'fixed' }}
+                    />
+                  ),
+                  TableHead: (props) => (
+                    <thead {...props} className="bg-surface-secondary sticky top-0 z-10" />
+                  ),
+                  TableBody: (props) => <tbody {...props} />,
+                  TableRow: (props) => (
+                    <tr
+                      {...props}
+                      className="border-b border-border bg-surface hover:bg-surface-secondary transition-all duration-150 group"
+                    />
+                  ),
+                }}
+              />
+            ) : (
+              <table className="w-full border-collapse text-sm" style={{ tableLayout: 'fixed' }}>
+                <thead className="bg-surface-secondary">{TableHeader()}</thead>
+                <tbody>
+                  {filteredTools.slice(0, 20).map((tool, index) => (
+                    <tr
+                      key={tool.id}
+                      className="border-b border-border bg-surface hover:bg-surface-secondary transition-all duration-150 group"
+                    >
+                      {TableRow(index, tool)}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+
+        {/* Results count */}
+        {!loading && !error && filteredTools.length > 0 && (
+          <div className="mt-4 text-sm text-foreground-tertiary">
+            Showing {filteredTools.length} tool{filteredTools.length !== 1 ? 's' : ''}
+            {searchQuery && ` matching "${searchQuery}"`}
+          </div>
+        )}
+
+        {/* Empty States */}
+        {!loading && !error && filteredTools.length === 0 && (
+          <Card className="max-w-2xl mx-auto">
+            <CardContent className="pt-6 pb-6">
+              {searchQuery ? (
+                <EmptyState
+                  icon="search"
+                  title={`No tools found matching "${searchQuery}"`}
+                  description="Try adjusting your search terms or filters."
+                  action={
+                    <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                      <Button variant="default" onClick={() => setSearchQuery('')}>
+                        Clear Search
+                      </Button>
+                      {(categoryFilter !== 'all' || healthFilter !== 'all') && (
+                        <Button
+                          variant="outline"
+                          onClick={() => {
+                            setCategoryFilter('all');
+                            setHealthFilter('all');
+                          }}
+                        >
+                          Clear All Filters
+                        </Button>
+                      )}
+                    </div>
+                  }
+                />
+              ) : categoryFilter !== 'all' || healthFilter !== 'all' ? (
+                <EmptyState
+                  icon="search"
+                  title="No tools match your filters"
+                  description="Try adjusting or clearing your filters to see more tools."
+                  action={
+                    <Button
+                      variant="default"
+                      onClick={() => {
+                        setCategoryFilter('all');
+                        setHealthFilter('all');
+                      }}
+                    >
+                      Clear All Filters
+                    </Button>
+                  }
+                />
+              ) : (
+                <EmptyState
+                  icon="puzzle"
+                  title="No tools yet"
+                  description="Be the first to publish a tool and help AI agents gain new capabilities."
+                  action={
+                    <Button
+                      variant="default"
+                      onClick={() =>
+                        window.open('https://github.com/tpmjs/tpmjs', '_blank', 'noopener')
+                      }
+                    >
+                      <Icon icon="github" size="sm" className="mr-2" />
+                      View Documentation
+                    </Button>
+                  }
+                />
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </Container>
+    </div>
+  );
+}

--- a/apps/web/src/app/tool/tool-search/layout.tsx
+++ b/apps/web/src/app/tool/tool-search/layout.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Tool Search | TPMJS',
+  title: 'Tool Search',
   description:
     'Search and discover AI tools from the TPMJS registry. Browse by category, sort by downloads or recency.',
+  alternates: { canonical: '/tool/tool-search' },
+  robots: { index: true, follow: true },
   openGraph: {
     title: 'Tool Search | TPMJS',
     description:

--- a/apps/web/src/app/tool/tool-search/page.tsx
+++ b/apps/web/src/app/tool/tool-search/page.tsx
@@ -1,425 +1,65 @@
-'use client';
+import { loadInitialTools } from '~/lib/discovery/server';
+import type { DiscoveryTool } from '~/lib/discovery/types';
+import { ToolSearchClient } from './ToolSearchClient';
 
-import { Badge } from '@tpmjs/ui/Badge/Badge';
-import { Button } from '@tpmjs/ui/Button/Button';
-import { Card, CardContent } from '@tpmjs/ui/Card/Card';
-import { Container } from '@tpmjs/ui/Container/Container';
-import { EmptyState } from '@tpmjs/ui/EmptyState/EmptyState';
-import { ErrorState } from '@tpmjs/ui/ErrorState/ErrorState';
-import { Icon } from '@tpmjs/ui/Icon/Icon';
-import { Input } from '@tpmjs/ui/Input/Input';
-import { LoadingState } from '@tpmjs/ui/LoadingState/LoadingState';
-import { PageHeader } from '@tpmjs/ui/PageHeader/PageHeader';
-import { Select } from '@tpmjs/ui/Select/Select';
-import Link from 'next/link';
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { TableVirtuoso } from 'react-virtuoso';
-import { AppHeader } from '~/components/AppHeader';
-import { CopyButton } from '~/components/CopyButton';
-import { LikeButton } from '~/components/LikeButton';
-import {
-  getInstallCommand,
-  PackageManagerSelector,
-  usePackageManager,
-} from '~/components/PackageManagerSelector';
-import { type Tool, useTools } from '~/hooks/useTools';
-import { trackEvent } from '~/lib/analytics';
+export const dynamic = 'force-dynamic';
 
-type SortOption = 'downloads' | 'likes' | 'recent' | 'name';
-
-function formatDownloads(count: number): string {
-  if (count >= 1000000) return `${(count / 1000000).toFixed(1)}M`;
-  if (count >= 1000) return `${(count / 1000).toFixed(1)}k`;
-  return count.toString();
+interface ToolSearchPageProps {
+  searchParams: Promise<{ q?: string | string[] }>;
 }
 
-function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text;
-  return `${text.slice(0, maxLength).trim()}...`;
+function firstQueryValue(value: string | string[] | undefined): string {
+  const query = Array.isArray(value) ? value[0] : value;
+  return query?.trim().slice(0, 200) ?? '';
 }
 
-/** Sort tools by criterion, pushing broken tools to the bottom */
-function sortTools(tools: Tool[], sortBy: SortOption): Tool[] {
-  return [...tools].sort((a, b) => {
-    const aIsBroken = a.importHealth === 'BROKEN' || a.executionHealth === 'BROKEN';
-    const bIsBroken = b.importHealth === 'BROKEN' || b.executionHealth === 'BROKEN';
-    // Always push broken tools to bottom
-    if (aIsBroken && !bIsBroken) return 1;
-    if (!aIsBroken && bIsBroken) return -1;
-
-    // Within same broken status, sort by selected criterion
-    switch (sortBy) {
-      case 'downloads': {
-        const aDownloads = a.package.npmDownloadsLastMonth ?? 0;
-        const bDownloads = b.package.npmDownloadsLastMonth ?? 0;
-        return bDownloads - aDownloads;
-      }
-      case 'likes': {
-        const aLikes = a.likeCount ?? 0;
-        const bLikes = b.likeCount ?? 0;
-        return bLikes - aLikes;
-      }
-      case 'recent': {
-        const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-        const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-        return bTime - aTime;
-      }
-      case 'name': {
-        const aName = a.name.toLowerCase();
-        const bName = b.name.toLowerCase();
-        return aName.localeCompare(bName);
-      }
-      default:
-        return 0;
-    }
-  });
+function toolUrl(tool: DiscoveryTool): string {
+  return `https://tpmjs.com/tool/${tool.package.npmPackageName}/${tool.name}`;
 }
 
-export default function ToolSearchPage(): React.ReactElement {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState('all');
-  const [healthFilter, setHealthFilter] = useState('all');
-  const [sortBy, setSortBy] = useState<SortOption>('downloads');
-  const [packageManager, setPackageManager] = usePackageManager();
-  // Keep a ref so TableRow callback stays stable and doesn't cause react-virtuoso
-  // to reconcile DOM nodes mid-render (which triggers null.removeChild errors).
-  const packageManagerRef = useRef(packageManager);
-  useLayoutEffect(() => {
-    packageManagerRef.current = packageManager;
-  });
+export default async function ToolSearchPage({
+  searchParams,
+}: ToolSearchPageProps): Promise<React.ReactElement> {
+  const initialQuery = firstQueryValue((await searchParams).q);
+  let initialTools: DiscoveryTool[] = [];
+  let initialLoadFailed = false;
 
-  // Fetch tools from API using SWR
-  const {
-    data: tools = [],
-    isLoading: loading,
-    error: swrError,
-  } = useTools({
-    category: categoryFilter !== 'all' ? categoryFilter : undefined,
-    importHealth: healthFilter === 'healthy' ? 'HEALTHY' : undefined,
-    executionHealth: healthFilter === 'healthy' ? 'HEALTHY' : undefined,
-    broken: healthFilter === 'broken' ? true : undefined,
-  });
+  try {
+    initialTools = await loadInitialTools(initialQuery);
+  } catch (error) {
+    initialLoadFailed = true;
+    console.error('[Tool Search] Initial server load failed; client retry enabled:', error);
+  }
 
-  const error = swrError?.message ?? null;
-
-  // Extract unique categories from all tools
-  const availableCategories = useMemo(() => {
-    const categories = new Set<string>();
-    for (const tool of tools) {
-      if (tool.package.category) {
-        categories.add(tool.package.category);
-      }
-    }
-    return Array.from(categories).sort();
-  }, [tools]);
-
-  // Filter and sort tools
-  const filteredTools = useMemo(() => {
-    let result = tools;
-
-    // Apply search filter
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      result = result.filter(
-        (tool: Tool) =>
-          tool.name.toLowerCase().includes(query) ||
-          tool.package.npmPackageName.toLowerCase().includes(query) ||
-          tool.description.toLowerCase().includes(query)
-      );
-    }
-
-    // Sort tools
-    return sortTools(result, sortBy);
-  }, [tools, searchQuery, sortBy]);
-
-  // Activation-funnel analytics: a search was performed (debounced so we count
-  // intent, not keystrokes). Records the query and how many tools matched.
-  useEffect(() => {
-    const q = searchQuery.trim();
-    if (q.length < 2) return;
-    const timer = setTimeout(() => {
-      trackEvent('tool_search', { query: q, results: filteredTools.length });
-    }, 600);
-    return () => clearTimeout(timer);
-  }, [searchQuery, filteredTools.length]);
-
-  const TableHeader = useCallback(
-    () => (
-      <tr className="bg-surface-secondary text-left text-xs font-semibold uppercase tracking-wider text-foreground-secondary border-b border-border">
-        <th className="px-4 py-3 w-[250px]">Name</th>
-        <th className="px-4 py-3 w-[300px]">Description</th>
-        <th className="px-4 py-3 w-[100px]">Category</th>
-        <th className="px-4 py-3 w-[80px] text-right">Downloads</th>
-        <th className="px-4 py-3 w-[60px] text-right">Likes</th>
-        <th className="px-4 py-3 w-[100px] text-right">Install</th>
-      </tr>
-    ),
-    []
-  );
-
-  const TableRow = useCallback((_index: number, tool: Tool) => {
-    const isBroken = tool.importHealth === 'BROKEN' || tool.executionHealth === 'BROKEN';
-    const displayName = tool.name !== 'default' ? tool.name : tool.package.npmPackageName;
-    const installCommand = getInstallCommand(
-      tool.package.npmPackageName,
-      packageManagerRef.current
-    );
-
-    return (
-      <>
-        <td className="px-4 py-3">
-          <Link href={`/tool/${tool.package.npmPackageName}/${tool.name}`} className="block">
-            <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
-              {displayName}
-              {isBroken && (
-                <Badge variant="error" size="sm" className="ml-2">
-                  Broken
-                </Badge>
-              )}
-            </div>
-            <div className="text-xs text-foreground-tertiary truncate max-w-[230px]">
-              {tool.package.npmPackageName}
-            </div>
-          </Link>
-        </td>
-        <td className="px-4 py-3 text-sm text-foreground-secondary">
-          {tool.description ? truncateText(tool.description, 60) : '—'}
-        </td>
-        <td className="px-4 py-3">
-          <Badge variant="secondary" size="sm">
-            {tool.package.category}
-          </Badge>
-        </td>
-        <td className="px-4 py-3 text-right text-sm text-foreground-secondary tabular-nums">
-          {formatDownloads(tool.package.npmDownloadsLastMonth ?? 0)}
-        </td>
-        <td className="px-4 py-3 text-right">
-          <LikeButton
-            entityType="tool"
-            entityId={tool.id}
-            initialCount={tool.likeCount ?? 0}
-            size="sm"
-            showCount={true}
-          />
-        </td>
-        <td className="px-4 py-3 text-right">
-          <CopyButton text={installCommand} label="Copy" size="xs" />
-        </td>
-      </>
-    );
-  }, []);
+  const itemList = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: initialQuery ? `TPMJS tools matching ${initialQuery}` : 'TPMJS Tool Registry',
+    numberOfItems: initialTools.length,
+    itemListElement: initialTools.map((tool, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: toolUrl(tool),
+      name: tool.name,
+      description: tool.description,
+    })),
+  };
 
   return (
-    <div className="min-h-screen bg-background">
-      <AppHeader />
-
-      <Container size="xl" padding="md" className="py-8">
-        <PageHeader
-          title="Tool Registry"
-          description="Search npm packages indexed as AI agent tools. Filter by category, health status, or keyword."
-          size="lg"
+    <>
+      {initialTools.length > 0 && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(itemList).replace(/</g, '\\u003c'),
+          }}
         />
-
-        {/* Search and filters section */}
-        <div className="space-y-4 mb-6">
-          {/* Search input */}
-          <Input
-            placeholder="Search tools..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-
-          {/* Filter row */}
-          <div className="flex flex-col sm:flex-row flex-wrap gap-3 sm:gap-4 items-start sm:items-center">
-            {/* Category filter */}
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-foreground-secondary whitespace-nowrap">
-                Category:
-              </span>
-              <Select
-                value={categoryFilter}
-                onChange={(e) => setCategoryFilter(e.target.value)}
-                size="sm"
-                className="min-w-[150px]"
-                options={[
-                  { value: 'all', label: 'All Categories' },
-                  ...availableCategories.map((cat) => ({
-                    value: cat,
-                    label: cat.charAt(0).toUpperCase() + cat.slice(1),
-                  })),
-                ]}
-              />
-            </div>
-
-            {/* Health filter */}
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-foreground-secondary whitespace-nowrap">
-                Health:
-              </span>
-              <Select
-                value={healthFilter}
-                onChange={(e) => setHealthFilter(e.target.value)}
-                size="sm"
-                className="min-w-[130px]"
-                options={[
-                  { value: 'all', label: 'All Tools' },
-                  { value: 'healthy', label: 'Healthy Only' },
-                  { value: 'broken', label: 'Broken Only' },
-                ]}
-              />
-            </div>
-
-            {/* Sort dropdown */}
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-foreground-secondary whitespace-nowrap">
-                Sort:
-              </span>
-              <Select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as SortOption)}
-                size="sm"
-                className="min-w-[150px]"
-                options={[
-                  { value: 'downloads', label: 'Downloads' },
-                  { value: 'likes', label: 'Likes' },
-                  { value: 'recent', label: 'Recent' },
-                  { value: 'name', label: 'Name (A-Z)' },
-                ]}
-              />
-            </div>
-
-            {/* Clear filters button */}
-            {(categoryFilter !== 'all' || healthFilter !== 'all') && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setCategoryFilter('all');
-                  setHealthFilter('all');
-                }}
-              >
-                Clear Filters
-              </Button>
-            )}
-          </div>
-
-          {/* Package manager selector */}
-          <PackageManagerSelector value={packageManager} onChange={setPackageManager} />
-        </div>
-
-        {/* Loading state */}
-        {loading && <LoadingState message="Loading tools..." size="lg" />}
-
-        {/* Error state */}
-        {error && <ErrorState message={error} />}
-
-        {/* Tool table */}
-        {!loading && !error && filteredTools.length > 0 && (
-          <div className="border border-border rounded-lg overflow-hidden">
-            <TableVirtuoso
-              style={{ height: 'calc(100vh - 400px)', minHeight: '400px' }}
-              data={filteredTools}
-              overscan={50}
-              fixedHeaderContent={TableHeader}
-              itemContent={TableRow}
-              components={{
-                Table: (props) => (
-                  <table
-                    {...props}
-                    className="w-full border-collapse text-sm"
-                    style={{ tableLayout: 'fixed' }}
-                  />
-                ),
-                TableHead: (props) => (
-                  <thead {...props} className="bg-surface-secondary sticky top-0 z-10" />
-                ),
-                TableBody: (props) => <tbody {...props} />,
-                TableRow: (props) => (
-                  <tr
-                    {...props}
-                    className="border-b border-border bg-surface hover:bg-surface-secondary transition-all duration-150 group"
-                  />
-                ),
-              }}
-            />
-          </div>
-        )}
-
-        {/* Results count */}
-        {!loading && !error && filteredTools.length > 0 && (
-          <div className="mt-4 text-sm text-foreground-tertiary">
-            Showing {filteredTools.length} tool{filteredTools.length !== 1 ? 's' : ''}
-            {searchQuery && ` matching "${searchQuery}"`}
-          </div>
-        )}
-
-        {/* Empty States */}
-        {!loading && !error && filteredTools.length === 0 && (
-          <Card className="max-w-2xl mx-auto">
-            <CardContent className="pt-6 pb-6">
-              {searchQuery ? (
-                <EmptyState
-                  icon="search"
-                  title={`No tools found matching "${searchQuery}"`}
-                  description="Try adjusting your search terms or filters."
-                  action={
-                    <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                      <Button variant="default" onClick={() => setSearchQuery('')}>
-                        Clear Search
-                      </Button>
-                      {(categoryFilter !== 'all' || healthFilter !== 'all') && (
-                        <Button
-                          variant="outline"
-                          onClick={() => {
-                            setCategoryFilter('all');
-                            setHealthFilter('all');
-                          }}
-                        >
-                          Clear All Filters
-                        </Button>
-                      )}
-                    </div>
-                  }
-                />
-              ) : categoryFilter !== 'all' || healthFilter !== 'all' ? (
-                <EmptyState
-                  icon="search"
-                  title="No tools match your filters"
-                  description="Try adjusting or clearing your filters to see more tools."
-                  action={
-                    <Button
-                      variant="default"
-                      onClick={() => {
-                        setCategoryFilter('all');
-                        setHealthFilter('all');
-                      }}
-                    >
-                      Clear All Filters
-                    </Button>
-                  }
-                />
-              ) : (
-                <EmptyState
-                  icon="puzzle"
-                  title="No tools yet"
-                  description="Be the first to publish a tool and help AI agents gain new capabilities."
-                  action={
-                    <Button
-                      variant="default"
-                      onClick={() =>
-                        window.open('https://github.com/tpmjs/tpmjs', '_blank', 'noopener')
-                      }
-                    >
-                      <Icon icon="github" size="sm" className="mr-2" />
-                      View Documentation
-                    </Button>
-                  }
-                />
-              )}
-            </CardContent>
-          </Card>
-        )}
-      </Container>
-    </div>
+      )}
+      <ToolSearchClient
+        initialTools={initialTools}
+        initialQuery={initialQuery}
+        initialLoadFailed={initialLoadFailed}
+      />
+    </>
   );
 }

--- a/apps/web/src/hooks/useTools.ts
+++ b/apps/web/src/hooks/useTools.ts
@@ -1,24 +1,7 @@
 import useSWR from 'swr';
+import type { DiscoveryTool } from '~/lib/discovery/types';
 
-export interface Tool {
-  id: string;
-  name: string;
-  description: string;
-  qualityScore: string;
-  likeCount?: number;
-  importHealth?: 'HEALTHY' | 'BROKEN' | 'UNKNOWN';
-  executionHealth?: 'HEALTHY' | 'BROKEN' | 'UNKNOWN';
-  createdAt: string;
-  package: {
-    npmPackageName: string;
-    npmVersion: string;
-    npmPublishedAt: string;
-    category: string;
-    npmRepository: { url: string; type: string } | null;
-    isOfficial: boolean;
-    npmDownloadsLastMonth: number | null;
-  };
-}
+export type Tool = DiscoveryTool;
 
 export interface UseToolsParams {
   category?: string;
@@ -28,7 +11,11 @@ export interface UseToolsParams {
   limit?: number;
 }
 
-export function useTools(params: UseToolsParams = {}) {
+interface UseToolsOptions {
+  fallbackData?: Tool[];
+}
+
+export function useTools(params: UseToolsParams = {}, options: UseToolsOptions = {}) {
   const searchParams = new URLSearchParams();
 
   if (params.category && params.category !== 'all') {
@@ -47,5 +34,7 @@ export function useTools(params: UseToolsParams = {}) {
 
   const queryString = searchParams.toString();
 
-  return useSWR<Tool[]>(`/api/tools?${queryString}`);
+  return useSWR<Tool[]>(`/api/tools?${queryString}`, {
+    fallbackData: options.fallbackData,
+  });
 }

--- a/apps/web/src/lib/discovery/server.test.ts
+++ b/apps/web/src/lib/discovery/server.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  toolFindMany: vi.fn(),
+  collectionFindMany: vi.fn(),
+}));
+
+vi.mock('@tpmjs/db', () => ({
+  prisma: {
+    tool: { findMany: dbMocks.toolFindMany },
+    collection: { findMany: dbMocks.collectionFindMany },
+  },
+}));
+
+import { loadInitialCollections, loadInitialTools } from './server';
+
+describe('discovery server loaders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads a bounded, searchable, serializable tool result', async () => {
+    dbMocks.toolFindMany.mockResolvedValue([
+      {
+        id: 'tool-1',
+        name: 'helloWorldTool',
+        description: 'Say hello',
+        qualityScore: { toString: () => '0.91' },
+        likeCount: 12,
+        importHealth: 'HEALTHY',
+        executionHealth: 'UNKNOWN',
+        createdAt: new Date('2026-07-20T12:00:00.000Z'),
+        package: {
+          npmPackageName: '@tpmjs/hello',
+          npmVersion: '1.2.3',
+          npmPublishedAt: new Date('2026-07-19T12:00:00.000Z'),
+          category: 'utilities',
+          npmRepository: { url: 'https://github.com/tpmjs/hello', type: 'git' },
+          isOfficial: true,
+          npmDownloadsLastMonth: 1000,
+        },
+      },
+    ]);
+
+    await expect(loadInitialTools('  hello  ', 7)).resolves.toEqual([
+      expect.objectContaining({
+        id: 'tool-1',
+        qualityScore: '0.91',
+        createdAt: '2026-07-20T12:00:00.000Z',
+        package: expect.objectContaining({
+          npmPublishedAt: '2026-07-19T12:00:00.000Z',
+          npmRepository: { url: 'https://github.com/tpmjs/hello', type: 'git' },
+        }),
+      }),
+    ]);
+
+    expect(dbMocks.toolFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 7,
+        where: expect.objectContaining({
+          consecutiveImportFailures: { lt: 3 },
+          OR: expect.arrayContaining([
+            { name: { contains: 'hello', mode: 'insensitive' } },
+            { description: { contains: 'hello', mode: 'insensitive' } },
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('normalizes malformed repository metadata instead of leaking arbitrary JSON', async () => {
+    dbMocks.toolFindMany.mockResolvedValue([
+      {
+        id: 'tool-2',
+        name: 'safeTool',
+        description: 'Safe metadata',
+        qualityScore: null,
+        likeCount: 0,
+        importHealth: null,
+        executionHealth: null,
+        createdAt: new Date('2026-07-20T12:00:00.000Z'),
+        package: {
+          npmPackageName: 'safe-tool',
+          npmVersion: '1.0.0',
+          npmPublishedAt: new Date('2026-07-19T12:00:00.000Z'),
+          category: 'utilities',
+          npmRepository: { unexpected: true },
+          isOfficial: false,
+          npmDownloadsLastMonth: null,
+        },
+      },
+    ]);
+
+    const [tool] = await loadInitialTools('');
+    expect(tool?.package.npmRepository).toBeNull();
+  });
+
+  it('returns the first collection page and an exact has-more signal', async () => {
+    const rows = Array.from({ length: 3 }, (_, index) => ({
+      id: `collection-${index}`,
+      slug: index === 0 ? 'research' : null,
+      name: `Collection ${index}`,
+      description: null,
+      likeCount: 3 - index,
+      forkCount: index,
+      createdAt: new Date(`2026-07-${20 - index}T12:00:00.000Z`),
+      user: {
+        id: 'user-1',
+        name: 'Maintainer',
+        image: null,
+        username: 'maintainer',
+      },
+      _count: { tools: index + 1 },
+    }));
+    dbMocks.collectionFindMany.mockResolvedValue(rows);
+
+    await expect(loadInitialCollections(2)).resolves.toEqual({
+      collections: [
+        expect.objectContaining({
+          id: 'collection-0',
+          slug: 'research',
+          toolCount: 1,
+          createdAt: '2026-07-20T12:00:00.000Z',
+        }),
+        expect.objectContaining({ id: 'collection-1', slug: null, toolCount: 2 }),
+      ],
+      hasMore: true,
+    });
+
+    expect(dbMocks.collectionFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 3, where: { isPublic: true } })
+    );
+  });
+});

--- a/apps/web/src/lib/discovery/server.ts
+++ b/apps/web/src/lib/discovery/server.ts
@@ -1,0 +1,142 @@
+import { type Prisma, prisma } from '@tpmjs/db';
+import { defaultToolDiscoveryFilter } from '~/lib/tool-health-policy';
+import type { DiscoveryTool, PublicCollection } from './types';
+
+export const INITIAL_DISCOVERY_LIMIT = 50;
+
+const discoveryToolSelect = {
+  id: true,
+  name: true,
+  description: true,
+  qualityScore: true,
+  likeCount: true,
+  importHealth: true,
+  executionHealth: true,
+  createdAt: true,
+  package: {
+    select: {
+      npmPackageName: true,
+      npmVersion: true,
+      npmPublishedAt: true,
+      category: true,
+      npmRepository: true,
+      isOfficial: true,
+      npmDownloadsLastMonth: true,
+    },
+  },
+} satisfies Prisma.ToolSelect;
+
+type DiscoveryToolRow = Prisma.ToolGetPayload<{ select: typeof discoveryToolSelect }>;
+
+function normalizeRepository(
+  repository: Prisma.JsonValue | null
+): DiscoveryTool['package']['npmRepository'] {
+  if (!repository || typeof repository !== 'object' || Array.isArray(repository)) return null;
+
+  const { url, type } = repository as Record<string, unknown>;
+  return typeof url === 'string' && typeof type === 'string' ? { url, type } : null;
+}
+
+export function serializeDiscoveryTool(tool: DiscoveryToolRow): DiscoveryTool {
+  return {
+    id: tool.id,
+    name: tool.name,
+    description: tool.description,
+    qualityScore: tool.qualityScore?.toString() ?? null,
+    likeCount: tool.likeCount,
+    importHealth: tool.importHealth,
+    executionHealth: tool.executionHealth,
+    createdAt: tool.createdAt.toISOString(),
+    package: {
+      npmPackageName: tool.package.npmPackageName,
+      npmVersion: tool.package.npmVersion,
+      npmPublishedAt: tool.package.npmPublishedAt.toISOString(),
+      category: tool.package.category,
+      npmRepository: normalizeRepository(tool.package.npmRepository),
+      isOfficial: tool.package.isOfficial,
+      npmDownloadsLastMonth: tool.package.npmDownloadsLastMonth,
+    },
+  };
+}
+
+export async function loadInitialTools(
+  searchQuery: string,
+  limit = INITIAL_DISCOVERY_LIMIT
+): Promise<DiscoveryTool[]> {
+  const query = searchQuery.trim();
+  const tools = await prisma.tool.findMany({
+    where: {
+      ...defaultToolDiscoveryFilter(),
+      ...(query && {
+        OR: [
+          { name: { contains: query, mode: 'insensitive' } },
+          { description: { contains: query, mode: 'insensitive' } },
+          { package: { npmPackageName: { contains: query, mode: 'insensitive' } } },
+        ],
+      }),
+    },
+    select: discoveryToolSelect,
+    orderBy: [
+      { qualityScore: 'desc' },
+      { package: { npmDownloadsLastMonth: 'desc' } },
+      { createdAt: 'desc' },
+    ],
+    take: limit,
+  });
+
+  return tools.map(serializeDiscoveryTool);
+}
+
+const publicCollectionSelect = {
+  id: true,
+  slug: true,
+  name: true,
+  description: true,
+  likeCount: true,
+  forkCount: true,
+  createdAt: true,
+  user: {
+    select: {
+      id: true,
+      name: true,
+      image: true,
+      username: true,
+    },
+  },
+  _count: {
+    select: { tools: true },
+  },
+} satisfies Prisma.CollectionSelect;
+
+type PublicCollectionRow = Prisma.CollectionGetPayload<{ select: typeof publicCollectionSelect }>;
+
+export function serializePublicCollection(collection: PublicCollectionRow): PublicCollection {
+  return {
+    id: collection.id,
+    slug: collection.slug,
+    name: collection.name,
+    description: collection.description,
+    likeCount: collection.likeCount,
+    forkCount: collection.forkCount,
+    toolCount: collection._count.tools,
+    createdAt: collection.createdAt.toISOString(),
+    createdBy: collection.user,
+  };
+}
+
+export async function loadInitialCollections(
+  limit = INITIAL_DISCOVERY_LIMIT
+): Promise<{ collections: PublicCollection[]; hasMore: boolean }> {
+  const rows = await prisma.collection.findMany({
+    where: { isPublic: true },
+    select: publicCollectionSelect,
+    orderBy: [{ likeCount: 'desc' }, { createdAt: 'desc' }],
+    take: limit + 1,
+  });
+
+  const hasMore = rows.length > limit;
+  return {
+    collections: rows.slice(0, limit).map(serializePublicCollection),
+    hasMore,
+  };
+}

--- a/apps/web/src/lib/discovery/types.ts
+++ b/apps/web/src/lib/discovery/types.ts
@@ -1,0 +1,38 @@
+export type HealthStatus = 'HEALTHY' | 'BROKEN' | 'UNKNOWN';
+
+export interface DiscoveryTool {
+  id: string;
+  name: string;
+  description: string;
+  qualityScore: string | null;
+  likeCount?: number;
+  importHealth?: HealthStatus | null;
+  executionHealth?: HealthStatus | null;
+  createdAt: string;
+  package: {
+    npmPackageName: string;
+    npmVersion: string;
+    npmPublishedAt: string;
+    category: string;
+    npmRepository: { url: string; type: string } | null;
+    isOfficial: boolean;
+    npmDownloadsLastMonth: number | null;
+  };
+}
+
+export interface PublicCollection {
+  id: string;
+  slug: string | null;
+  name: string;
+  description: string | null;
+  likeCount: number;
+  forkCount: number;
+  toolCount: number;
+  createdAt: string;
+  createdBy: {
+    id: string;
+    name: string;
+    image: string | null;
+    username: string | null;
+  };
+}


### PR DESCRIPTION
Closes #136
Tracks #125

## Summary
- server-render a bounded first page of healthy registry tools and public collections using the same ranking and quarantine policy as the APIs
- preserve SWR refresh, filtering, sorting, infinite scroll, and post-hydration virtualization while shipping semantic table rows before JavaScript
- honor the documented `?q=` tool-search contract and keep searches shareable in the URL
- add canonical/indexable metadata plus ItemList structured data
- degrade to client retry rather than a route-level 500 when the initial database read fails

## Verification
- 136 web tests passed (12 credential-dependent skips)
- 238/238 monorepo type-check tasks passed
- 9/9 forced production-build tasks passed; 99/99 static pages generated
- pre-commit and pre-push hooks passed
- raw HTML contains real tool/collection detail links and query-specific ItemList data
- browser-verified hydration, query URL sync, tool filtering, collection filtering/sorting, and zero console errors