### PR TITLE
fix(ops): prevent stale executor provenance

### DIFF
--- a/scripts/deploy-on-box.sh
+++ b/scripts/deploy-on-box.sh
@@ -366,7 +366,10 @@ finish_activation() {
 deploy_executor() {
   log 'building executor candidate'
   CANDIDATE_IMAGE="localhost/tpmjs-railway-executor:candidate-${COMMIT_SHA}"
-  sudo podman build \
+  # Podman's layer cache can reuse an ARG-expanded LABEL from an older build
+  # when the executor source itself is unchanged. That produces correct code
+  # with false provenance, so release candidates deliberately rebuild metadata.
+  sudo podman build --no-cache \
     --build-arg "COMMIT_SHA=$COMMIT_SHA" \
     --build-arg "COMMIT_MESSAGE=$COMMIT_MESSAGE" \
     --tag "$CANDIDATE_IMAGE" \


### PR DESCRIPTION
Podman reused the cached executor ARG/LABEL layers during the first transactional rollout, producing the correct old image with stale `cdeaf8ad` provenance. The pre-activation assertion failed safely and neither service restarted. Force executor candidate builds to bypass the layer cache so both the OCI revision and runtime version are derived from the intended commit. Proven with a clean candidate stamped `cacheprf`; Bash syntax, ShellCheck, secrets, and the full local test hook pass.