### PR TITLE
fix(registry): preserve tool evidence across releases

### DIFF
--- a/apps/web/src/app/api/agents/[id]/tools/route.ts
+++ b/apps/web/src/app/api/agents/[id]/tools/route.ts
@@ -122,8 +122,8 @@ export async function POST(request: NextRequest, context: RouteContext): Promise
     }
 
     // Check tool exists
-    const tool = await prisma.tool.findUnique({
-      where: { id: parsed.data.toolId },
+    const tool = await prisma.tool.findFirst({
+      where: { id: parsed.data.toolId, isActive: true },
       select: {
         id: true,
         name: true,

--- a/apps/web/src/app/api/collections/[id]/tools/route.ts
+++ b/apps/web/src/app/api/collections/[id]/tools/route.ts
@@ -215,8 +215,8 @@ export async function POST(
     }
 
     // Verify tool exists
-    const tool = await prisma.tool.findUnique({
-      where: { id: toolId },
+    const tool = await prisma.tool.findFirst({
+      where: { id: toolId, isActive: true },
       include: {
         package: {
           select: {

--- a/apps/web/src/app/api/mcp/registry/[transport]/route.ts
+++ b/apps/web/src/app/api/mcp/registry/[transport]/route.ts
@@ -289,6 +289,7 @@ async function handleExecuteTool(
     const tool = await withTimeout(
       prisma.tool.findFirst({
         where: {
+          isActive: true,
           name: args.toolName,
           package: { npmPackageName: args.packageName },
         },

--- a/apps/web/src/app/api/registry/execute/route.ts
+++ b/apps/web/src/app/api/registry/execute/route.ts
@@ -175,13 +175,13 @@ export async function POST(request: NextRequest) {
   const safeEnv = (env as Record<string, string>) || {};
 
   // --- Look up tool metadata ---
-  let toolDbId: string | undefined;
-  let version = 'latest';
-  let importUrl = `https://esm.sh/${packageName}@latest`;
+  let toolDbId: string;
+  let version: string;
 
   try {
     const tool = await prisma.tool.findFirst({
       where: {
+        isActive: true,
         name: exportName,
         package: { npmPackageName: packageName },
       },
@@ -193,15 +193,30 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    if (tool) {
-      toolDbId = tool.id;
-      version = tool.package.npmVersion;
-      importUrl = `https://esm.sh/${packageName}@${version}`;
+    if (!tool) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: { code: 'TOOL_NOT_FOUND', message: `Active registry tool not found: ${toolId}` },
+        },
+        { status: 404 }
+      );
     }
+
+    toolDbId = tool.id;
+    version = tool.package.npmVersion;
   } catch (error) {
-    // DB lookup failed - continue with 'latest' version
     console.warn(`[REGISTRY EXECUTE] DB lookup failed for ${toolId}:`, error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: { code: 'REGISTRY_UNAVAILABLE', message: 'Registry lookup temporarily unavailable' },
+      },
+      { status: 503 }
+    );
   }
+
+  const importUrl = `https://esm.sh/${packageName}@${version}`;
 
   // --- Execute via executor service ---
   let executorResult: {

--- a/apps/web/src/app/api/stats/health/route.ts
+++ b/apps/web/src/app/api/stats/health/route.ts
@@ -67,20 +67,20 @@ export async function GET(request: NextRequest) {
       dailyTrends,
     ] = await Promise.all([
       // Total tools
-      prisma.tool.count(),
+      prisma.tool.count({ where: { isActive: true } }),
 
       // Import health distribution
-      prisma.tool.count({ where: { importHealth: 'HEALTHY' } }),
-      prisma.tool.count({ where: { importHealth: 'BROKEN' } }),
-      prisma.tool.count({ where: { importHealth: 'UNKNOWN' } }),
+      prisma.tool.count({ where: { isActive: true, importHealth: 'HEALTHY' } }),
+      prisma.tool.count({ where: { isActive: true, importHealth: 'BROKEN' } }),
+      prisma.tool.count({ where: { isActive: true, importHealth: 'UNKNOWN' } }),
 
       // Execution health distribution
-      prisma.tool.count({ where: { executionHealth: 'HEALTHY' } }),
-      prisma.tool.count({ where: { executionHealth: 'BROKEN' } }),
-      prisma.tool.count({ where: { executionHealth: 'UNKNOWN' } }),
+      prisma.tool.count({ where: { isActive: true, executionHealth: 'HEALTHY' } }),
+      prisma.tool.count({ where: { isActive: true, executionHealth: 'BROKEN' } }),
+      prisma.tool.count({ where: { isActive: true, executionHealth: 'UNKNOWN' } }),
 
       // Never checked tools
-      prisma.tool.count({ where: { lastHealthCheck: null } }),
+      prisma.tool.count({ where: { isActive: true, lastHealthCheck: null } }),
 
       // Health check counts
       prisma.healthCheck.count({ where: { createdAt: { gte: last24h } } }),
@@ -120,6 +120,7 @@ export async function GET(request: NextRequest) {
       // Broken tools with error details
       prisma.tool.findMany({
         where: {
+          isActive: true,
           OR: [{ importHealth: 'BROKEN' }, { executionHealth: 'BROKEN' }],
         },
         select: {

--- a/apps/web/src/app/api/stats/route.ts
+++ b/apps/web/src/app/api/stats/route.ts
@@ -82,25 +82,27 @@ export async function GET(request: NextRequest) {
       qualityScoreDistribution,
     ] = await Promise.all([
       // Total tools
-      prisma.tool.count(),
+      prisma.tool.count({ where: { isActive: true } }),
 
       // Official tools
       prisma.tool.count({
-        where: { package: { isOfficial: true } },
+        where: { isActive: true, package: { isOfficial: true } },
       }),
 
       // Tools with extracted schema
       prisma.tool.count({
-        where: { schemaSource: 'extracted' },
+        where: { isActive: true, schemaSource: 'extracted' },
       }),
 
       // Health status distribution - consolidated groupBy queries
       prisma.tool.groupBy({
         by: ['importHealth'],
+        where: { isActive: true },
         _count: { _all: true },
       }),
       prisma.tool.groupBy({
         by: ['executionHealth'],
+        where: { isActive: true },
         _count: { _all: true },
       }),
 
@@ -112,14 +114,14 @@ export async function GET(request: NextRequest) {
           npmDownloadsLastMonth: true,
           githubStars: true,
           isOfficial: true,
-          _count: { select: { tools: true } },
+          _count: { select: { tools: { where: { isActive: true } } } },
         },
       }),
 
       // Recent tools
-      prisma.tool.count({ where: { createdAt: { gte: last24h } } }),
-      prisma.tool.count({ where: { createdAt: { gte: last7d } } }),
-      prisma.tool.count({ where: { createdAt: { gte: last30d } } }),
+      prisma.tool.count({ where: { isActive: true, createdAt: { gte: last24h } } }),
+      prisma.tool.count({ where: { isActive: true, createdAt: { gte: last7d } } }),
+      prisma.tool.count({ where: { isActive: true, createdAt: { gte: last30d } } }),
       prisma.package.count({ where: { createdAt: { gte: last7d } } }),
 
       // Simulation status counts - consolidated groupBy query
@@ -197,6 +199,7 @@ export async function GET(request: NextRequest) {
           END as bucket,
           COUNT(*) as count
         FROM tools
+        WHERE is_active
         GROUP BY
           CASE
             WHEN quality_score IS NULL THEN 'unscored'

--- a/apps/web/src/app/api/stats/tools/route.ts
+++ b/apps/web/src/app/api/stats/tools/route.ts
@@ -1,10 +1,26 @@
-import { prisma } from '@tpmjs/db';
+import { type Prisma, prisma } from '@tpmjs/db';
 import { type NextRequest, NextResponse } from 'next/server';
 import { checkRateLimit } from '~/lib/rate-limit';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
+
+const statsPackageSelect = {
+  npmPackageName: true,
+  npmVersion: true,
+  npmDownloadsLastMonth: true,
+  githubStars: true,
+  category: true,
+  tier: true,
+  isOfficial: true,
+  npmHomepage: true,
+  npmRepository: true,
+} satisfies Prisma.PackageSelect;
+
+type ToolStatsRow = Prisma.ToolGetPayload<{
+  include: { package: { select: typeof statsPackageSelect } };
+}>;
 
 /**
  * GET /api/stats/tools
@@ -42,7 +58,7 @@ export async function GET(request: NextRequest) {
     const now = new Date();
 
     // Build where clause
-    const whereClause: Record<string, unknown> = {};
+    const whereClause: Record<string, unknown> = { isActive: true };
     if (category) {
       whereClause.package = { category };
     }
@@ -70,7 +86,7 @@ export async function GET(request: NextRequest) {
     }
 
     // For execution sorting, we need a different query
-    let tools;
+    let tools: ToolStatsRow[];
     let executionCounts: Map<string, number> = new Map();
 
     if (sortBy === 'executions') {
@@ -92,19 +108,7 @@ export async function GET(request: NextRequest) {
         },
         take: limit,
         include: {
-          package: {
-            select: {
-              npmPackageName: true,
-              npmVersion: true,
-              npmDownloadsLastMonth: true,
-              githubStars: true,
-              category: true,
-              tier: true,
-              isOfficial: true,
-              npmHomepage: true,
-              npmRepository: true,
-            },
-          },
+          package: { select: statsPackageSelect },
         },
       });
 
@@ -116,19 +120,7 @@ export async function GET(request: NextRequest) {
         orderBy,
         take: limit,
         include: {
-          package: {
-            select: {
-              npmPackageName: true,
-              npmVersion: true,
-              npmDownloadsLastMonth: true,
-              githubStars: true,
-              category: true,
-              tier: true,
-              isOfficial: true,
-              npmHomepage: true,
-              npmRepository: true,
-            },
-          },
+          package: { select: statsPackageSelect },
           _count: {
             select: { simulations: true },
           },

--- a/apps/web/src/app/api/sync/changes/route.ts
+++ b/apps/web/src/app/api/sync/changes/route.ts
@@ -3,6 +3,12 @@ import { fetchChanges, fetchLatestPackageWithMetadata } from '@tpmjs/npm-client'
 import { validateTpmjsField } from '@tpmjs/types/tpmjs';
 import { type NextRequest, NextResponse } from 'next/server';
 import { requireCronAuth } from '~/lib/cron-auth';
+import {
+  newToolLifecycle,
+  refreshedToolLifecycle,
+  retireMissingTools,
+  retireToolsFromOtherVersions,
+} from '~/lib/sync/tool-lifecycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -112,8 +118,9 @@ export async function POST(request: NextRequest) {
 
         // For auto-discovery packages, skip tool creation — enrichment will handle it
         if (validation.needsAutoDiscovery) {
+          const retired = await retireToolsFromOtherVersions(packageRecord.id, pkg.version);
           console.log(
-            `Package ${pkg.name} needs auto-discovery — enrichment will handle tool creation`
+            `Package ${pkg.name} needs auto-discovery — retired ${retired} prior-version tools and queued enrichment`
           );
           processed++;
           continue;
@@ -125,6 +132,7 @@ export async function POST(request: NextRequest) {
         const existingTools = await prisma.tool.findMany({
           where: { packageId: packageRecord.id },
         });
+        const existingByName = new Map(existingTools.map((tool) => [tool.name, tool]));
 
         for (const toolDef of toolsToProcess) {
           const toolName = toolDef.name;
@@ -156,6 +164,7 @@ export async function POST(request: NextRequest) {
               qualityScore: null,
               schemaSource: toolDef.parameters ? 'author' : null,
               toolDiscoverySource: 'manual',
+              ...newToolLifecycle(pkg.version),
             },
             update: {
               description: toolDef.description || undefined,
@@ -170,22 +179,17 @@ export async function POST(request: NextRequest) {
                 ? (toolDef.healthCheck as Prisma.InputJsonValue)
                 : Prisma.DbNull,
               toolDiscoverySource: 'manual',
+              ...refreshedToolLifecycle(existingByName.get(toolName), pkg.version),
             },
           });
         }
 
-        // Delete orphaned tools (tools removed from package.json)
-        const orphanedTools = existingTools.filter(
-          (existingTool) => !toolsToProcess.some((toolDef) => toolDef.name === existingTool.name)
+        const retired = await retireMissingTools(
+          packageRecord.id,
+          toolsToProcess.flatMap((tool) => (tool.name ? [tool.name] : []))
         );
-
-        if (orphanedTools.length > 0) {
-          await prisma.tool.deleteMany({
-            where: {
-              id: { in: orphanedTools.map((t) => t.id) },
-            },
-          });
-          console.log(`Deleted ${orphanedTools.length} orphaned tools from package: ${pkg.name}`);
+        if (retired > 0) {
+          console.log(`Retired ${retired} absent tools from package ${pkg.name}@${pkg.version}`);
         }
 
         processed++;

--- a/apps/web/src/app/api/sync/enrich/route.ts
+++ b/apps/web/src/app/api/sync/enrich/route.ts
@@ -9,6 +9,11 @@ import {
   extractToolSchema,
   listToolExports,
 } from '~/lib/schema-extraction';
+import {
+  newToolLifecycle,
+  refreshedToolLifecycle,
+  retireMissingTools,
+} from '~/lib/sync/tool-lifecycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -47,7 +52,7 @@ export async function POST(request: NextRequest) {
     // the queue and starve everything behind them.
     const discoveryCandidates = await prisma.package.findMany({
       where: {
-        tools: { none: {} },
+        tools: { none: { isActive: true } },
       },
       orderBy: { toolDiscoveryAttemptAt: { sort: 'asc', nulls: 'first' } },
       take: 25,
@@ -104,6 +109,8 @@ export async function POST(request: NextRequest) {
         }
 
         const validTools = exportsResult.tools.filter((t) => t.isValidTool);
+        const existingTools = await prisma.tool.findMany({ where: { packageId: pkg.id } });
+        const existingByName = new Map(existingTools.map((tool) => [tool.name, tool]));
 
         for (const tool of validTools) {
           await prisma.tool.upsert({
@@ -120,16 +127,23 @@ export async function POST(request: NextRequest) {
               qualityScore: null,
               schemaSource: null,
               toolDiscoverySource: 'auto',
+              ...newToolLifecycle(pkg.npmVersion),
             },
             update: {
               description: tool.description || undefined,
               toolDiscoverySource: 'auto',
+              ...refreshedToolLifecycle(existingByName.get(tool.name), pkg.npmVersion),
             },
           });
         }
 
+        const retired = await retireMissingTools(
+          pkg.id,
+          validTools.map((tool) => tool.name)
+        );
+
         console.log(
-          `Auto-discovered ${validTools.length} tools for ${pkg.npmPackageName}: ${validTools.map((t) => t.name).join(', ')}`
+          `Auto-discovered ${validTools.length} tools for ${pkg.npmPackageName}; retired ${retired}: ${validTools.map((t) => t.name).join(', ')}`
         );
         await prisma.package.update({
           where: { id: pkg.id },
@@ -158,6 +172,7 @@ export async function POST(request: NextRequest) {
     // Phase 2: Enrich tools that need schema extraction
     const toolsToEnrich = await prisma.tool.findMany({
       where: {
+        isActive: true,
         schemaSource: null,
         OR: [
           { schemaExtractionAttemptAt: null },
@@ -265,6 +280,7 @@ export async function POST(request: NextRequest) {
     if (Date.now() - startTime < TIME_BUDGET_MS) {
       const toolsNeedingTags = await prisma.tool.findMany({
         where: {
+          isActive: true,
           schemaSource: 'extracted',
           tags: { isEmpty: true },
         },

--- a/apps/web/src/app/api/sync/keyword/route.ts
+++ b/apps/web/src/app/api/sync/keyword/route.ts
@@ -3,6 +3,12 @@ import { fetchLatestPackageWithMetadata, searchByKeyword } from '@tpmjs/npm-clie
 import { validateTpmjsField } from '@tpmjs/types/tpmjs';
 import { type NextRequest, NextResponse } from 'next/server';
 import { requireCronAuth } from '~/lib/cron-auth';
+import {
+  newToolLifecycle,
+  refreshedToolLifecycle,
+  retireMissingTools,
+  retireToolsFromOtherVersions,
+} from '~/lib/sync/tool-lifecycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -141,8 +147,9 @@ export async function POST(request: NextRequest) {
 
         // For auto-discovery packages, skip tool creation — enrichment will handle it
         if (validation.needsAutoDiscovery) {
+          const retired = await retireToolsFromOtherVersions(packageRecord.id, pkg.version);
           console.log(
-            `Package ${pkg.name} needs auto-discovery — enrichment will handle tool creation`
+            `Package ${pkg.name} needs auto-discovery — retired ${retired} prior-version tools and queued enrichment`
           );
           processed++;
           continue;
@@ -154,6 +161,7 @@ export async function POST(request: NextRequest) {
         const existingTools = await prisma.tool.findMany({
           where: { packageId: packageRecord.id },
         });
+        const existingByName = new Map(existingTools.map((tool) => [tool.name, tool]));
 
         for (const toolDef of toolsToProcess) {
           const toolName = toolDef.name;
@@ -185,6 +193,7 @@ export async function POST(request: NextRequest) {
               qualityScore: null,
               schemaSource: toolDef.parameters ? 'author' : null,
               toolDiscoverySource: 'manual',
+              ...newToolLifecycle(pkg.version),
             },
             update: {
               description: toolDef.description || undefined,
@@ -200,22 +209,17 @@ export async function POST(request: NextRequest) {
                 : Prisma.DbNull,
               toolDiscoverySource: 'manual',
               qualityMetricsVersion: 0,
+              ...refreshedToolLifecycle(existingByName.get(toolName), pkg.version),
             },
           });
         }
 
-        // Delete orphaned tools (tools removed from package.json)
-        const orphanedTools = existingTools.filter(
-          (existingTool) => !toolsToProcess.some((toolDef) => toolDef.name === existingTool.name)
+        const retired = await retireMissingTools(
+          packageRecord.id,
+          toolsToProcess.flatMap((tool) => (tool.name ? [tool.name] : []))
         );
-
-        if (orphanedTools.length > 0) {
-          await prisma.tool.deleteMany({
-            where: {
-              id: { in: orphanedTools.map((t) => t.id) },
-            },
-          });
-          console.log(`Deleted ${orphanedTools.length} orphaned tools from package: ${pkg.name}`);
+        if (retired > 0) {
+          console.log(`Retired ${retired} absent tools from package ${pkg.name}@${pkg.version}`);
         }
 
         processed++;

--- a/apps/web/src/app/api/sync/package/route.ts
+++ b/apps/web/src/app/api/sync/package/route.ts
@@ -10,6 +10,11 @@ import {
   extractToolSchema,
   listToolExports,
 } from '~/lib/schema-extraction';
+import {
+  newToolLifecycle,
+  refreshedToolLifecycle,
+  retireMissingTools,
+} from '~/lib/sync/tool-lifecycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -173,6 +178,10 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const existingTools = await prisma.tool.findMany({
+      where: { packageId: packageRecord.id },
+    });
+    const existingByName = new Map(existingTools.map((tool) => [tool.name, tool]));
     const syncedTools: string[] = [];
 
     // Upsert each tool
@@ -203,6 +212,7 @@ export async function POST(request: NextRequest) {
           qualityScore: null,
           schemaSource: toolDef.parameters ? 'author' : null,
           toolDiscoverySource,
+          ...newToolLifecycle(pkg.version),
         },
         update: {
           description: toolDef.description || undefined,
@@ -217,6 +227,7 @@ export async function POST(request: NextRequest) {
             ? (toolDef.healthCheck as Prisma.InputJsonValue)
             : Prisma.DbNull,
           toolDiscoverySource,
+          ...refreshedToolLifecycle(existingByName.get(toolName), pkg.version),
         },
       });
 
@@ -246,6 +257,11 @@ export async function POST(request: NextRequest) {
       });
 
       syncedTools.push(toolName);
+    }
+
+    const retired = await retireMissingTools(packageRecord.id, syncedTools);
+    if (retired > 0) {
+      console.log(`Retired ${retired} absent tools from package ${pkg.name}@${pkg.version}`);
     }
 
     return NextResponse.json({

--- a/apps/web/src/app/api/tools/[...slug]/route.ts
+++ b/apps/web/src/app/api/tools/[...slug]/route.ts
@@ -60,6 +60,7 @@ export async function GET(
       // Find specific tool by package name and export name
       const tool = await prisma.tool.findFirst({
         where: {
+          isActive: true,
           package: { npmPackageName: packageName },
           name: name,
         },
@@ -84,7 +85,7 @@ export async function GET(
     // Find all tools for the package
     const pkg = await prisma.package.findUnique({
       where: { npmPackageName: packageName },
-      include: { tools: true },
+      include: { tools: { where: { isActive: true } } },
     });
 
     if (!pkg) {
@@ -154,6 +155,7 @@ export async function POST(
     // Find the tool
     const tool = await prisma.tool.findFirst({
       where: {
+        isActive: true,
         package: { npmPackageName: packageName },
         name: name,
       },

--- a/apps/web/src/app/api/tools/[id]/like/route.ts
+++ b/apps/web/src/app/api/tools/[id]/like/route.ts
@@ -65,8 +65,8 @@ export async function GET(
       },
     });
 
-    const tool = await prisma.tool.findUnique({
-      where: { id },
+    const tool = await prisma.tool.findFirst({
+      where: { id, isActive: true },
       select: { likeCount: true },
     });
 
@@ -118,9 +118,9 @@ export async function POST(
       );
     }
 
-    // Check tool exists
-    const tool = await prisma.tool.findUnique({
-      where: { id },
+    // Only active registry tools accept new likes.
+    const tool = await prisma.tool.findFirst({
+      where: { id, isActive: true },
     });
 
     if (!tool) {

--- a/apps/web/src/app/api/tools/[id]/rate/route.ts
+++ b/apps/web/src/app/api/tools/[id]/rate/route.ts
@@ -45,8 +45,8 @@ export async function GET(
     });
 
     // Get tool rating stats (always available)
-    const tool = await prisma.tool.findUnique({
-      where: { id },
+    const tool = await prisma.tool.findFirst({
+      where: { id, isActive: true },
       select: {
         averageRating: true,
         ratingCount: true,
@@ -143,9 +143,9 @@ export async function POST(
       );
     }
 
-    // Check tool exists
-    const tool = await prisma.tool.findUnique({
-      where: { id },
+    // Only active registry tools accept new ratings.
+    const tool = await prisma.tool.findFirst({
+      where: { id, isActive: true },
     });
 
     if (!tool) {

--- a/apps/web/src/app/api/tools/[id]/reviews/route.ts
+++ b/apps/web/src/app/api/tools/[id]/reviews/route.ts
@@ -51,8 +51,8 @@ export async function GET(
     const sort = searchParams.get('sort') || 'recent'; // 'recent', 'helpful', 'highest', 'lowest'
 
     // Check tool exists
-    const tool = await prisma.tool.findUnique({
-      where: { id },
+    const tool = await prisma.tool.findFirst({
+      where: { id, isActive: true },
       select: { id: true, reviewCount: true },
     });
 
@@ -241,9 +241,9 @@ export async function POST(
       );
     }
 
-    // Check tool exists
-    const tool = await prisma.tool.findUnique({
-      where: { id },
+    // Only active registry tools accept new reviews.
+    const tool = await prisma.tool.findFirst({
+      where: { id, isActive: true },
     });
 
     if (!tool) {

--- a/apps/web/src/app/api/tools/broken/route.ts
+++ b/apps/web/src/app/api/tools/broken/route.ts
@@ -23,6 +23,7 @@ export async function GET(request: NextRequest) {
   try {
     const brokenTools = await prisma.tool.findMany({
       where: {
+        isActive: true,
         OR: [{ importHealth: 'BROKEN' }, { executionHealth: 'BROKEN' }],
       },
       include: {

--- a/apps/web/src/app/api/tools/execute/[...slug]/route.ts
+++ b/apps/web/src/app/api/tools/execute/[...slug]/route.ts
@@ -72,13 +72,14 @@ export async function POST(
     const tool =
       slug.length === 1
         ? // Single slug - treat as tool ID
-          await prisma.tool.findUnique({
-            where: { id: slug[0] || '' },
+          await prisma.tool.findFirst({
+            where: { id: slug[0] || '', isActive: true },
             include: { package: true },
           })
         : // Multiple slugs - treat as packageName/name
           await prisma.tool.findFirst({
             where: {
+              isActive: true,
               package: { npmPackageName: decodeURIComponent(slug.slice(0, -1).join('/')) },
               name: decodeURIComponent(slug[slug.length - 1] || ''),
             },

--- a/apps/web/src/app/api/tools/extract-schema/route.ts
+++ b/apps/web/src/app/api/tools/extract-schema/route.ts
@@ -33,6 +33,7 @@ export async function POST(request: NextRequest) {
     // Find the tool by package name and export name
     const tool = await prisma.tool.findFirst({
       where: {
+        isActive: true,
         name,
         package: {
           npmPackageName: packageName,

--- a/apps/web/src/app/api/tools/parameters/route.ts
+++ b/apps/web/src/app/api/tools/parameters/route.ts
@@ -81,6 +81,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // Find the tool
     const tool = await prisma.tool.findFirst({
       where: {
+        isActive: true,
         name,
         package: {
           npmPackageName: packageName,

--- a/apps/web/src/app/api/tools/report-health/route.ts
+++ b/apps/web/src/app/api/tools/report-health/route.ts
@@ -104,6 +104,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Find the tool
     const tool = await prisma.tool.findFirst({
       where: {
+        isActive: true,
         name,
         package: { npmPackageName: packageName },
       },

--- a/apps/web/src/app/api/tools/route.ts
+++ b/apps/web/src/app/api/tools/route.ts
@@ -2,6 +2,7 @@ import { type Prisma, prisma } from '@tpmjs/db';
 import { type NextRequest, NextResponse } from 'next/server';
 import { checkRateLimit } from '~/lib/rate-limit';
 import {
+  activeToolFilter,
   defaultToolDiscoveryFilter,
   shouldIncludePersistentlyBrokenTools,
 } from '~/lib/tool-health-policy';
@@ -344,6 +345,8 @@ export async function GET(request: NextRequest) {
       });
       if (!includePersistentBroken) {
         healthFilters.push(defaultToolDiscoveryFilter());
+      } else {
+        healthFilters.push(activeToolFilter());
       }
       where = buildWhereClause(query, packageFilter, healthFilters);
     } catch (error) {

--- a/apps/web/src/app/api/tools/search/route.ts
+++ b/apps/web/src/app/api/tools/search/route.ts
@@ -4,7 +4,7 @@ import { authenticateRequest } from '~/lib/api-keys/middleware';
 import { checkApiKeyRateLimit, getRateLimitHeaders } from '~/lib/api-keys/rate-limit';
 import { checkRateLimit, STRICT_RATE_LIMIT } from '~/lib/rate-limit';
 import { calculateBM25, hasExactNameMatch, hasPackageNameMatch, tokenize } from '~/lib/search/bm25';
-import { defaultToolDiscoveryFilter } from '~/lib/tool-health-policy';
+import { activeToolFilter, defaultToolDiscoveryFilter } from '~/lib/tool-health-policy';
 import { trackSearch } from '~/lib/tracking/search';
 
 export const runtime = 'nodejs';
@@ -78,7 +78,7 @@ export async function GET(request: NextRequest) {
     // Build database filter - pre-filter at DB level to reduce in-memory processing
     // Use OR conditions to find tools that match ANY search token
     const dbFilter = {
-      ...(!includePersistentBroken && defaultToolDiscoveryFilter()),
+      ...(includePersistentBroken ? activeToolFilter() : defaultToolDiscoveryFilter()),
       // Exclude tools already in collection (if provided)
       ...(excludeIds.length > 0 && { id: { notIn: excludeIds } }),
       ...(category && { package: { category } }),

--- a/apps/web/src/app/api/tools/trending/route.ts
+++ b/apps/web/src/app/api/tools/trending/route.ts
@@ -51,6 +51,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<ApiRespons
 
     // Build where clause
     const where: Record<string, unknown> = {
+      isActive: true,
       importHealth: 'HEALTHY',
     };
 

--- a/apps/web/src/app/api/tools/update-schema/route.ts
+++ b/apps/web/src/app/api/tools/update-schema/route.ts
@@ -44,6 +44,7 @@ export async function POST(request: NextRequest) {
     // Find the tool by package name and name
     const tool = await prisma.tool.findFirst({
       where: {
+        isActive: true,
         name,
         package: {
           npmPackageName: packageName,

--- a/apps/web/src/app/tool/[...slug]/page.tsx
+++ b/apps/web/src/app/tool/[...slug]/page.tsx
@@ -52,6 +52,7 @@ const getTool = cache(async function getTool(slug: string[]): Promise<Tool | nul
     const tool = await prisma.tool.findFirst({
       where: {
         packageId: pkg.id,
+        isActive: true,
         ...(toolName && { name: toolName }),
       },
       include: {

--- a/apps/web/src/lib/health-check/health-check-service.ts
+++ b/apps/web/src/lib/health-check/health-check-service.ts
@@ -424,7 +424,7 @@ export async function performHealthCheck(
     include: { package: true },
   });
 
-  if (!tool) {
+  if (!tool || !tool.isActive) {
     throw new Error(`Tool not found: ${toolId}`);
   }
 

--- a/apps/web/src/lib/maintenance/bounded-work.ts
+++ b/apps/web/src/lib/maintenance/bounded-work.ts
@@ -63,7 +63,8 @@ export async function leaseDueToolIds(owner: string, limit: number): Promise<str
     WITH due AS (
       SELECT id
       FROM tools
-      WHERE health_check_next_at <= CURRENT_TIMESTAMP
+      WHERE is_active
+        AND health_check_next_at <= CURRENT_TIMESTAMP
         AND (health_check_lease_until IS NULL OR health_check_lease_until <= CURRENT_TIMESTAMP)
       ORDER BY health_check_next_at, id
       FOR UPDATE SKIP LOCKED
@@ -151,7 +152,8 @@ export async function refreshQualityScoreSlice(limit: number): Promise<number> {
              ) AS score
       FROM tools AS t
       JOIN packages AS p ON p.id = t.package_id
-      WHERE t.quality_metrics_version < p.metrics_version
+      WHERE t.is_active
+        AND t.quality_metrics_version < p.metrics_version
       ORDER BY t.quality_metrics_version, t.id
       FOR UPDATE OF t SKIP LOCKED
       LIMIT ${limit}

--- a/apps/web/src/lib/sync/tool-lifecycle.test.ts
+++ b/apps/web/src/lib/sync/tool-lifecycle.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { newToolLifecycle, refreshedToolLifecycle } from './tool-lifecycle';
+
+describe('tool package-release lifecycle', () => {
+  const now = new Date('2026-07-21T16:30:00.000Z');
+
+  it('attributes a new active tool to the observed package version', () => {
+    expect(newToolLifecycle('1.2.3', now)).toEqual({
+      isActive: true,
+      lastSeenVersion: '1.2.3',
+      retiredAt: null,
+      healthCheckNextAt: now,
+    });
+  });
+
+  it('does not invalidate evidence during a same-version metadata poll', () => {
+    expect(
+      refreshedToolLifecycle({ lastSeenVersion: '1.2.3', schemaSource: 'extracted' }, '1.2.3', now)
+    ).toEqual({
+      isActive: true,
+      lastSeenVersion: '1.2.3',
+      retiredAt: null,
+    });
+  });
+
+  it('reactivates and requeues version-sensitive evidence for a new release', () => {
+    expect(
+      refreshedToolLifecycle({ lastSeenVersion: '1.2.2', schemaSource: 'extracted' }, '1.2.3', now)
+    ).toEqual({
+      isActive: true,
+      lastSeenVersion: '1.2.3',
+      retiredAt: null,
+      schemaSource: null,
+      schemaExtractedAt: null,
+      schemaExtractionAttemptAt: null,
+      schemaExtractionError: null,
+      healthCheckNextAt: now,
+      healthCheckLeaseUntil: null,
+      healthCheckLeasedBy: null,
+    });
+  });
+
+  it('preserves author-declared schemas while rechecking a new release', () => {
+    expect(
+      refreshedToolLifecycle({ lastSeenVersion: '1.2.2', schemaSource: 'author' }, '1.2.3', now)
+    ).toEqual({
+      isActive: true,
+      lastSeenVersion: '1.2.3',
+      retiredAt: null,
+      healthCheckNextAt: now,
+      healthCheckLeaseUntil: null,
+      healthCheckLeasedBy: null,
+    });
+  });
+});

--- a/apps/web/src/lib/sync/tool-lifecycle.ts
+++ b/apps/web/src/lib/sync/tool-lifecycle.ts
@@ -1,0 +1,96 @@
+import { prisma } from '@tpmjs/db';
+
+export interface ExistingToolLifecycle {
+  lastSeenVersion: string | null;
+  schemaSource: string | null;
+}
+
+/** Lifecycle fields for a tool first observed in a package release. */
+export function newToolLifecycle(packageVersion: string, now = new Date()) {
+  return {
+    isActive: true,
+    lastSeenVersion: packageVersion,
+    retiredAt: null,
+    healthCheckNextAt: now,
+  } as const;
+}
+
+/**
+ * Reactivate a returning export and make version-sensitive evidence fresh.
+ * An unchanged package poll must not continually discard valid schemas.
+ */
+export function refreshedToolLifecycle(
+  existing: ExistingToolLifecycle | undefined,
+  packageVersion: string,
+  now = new Date()
+) {
+  const versionChanged = existing?.lastSeenVersion !== packageVersion;
+  const schemaNeedsRefresh = versionChanged && existing?.schemaSource !== 'author';
+  return {
+    isActive: true,
+    lastSeenVersion: packageVersion,
+    retiredAt: null,
+    ...(schemaNeedsRefresh
+      ? {
+          schemaSource: null,
+          schemaExtractedAt: null,
+          schemaExtractionAttemptAt: null,
+          schemaExtractionError: null,
+        }
+      : {}),
+    ...(versionChanged
+      ? {
+          healthCheckNextAt: now,
+          healthCheckLeaseUntil: null,
+          healthCheckLeasedBy: null,
+        }
+      : {}),
+  } as const;
+}
+
+/**
+ * Retire exports absent from the observed package version without deleting any
+ * historical or user-linked rows. Re-publishing a name later reuses its ID.
+ */
+export async function retireMissingTools(
+  packageId: string,
+  observedNames: readonly string[],
+  retiredAt = new Date()
+): Promise<number> {
+  const result = await prisma.tool.updateMany({
+    where: {
+      packageId,
+      isActive: true,
+      ...(observedNames.length > 0 ? { name: { notIn: [...observedNames] } } : {}),
+    },
+    data: {
+      isActive: false,
+      retiredAt,
+      healthCheckLeaseUntil: null,
+      healthCheckLeasedBy: null,
+    },
+  });
+  return result.count;
+}
+
+/** Queue auto-discovery for a new package version without erasing old exports. */
+export async function retireToolsFromOtherVersions(
+  packageId: string,
+  packageVersion: string,
+  retiredAt = new Date()
+): Promise<number> {
+  const result = await prisma.tool.updateMany({
+    where: {
+      packageId,
+      isActive: true,
+      OR: [{ lastSeenVersion: null }, { lastSeenVersion: { not: packageVersion } }],
+    },
+    data: {
+      isActive: false,
+      retiredAt,
+      healthCheckLeaseUntil: null,
+      healthCheckLeasedBy: null,
+    },
+  });
+  return result.count;
+}

--- a/apps/web/src/lib/tool-health-policy.test.ts
+++ b/apps/web/src/lib/tool-health-policy.test.ts
@@ -22,6 +22,7 @@ describe('persistent import-failure policy', () => {
     expect(isPersistentlyImportBroken(PERSISTENT_IMPORT_FAILURE_THRESHOLD - 1)).toBe(false);
     expect(isPersistentlyImportBroken(PERSISTENT_IMPORT_FAILURE_THRESHOLD)).toBe(true);
     expect(defaultToolDiscoveryFilter()).toEqual({
+      isActive: true,
       consecutiveImportFailures: { lt: PERSISTENT_IMPORT_FAILURE_THRESHOLD },
     });
   });

--- a/apps/web/src/lib/tool-health-policy.ts
+++ b/apps/web/src/lib/tool-health-policy.ts
@@ -30,11 +30,18 @@ export function isPersistentlyImportBroken(consecutiveImportFailures: number): b
 
 /** Prisma-compatible filter used by every default tool-discovery surface. */
 export function defaultToolDiscoveryFilter(): {
+  isActive: true;
   consecutiveImportFailures: { lt: number };
 } {
   return {
+    isActive: true,
     consecutiveImportFailures: { lt: PERSISTENT_IMPORT_FAILURE_THRESHOLD },
   };
+}
+
+/** Retired package exports remain durable evidence but are never executable. */
+export function activeToolFilter(): { isActive: true } {
+  return { isActive: true };
 }
 
 /** Explicit broken-tool requests remain an evidence and recovery surface. */

--- a/apps/web/src/lib/workflows/node-executors/tool.ts
+++ b/apps/web/src/lib/workflows/node-executors/tool.ts
@@ -23,7 +23,7 @@ export async function executeTool(
     },
   });
 
-  if (!tool) {
+  if (!tool || !tool.isActive) {
     throw new Error(`Tool not found: ${toolId}`);
   }
 

--- a/packages/db/prisma/migrations/20260721163000_non_destructive_tool_reconciliation/migration.sql
+++ b/packages/db/prisma/migrations/20260721163000_non_destructive_tool_reconciliation/migration.sql
@@ -1,0 +1,179 @@
+-- Preserve tool identity and evidence across package releases.
+--
+-- Removed/renamed exports used to be DELETEd by package sync, cascading into
+-- health checks, simulations, ratings, collection membership, and agent
+-- configuration. Tools now move between active/retired lifecycle states while
+-- registry counters continue to describe only the installable surface.
+
+ALTER TABLE tools
+  ADD COLUMN is_active boolean NOT NULL DEFAULT true,
+  ADD COLUMN last_seen_version varchar(50),
+  ADD COLUMN retired_at timestamp(3);
+
+UPDATE tools AS t
+SET last_seen_version = p.npm_version
+FROM packages AS p
+WHERE p.id = t.package_id;
+
+CREATE INDEX tools_is_active_idx ON tools(is_active);
+CREATE INDEX tools_package_id_is_active_idx ON tools(package_id, is_active);
+
+CREATE OR REPLACE FUNCTION tpmjs_count_tool()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  old_category text;
+  new_category text;
+  old_official boolean := false;
+  new_official boolean := false;
+  old_import text;
+  new_import text;
+  old_execution text;
+  new_execution text;
+  old_active boolean := false;
+  new_active boolean := false;
+BEGIN
+  IF TG_OP <> 'INSERT' THEN
+    SELECT category,is_official INTO old_category,old_official FROM packages WHERE id=OLD.package_id;
+    old_import := COALESCE(OLD.import_health::text,'UNKNOWN');
+    old_execution := COALESCE(OLD.execution_health::text,'UNKNOWN');
+    old_active := OLD.is_active;
+  END IF;
+  IF TG_OP <> 'DELETE' THEN
+    SELECT category,is_official INTO new_category,new_official FROM packages WHERE id=NEW.package_id;
+    new_import := COALESCE(NEW.import_health::text,'UNKNOWN');
+    new_execution := COALESCE(NEW.execution_health::text,'UNKNOWN');
+    new_active := NEW.is_active;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    IF NOT new_active THEN RETURN NEW; END IF;
+    PERFORM tpmjs_counter_add('total_tools','',1);
+    PERFORM tpmjs_counter_add('package_tools',NEW.package_id,1);
+    PERFORM tpmjs_counter_add('category_tools',new_category,1);
+    PERFORM tpmjs_counter_add('official_tools','',CASE WHEN new_official THEN 1 ELSE 0 END);
+    PERFORM tpmjs_counter_add('tools_with_schema','',CASE WHEN NEW.schema_source='extracted' THEN 1 ELSE 0 END);
+    PERFORM tpmjs_counter_add('import_health',new_import,1);
+    PERFORM tpmjs_counter_add('execution_health',new_execution,1);
+    PERFORM tpmjs_counter_add('quality_bucket',tpmjs_quality_bucket(NEW.quality_score),1);
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    IF NOT old_active THEN RETURN OLD; END IF;
+    PERFORM tpmjs_counter_add('total_tools','',-1);
+    IF old_category IS NOT NULL THEN
+      PERFORM tpmjs_counter_add('package_tools',OLD.package_id,-1);
+      PERFORM tpmjs_counter_add('category_tools',old_category,-1);
+      PERFORM tpmjs_counter_add('official_tools','',CASE WHEN old_official THEN -1 ELSE 0 END);
+    END IF;
+    PERFORM tpmjs_counter_add('tools_with_schema','',CASE WHEN OLD.schema_source='extracted' THEN -1 ELSE 0 END);
+    PERFORM tpmjs_counter_add('import_health',old_import,-1);
+    PERFORM tpmjs_counter_add('execution_health',old_execution,-1);
+    PERFORM tpmjs_counter_add('quality_bucket',tpmjs_quality_bucket(OLD.quality_score),-1);
+    RETURN OLD;
+  END IF;
+
+  IF old_active IS DISTINCT FROM new_active THEN
+    IF old_active THEN
+      PERFORM tpmjs_counter_add('total_tools','',-1);
+      PERFORM tpmjs_counter_add('package_tools',OLD.package_id,-1);
+      PERFORM tpmjs_counter_add('category_tools',old_category,-1);
+      PERFORM tpmjs_counter_add('official_tools','',CASE WHEN old_official THEN -1 ELSE 0 END);
+      PERFORM tpmjs_counter_add('tools_with_schema','',CASE WHEN OLD.schema_source='extracted' THEN -1 ELSE 0 END);
+      PERFORM tpmjs_counter_add('import_health',old_import,-1);
+      PERFORM tpmjs_counter_add('execution_health',old_execution,-1);
+      PERFORM tpmjs_counter_add('quality_bucket',tpmjs_quality_bucket(OLD.quality_score),-1);
+    ELSE
+      PERFORM tpmjs_counter_add('total_tools','',1);
+      PERFORM tpmjs_counter_add('package_tools',NEW.package_id,1);
+      PERFORM tpmjs_counter_add('category_tools',new_category,1);
+      PERFORM tpmjs_counter_add('official_tools','',CASE WHEN new_official THEN 1 ELSE 0 END);
+      PERFORM tpmjs_counter_add('tools_with_schema','',CASE WHEN NEW.schema_source='extracted' THEN 1 ELSE 0 END);
+      PERFORM tpmjs_counter_add('import_health',new_import,1);
+      PERFORM tpmjs_counter_add('execution_health',new_execution,1);
+      PERFORM tpmjs_counter_add('quality_bucket',tpmjs_quality_bucket(NEW.quality_score),1);
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- Retired evidence remains mutable/restorable without changing the active
+  -- registry projection.
+  IF NOT new_active THEN RETURN NEW; END IF;
+
+  IF OLD.package_id IS DISTINCT FROM NEW.package_id THEN
+    PERFORM tpmjs_counter_add('package_tools',OLD.package_id,-1);
+    PERFORM tpmjs_counter_add('package_tools',NEW.package_id,1);
+    PERFORM tpmjs_counter_add('category_tools',old_category,-1);
+    PERFORM tpmjs_counter_add('category_tools',new_category,1);
+    PERFORM tpmjs_counter_add('official_tools','',CASE WHEN old_official THEN -1 ELSE 0 END + CASE WHEN new_official THEN 1 ELSE 0 END);
+  END IF;
+  IF OLD.schema_source IS DISTINCT FROM NEW.schema_source THEN
+    PERFORM tpmjs_counter_add('tools_with_schema','',CASE WHEN OLD.schema_source='extracted' THEN -1 ELSE 0 END + CASE WHEN NEW.schema_source='extracted' THEN 1 ELSE 0 END);
+  END IF;
+  IF old_import IS DISTINCT FROM new_import THEN
+    PERFORM tpmjs_counter_add('import_health',old_import,-1);
+    PERFORM tpmjs_counter_add('import_health',new_import,1);
+  END IF;
+  IF old_execution IS DISTINCT FROM new_execution THEN
+    PERFORM tpmjs_counter_add('execution_health',old_execution,-1);
+    PERFORM tpmjs_counter_add('execution_health',new_execution,1);
+  END IF;
+  IF tpmjs_quality_bucket(OLD.quality_score) IS DISTINCT FROM tpmjs_quality_bucket(NEW.quality_score) THEN
+    PERFORM tpmjs_counter_add('quality_bucket',tpmjs_quality_bucket(OLD.quality_score),-1);
+    PERFORM tpmjs_counter_add('quality_bucket',tpmjs_quality_bucket(NEW.quality_score),1);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION tpmjs_reconcile_counters()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  LOCK TABLE packages, tools, collections, agents, simulations IN SHARE MODE;
+
+  DELETE FROM registry_counters;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT metric, dimension, value, CURRENT_TIMESTAMP
+  FROM (
+    SELECT 'total_packages'::text AS metric, ''::text AS dimension, count(*)::bigint AS value FROM packages
+    UNION ALL SELECT 'official_packages', '', count(*) FROM packages WHERE is_official
+    UNION ALL SELECT 'total_tools', '', count(*) FROM tools WHERE is_active
+    UNION ALL SELECT 'official_tools', '', count(*) FROM tools t JOIN packages p ON p.id = t.package_id WHERE t.is_active AND p.is_official
+    UNION ALL SELECT 'tools_with_schema', '', count(*) FROM tools WHERE is_active AND schema_source = 'extracted'
+    UNION ALL SELECT 'total_npm_downloads', '', COALESCE(sum(npm_downloads_last_month), 0) FROM packages
+    UNION ALL SELECT 'total_github_stars', '', COALESCE(sum(github_stars), 0) FROM packages
+    UNION ALL SELECT 'public_collections', '', count(*) FROM collections WHERE is_public
+    UNION ALL SELECT 'public_agents', '', count(*) FROM agents WHERE is_public
+    UNION ALL SELECT 'total_simulations', '', count(*) FROM simulations
+  ) fixed;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'tier_packages', tier, count(*), CURRENT_TIMESTAMP FROM packages GROUP BY tier;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'package_tools', package_id, count(*), CURRENT_TIMESTAMP
+  FROM tools WHERE is_active GROUP BY package_id;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'category_tools', COALESCE(p.category, ''), count(*), CURRENT_TIMESTAMP
+  FROM tools t JOIN packages p ON p.id = t.package_id
+  WHERE t.is_active GROUP BY p.category;
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'import_health', COALESCE(import_health::text, 'UNKNOWN'), count(*), CURRENT_TIMESTAMP
+  FROM tools WHERE is_active GROUP BY COALESCE(import_health::text, 'UNKNOWN');
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'execution_health', COALESCE(execution_health::text, 'UNKNOWN'), count(*), CURRENT_TIMESTAMP
+  FROM tools WHERE is_active GROUP BY COALESCE(execution_health::text, 'UNKNOWN');
+
+  INSERT INTO registry_counters(metric, dimension, value, updated_at)
+  SELECT 'quality_bucket', tpmjs_quality_bucket(quality_score), count(*), CURRENT_TIMESTAMP
+  FROM tools WHERE is_active GROUP BY tpmjs_quality_bucket(quality_score);
+END;
+$$;
+
+SELECT tpmjs_reconcile_counters();

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -96,6 +96,12 @@ model Tool {
   // Tool Discovery Fields
   toolDiscoverySource String? @map("tool_discovery_source") @db.VarChar(20) // 'auto' | 'manual' | null
 
+  // Package-release lifecycle. Missing exports are retired, never deleted, so
+  // historical health, usage, ratings, and collection evidence remains.
+  isActive        Boolean   @default(true) @map("is_active")
+  lastSeenVersion String?   @map("last_seen_version") @db.VarChar(50)
+  retiredAt       DateTime? @map("retired_at")
+
   // Enriched metadata for search and discoverability
   tags      String[] @default([])
   signature String?  @db.VarChar(500) // e.g. "(url: string) => Promise<{ content: string }>"
@@ -167,6 +173,8 @@ model Tool {
   @@index([lastHealthCheck])
   @@index([healthCheckNextAt, id])
   @@index([qualityMetricsVersion, id])
+  @@index([isActive])
+  @@index([packageId, isActive])
   @@map("tools")
 }
 

--- a/packages/db/scripts/verify-counter-invariants.ts
+++ b/packages/db/scripts/verify-counter-invariants.ts
@@ -192,6 +192,59 @@ async function verifyUpsertAndCascadeBalance(): Promise<void> {
         'dimension changes must move, not duplicate, projected counts'
       );
 
+      await tx.tool.update({
+        where: { id: toolId },
+        data: { isActive: false, retiredAt: new Date() },
+      });
+      const expectedWhileRetired = withDeltas(expectedAfterUpdate, [
+        [['total_tools', ''], -1n],
+        [['official_tools', ''], -1n],
+        [['package_tools', packageId], -1n],
+        [['category_tools', categoryB], -1n],
+        [['tools_with_schema', ''], -1n],
+        [['import_health', 'HEALTHY'], -1n],
+        [['execution_health', 'BROKEN'], -1n],
+        [['quality_bucket', 'high'], -1n],
+      ]);
+      assertSnapshot(
+        await readCounters(tx, keys),
+        expectedWhileRetired,
+        'retiring a tool must remove only its active-registry projections'
+      );
+
+      await tx.tool.update({
+        where: { id: toolId },
+        data: {
+          description: 'Mutable historical evidence',
+          importHealth: 'UNKNOWN',
+          executionHealth: 'UNKNOWN',
+          schemaSource: null,
+          qualityScore: null,
+        },
+      });
+      assertSnapshot(
+        await readCounters(tx, keys),
+        expectedWhileRetired,
+        'mutating retired evidence must not leak into active-registry projections'
+      );
+
+      await tx.tool.update({
+        where: { id: toolId },
+        data: {
+          isActive: true,
+          retiredAt: null,
+          importHealth: 'HEALTHY',
+          executionHealth: 'BROKEN',
+          schemaSource: 'extracted',
+          qualityScore: new Prisma.Decimal('0.75'),
+        },
+      });
+      assertSnapshot(
+        await readCounters(tx, keys),
+        expectedAfterUpdate,
+        'reactivating a tool must restore its current active-registry projections once'
+      );
+
       const driftedKeys: CounterKey[] = [
         ['total_packages', ''],
         ['tier_packages', 'rich'],


### PR DESCRIPTION
## What changed

- replace package-sync hard deletes with active/retired tool lifecycle reconciliation
- preserve tool IDs and all dependent health checks, simulations, ratings, reviews, collection membership, and agent configuration
- attribute every active export to the npm version where it was last observed
- reactivate returning exports and invalidate only version-sensitive extracted evidence; author schemas remain authoritative
- exclude retired tools from discovery, execution, schema enrichment, health scheduling, current registry statistics, and new user attachments
- update trigger-maintained counters and exact reconciliation to project active tools only
- make registry execution fail closed when the requested active tool cannot be resolved

## Why

The registry currently has two corrected package releases waiting to publish: `@tpmjs/tools-unsandbox@0.1.5` and `@tpmjs/tools-vercel@0.3.0`. Their complete export surfaces are much larger than the versions currently indexed in production. Existing sync routes hard-delete names absent from a new package manifest, which cascades into historical and user-linked records. That made the final release reconciliation unsafe even though the source packages themselves are ready.

This change makes package releases non-destructive: the current installable surface is an active projection over durable registry evidence.

## Impact

- package upgrades and renamed/removed exports no longer erase history or user configuration
- retired tools disappear from normal registry surfaces and cannot execute
- re-published exports reuse their stable database identity
- active tool counters remain exact through retirement and reactivation

## Verification

- `pnpm lint`
- `pnpm type-check` — 238/238 tasks
- `pnpm test` — 22/22 tasks, including 144 web tests and 858 UI tests
- `pnpm --filter @tpmjs/web... build`
- clean PostgreSQL 17 migration proof — all 7 migrations applied
- `pnpm --filter @tpmjs/db db:verify-counter-invariants` against the fresh database
- pre-commit secret/format/lint/type gates and pre-push full test gate

## Release follow-up

After this is merged and deployed, the remaining external gate is the one-time npm trusted-publisher grant for the two pending packages. The existing npm token is not usable; npm requires a maintainer login/Cloudflare verification to configure those package-level grants. No production package sync should run until this migration is deployed.
