### PR TITLE
ci: remove Vercel remote cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Turbo remote cache — shared across all jobs
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/scripts/check-no-vercel-hosting.mjs
+++ b/scripts/check-no-vercel-hosting.mjs
@@ -46,6 +46,21 @@ const forbiddenRuntimeTokens = [
   'NEXT_PUBLIC_VERCEL_URL',
 ];
 
+const forbiddenWorkflowTokens = ['TURBO_TOKEN', 'TURBO_TEAM'];
+const workflowRoot = join(root, '.github', 'workflows');
+
+for (const entry of readdirSync(workflowRoot)) {
+  const path = join(workflowRoot, entry);
+  if (statSync(path).isDirectory()) continue;
+
+  const contents = readFileSync(path, 'utf8');
+  for (const token of forbiddenWorkflowTokens) {
+    if (contents.includes(token)) {
+      errors.push(`${relative(root, path)} contains Vercel remote-cache token ${token}`);
+    }
+  }
+}
+
 function scan(directory) {
   for (const entry of readdirSync(directory)) {
     if (entry === 'node_modules' || entry === '.next') continue;
@@ -73,4 +88,4 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log('Vercel hosting independence: verified');
+console.log('Vercel hosting and remote-cache independence: verified');


### PR DESCRIPTION
## Outcome

TPMJS CI no longer injects Vercel Turborepo remote-cache credentials. The architecture ratchet now rejects `TURBO_TOKEN` or `TURBO_TEAM` in every workflow, preventing the dependency from returning.

## Verification

- `pnpm lint`
- `pnpm type-check` — 238/238 tasks
- `pnpm test` — 22/22 tasks
- `pnpm format:check`
- `pnpm check-architecture`
- Local Turbo output confirms remote caching is disabled

## After merge

Delete the orphaned GitHub `TURBO_TOKEN` secret and `TURBO_TEAM` variable. This is part of #138.