### PR TITLE
fix(mcp): restore public collection health contract

### DIFF
--- a/.github/workflows/endpoint-health-check.yml
+++ b/.github/workflows/endpoint-health-check.yml
@@ -100,7 +100,6 @@ jobs:
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "$BASE_URL/api/mcp/$TEST_USERNAME/$TEST_COLLECTION_SLUG/http" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.INTEGRATION_TEST_API_KEY }}" \
             -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
             --connect-timeout 15 --max-time 30)
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
@@ -111,8 +110,10 @@ jobs:
             echo "Response: $BODY"
           fi
 
-          # Check for successful JSON-RPC response
-          if [ "$HTTP_CODE" -eq 200 ] && echo "$BODY" | grep -q '"result"'; then
+          if [ "$HTTP_CODE" -eq 200 ] && echo "$BODY" | jq -e \
+            '.jsonrpc == "2.0" and .id == 1 and
+             (.result.protocolVersion | type == "string") and
+             (.result.serverInfo.name | type == "string")' >/dev/null; then
             echo "status=pass" >> $GITHUB_OUTPUT
             echo "✅ MCP HTTP initialize check passed"
           else
@@ -127,7 +128,6 @@ jobs:
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "$BASE_URL/api/mcp/$TEST_USERNAME/$TEST_COLLECTION_SLUG/http" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.INTEGRATION_TEST_API_KEY }}" \
             -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
             --connect-timeout 15 --max-time 30)
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
@@ -138,8 +138,9 @@ jobs:
             echo "Response: $BODY" | head -c 500
           fi
 
-          # Check for successful JSON-RPC response with tools
-          if [ "$HTTP_CODE" -eq 200 ] && echo "$BODY" | grep -q '"tools"'; then
+          if [ "$HTTP_CODE" -eq 200 ] && echo "$BODY" | jq -e \
+            '.jsonrpc == "2.0" and .id == 2 and (.result.tools | type == "array")' \
+            >/dev/null; then
             echo "status=pass" >> $GITHUB_OUTPUT
             echo "✅ MCP HTTP tools/list check passed"
           else
@@ -154,7 +155,6 @@ jobs:
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "$BASE_URL/api/mcp/$TEST_USERNAME/$TEST_COLLECTION_SLUG/sse" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.INTEGRATION_TEST_API_KEY }}" \
             -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
             --connect-timeout 15 --max-time 30)
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
@@ -165,8 +165,10 @@ jobs:
             echo "Response: $BODY"
           fi
 
-          # Check for SSE response with data prefix
-          if [ "$HTTP_CODE" -eq 200 ] && echo "$BODY" | grep -q 'data:'; then
+          EVENT_DATA=$(printf '%s\n' "$BODY" | sed -n 's/^data: //p' | head -n1)
+          if [ "$HTTP_CODE" -eq 200 ] && echo "$EVENT_DATA" | jq -e \
+            '.jsonrpc == "2.0" and .id == 1 and
+             (.result.protocolVersion | type == "string")' >/dev/null; then
             echo "status=pass" >> $GITHUB_OUTPUT
             echo "✅ MCP SSE check passed"
           else
@@ -273,15 +275,11 @@ jobs:
           steps.basic-health.outputs.status == 'fail' ||
           steps.db-health.outputs.status == 'fail' ||
           steps.stats-api.outputs.status == 'fail' ||
-          steps.mcp-info.outputs.status == 'fail'
+          steps.mcp-http-init.outputs.status == 'fail' ||
+          steps.mcp-http-tools.outputs.status == 'fail' ||
+          steps.mcp-sse.outputs.status == 'fail' ||
+          steps.mcp-info.outputs.status == 'fail' ||
+          steps.tool-health-stats.outputs.status == 'fail'
         run: |
           echo "One or more critical health checks failed!"
           exit 1
-
-      - name: Warn if non-critical checks failed
-        if: |
-          steps.mcp-http-init.outputs.status == 'fail' ||
-          steps.mcp-http-tools.outputs.status == 'fail' ||
-          steps.mcp-sse.outputs.status == 'fail'
-        run: |
-          echo "::warning::MCP authenticated endpoints failed — check INTEGRATION_TEST_API_KEY secret"

--- a/apps/web/src/app/api/mcp/[username]/[slug]/[transport]/route.test.ts
+++ b/apps/web/src/app/api/mcp/[username]/[slug]/[transport]/route.test.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authenticateRequest: vi.fn(),
+  findUser: vi.fn(),
+  findCollection: vi.fn(),
+  handleInitialize: vi.fn(),
+  handleToolsList: vi.fn(),
+  handleToolsCall: vi.fn(),
+}));
+
+vi.mock('@tpmjs/db', () => ({
+  prisma: {
+    user: { findUnique: mocks.findUser },
+    collection: { findFirst: mocks.findCollection },
+  },
+}));
+
+vi.mock('~/lib/api-keys/middleware', () => ({
+  authenticateRequest: mocks.authenticateRequest,
+  getClientMetadata: vi.fn(),
+  hasScope: vi.fn(() => true),
+}));
+
+vi.mock('~/lib/api-keys/rate-limit', () => ({
+  checkApiKeyRateLimit: vi.fn(),
+  createRateLimitResponse: vi.fn(),
+  getRateLimitHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock('~/lib/api-keys/usage', () => ({ trackUsage: vi.fn() }));
+
+vi.mock('~/lib/mcp/handlers', () => ({
+  handleInitialize: mocks.handleInitialize,
+  handleToolsList: mocks.handleToolsList,
+  handleToolsCall: mocks.handleToolsCall,
+}));
+
+import { POST } from './route';
+
+const context = {
+  params: Promise.resolve({ username: 'ajax', slug: 'public-tools', transport: 'http' }),
+};
+
+function request(method: string, id = 1): NextRequest {
+  return new NextRequest('https://tpmjs.test/api/mcp/ajax/public-tools/http', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id, method }),
+  });
+}
+
+describe('public collection MCP contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticateRequest.mockResolvedValue({
+      authenticated: false,
+      error: 'Missing authorization header',
+    });
+    mocks.findUser.mockResolvedValue({ id: 'user_1', username: 'ajax' });
+    mocks.findCollection.mockResolvedValue({
+      id: 'collection_1',
+      name: 'Public Tools',
+      description: null,
+      userId: 'user_1',
+      isPublic: true,
+    });
+    mocks.handleInitialize.mockReturnValue({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        protocolVersion: '2024-11-05',
+        serverInfo: { name: 'Public Tools', version: '1.0.0' },
+      },
+    });
+    mocks.handleToolsList.mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { tools: [] },
+    });
+  });
+
+  it('initializes a public MCP server without authentication', async () => {
+    const response = await POST(request('initialize'), context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('mcp-session-id')).toBeTruthy();
+    await expect(response.json()).resolves.toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { protocolVersion: '2024-11-05' },
+    });
+  });
+
+  it('lists public collection tools without authentication', async () => {
+    const response = await POST(request('tools/list', 2), context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { tools: [] },
+    });
+  });
+
+  it('does not expose a private collection to an anonymous caller', async () => {
+    mocks.findCollection.mockResolvedValueOnce({
+      id: 'collection_2',
+      name: 'Private Tools',
+      description: null,
+      userId: 'user_1',
+      isPublic: false,
+    });
+
+    const response = await POST(request('initialize'), context);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: 'Collection not found' },
+    });
+    expect(mocks.handleInitialize).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/mcp/[username]/[slug]/[transport]/route.ts
+++ b/apps/web/src/app/api/mcp/[username]/[slug]/[transport]/route.ts
@@ -22,9 +22,6 @@ export const maxDuration = 60;
 
 const DB_TIMEOUT_MS = 10000; // 10 second timeout for database queries
 
-// Authentication is required for all MCP operations
-const REQUIRE_AUTH = true;
-
 interface RouteContext {
   params: Promise<{ username: string; slug: string; transport: string }>;
 }
@@ -325,19 +322,10 @@ export async function POST(request: NextRequest, context: RouteContext): Promise
     // Authenticate the request
     authResult = await authenticateRequest();
 
-    // Check if auth is required
-    if (REQUIRE_AUTH && !authResult.authenticated) {
-      return NextResponse.json(
-        {
-          jsonrpc: '2.0',
-          error: { code: -32000, message: authResult.error || 'Authentication required' },
-          id: null,
-        },
-        { status: 401 }
-      );
-    }
-
-    // Check scope if authenticated
+    // Public collections are intentionally usable without a TPMJS account. An
+    // authenticated caller still has to carry the MCP execution scope; private
+    // collections are restricted to their owner below. This keeps the public
+    // "one MCP URL, no signup" contract while never exposing stored owner env.
     if (authResult.authenticated && !hasScope(authResult, API_KEY_SCOPES.MCP_EXECUTE)) {
       return NextResponse.json(
         {
@@ -359,14 +347,6 @@ export async function POST(request: NextRequest, context: RouteContext): Promise
       if (!rateLimitResult.allowed) {
         return createRateLimitResponse(rateLimitResult);
       }
-    }
-
-    // Log warning for unauthenticated requests (soft launch)
-    if (!authResult.authenticated && !REQUIRE_AUTH) {
-      console.warn(
-        `[MCP] Unauthenticated request to /${username}/${slug}/${transport} - ` +
-          'API key authentication will be required in a future update'
-      );
     }
 
     // First, find the user by username

--- a/apps/web/src/app/health/page.tsx
+++ b/apps/web/src/app/health/page.tsx
@@ -15,6 +15,7 @@ import {
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { AppHeader } from '~/components/AppHeader';
+import { formatLastRefresh } from './refresh-label';
 
 interface CheckStat {
   name: string;
@@ -125,7 +126,9 @@ export default function HealthPage() {
   const [healthData, setHealthData] = useState<HealthData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
+  // Keep the server render and the browser's first render identical. Creating
+  // a Date during render produces different text on either side of hydration.
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
   const fetchHealthData = useCallback(async () => {
     try {
@@ -186,9 +189,7 @@ export default function HealthPage() {
             </div>
             <div className="text-right">
               <p className="text-sm text-foreground-tertiary">Last updated</p>
-              <p className="text-sm text-foreground-secondary">
-                {lastRefresh.toLocaleTimeString()}
-              </p>
+              <p className="text-sm text-foreground-secondary">{formatLastRefresh(lastRefresh)}</p>
             </div>
           </div>
         </div>

--- a/apps/web/src/app/health/refresh-label.test.ts
+++ b/apps/web/src/app/health/refresh-label.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { formatLastRefresh } from './refresh-label';
+
+describe('formatLastRefresh', () => {
+  it('keeps the server and initial browser render deterministic', () => {
+    expect(formatLastRefresh(null)).toBe('Not checked yet');
+  });
+});

--- a/apps/web/src/app/health/refresh-label.ts
+++ b/apps/web/src/app/health/refresh-label.ts
@@ -1,0 +1,3 @@
+export function formatLastRefresh(lastRefresh: Date | null): string {
+  return lastRefresh ? lastRefresh.toLocaleTimeString() : 'Not checked yet';
+}

--- a/apps/web/src/test/integration/mcp/mcp-http.integration.test.ts
+++ b/apps/web/src/test/integration/mcp/mcp-http.integration.test.ts
@@ -107,7 +107,7 @@ describe('MCP HTTP Endpoint', () => {
       }
     });
 
-    it('should reject without API key', async () => {
+    it('should initialize a public collection without an API key', async () => {
       if (!testCollection) {
         console.log('Skipping: No test collection available');
         return;
@@ -122,8 +122,12 @@ describe('MCP HTTP Endpoint', () => {
         }
       );
 
-      expect(result.ok).toBe(false);
-      expect(result.status).toBe(401);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const response = result.data as JsonRpcResponse;
+        expect(response.jsonrpc).toBe('2.0');
+        expect(response.result).toBeDefined();
+      }
     });
   });
 
@@ -149,6 +153,28 @@ describe('MCP HTTP Endpoint', () => {
         expect(result.data.id).toBe(2);
         expect(result.data.result).toBeDefined();
 
+        const listResult = result.data.result as { tools: unknown[] };
+        expect(Array.isArray(listResult.tools)).toBe(true);
+      }
+    });
+
+    it('should expose public collection tools without an API key', async () => {
+      if (!testCollection) {
+        console.log('Skipping: No test collection available');
+        return;
+      }
+
+      const result = await ctx.publicClient.post<JsonRpcResponse>(
+        `/api/mcp/${actualUsername}/${testCollection.slug}/http`,
+        {
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          id: 3,
+        }
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
         const listResult = result.data.result as { tools: unknown[] };
         expect(Array.isArray(listResult.tools)).toBe(true);
       }


### PR DESCRIPTION
## Outcome

Restores the documented public-collection MCP contract and makes the public health monitor honest.

## Changes

- Allow anonymous access to public collection MCP endpoints while retaining owner-only access for private collections and never exposing stored owner environment variables.
- Remove the stale integration-token dependency from endpoint monitoring.
- Validate JSON-RPC and SSE response structure with jq.
- Treat all eight endpoint checks as release-critical.
- Make the health page initial refresh timestamp deterministic across SSR hydration.
- Add route, rendering-state, and integration regressions.

## Evidence

- Production-like candidate against the live database: HTTP initialize 200 with session ID; tools/list 200 with 8 tools; SSE initialize 200 with text/event-stream.
- Web tests: 159 passed, 12 intentionally skipped.
- Coverage run: 1,105 passed, 12 intentionally skipped; statements improved to 5.58%.
- Type coverage: 339,778 / 342,741 nodes across 1,467 files (99.13%).
- Knip, formatting, lint, web type-check, full Next.js production build: pass.

## Deployment

After authoritative CI passes, deploy web transactionally on-box, dispatch Endpoint Health Check, and verify 8/8 plus a browser console free of hydration errors.
