### PR TITLE
feat(dev): add one-command local bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,12 @@
 # -----------------------------------------------------------------------------
 # Database [REQUIRED]
 # -----------------------------------------------------------------------------
-# PostgreSQL connection string (local dev: see packages/db/README.md for the
-# one-line docker command). Production runs a self-hosted Postgres 17 container.
+# PostgreSQL connection string (`pnpm dev:setup` provisions this isolated local
+# database). Production runs a self-hosted Postgres 17 container.
 # DATABASE_URL_UNPOOLED exists only because schema.prisma's directUrl reads it —
 # point both at the same database.
-DATABASE_URL="postgresql://tpmjs:tpmjs@localhost:5432/tpmjs"
-DATABASE_URL_UNPOOLED="postgresql://tpmjs:tpmjs@localhost:5432/tpmjs"
+DATABASE_URL="postgresql://tpmjs:tpmjs@127.0.0.1:55433/tpmjs"
+DATABASE_URL_UNPOOLED="postgresql://tpmjs:tpmjs@127.0.0.1:55433/tpmjs"
 
 # -----------------------------------------------------------------------------
 # Authentication [REQUIRED for auth features]
@@ -29,7 +29,7 @@ BETTER_AUTH_URL="http://localhost:3000"
 # -----------------------------------------------------------------------------
 # Cron Jobs [REQUIRED for sync endpoints]
 # -----------------------------------------------------------------------------
-# Secret for authenticating Vercel Cron requests - generate with: openssl rand -hex 32
+# Secret for authenticating scheduled job requests - generate with: openssl rand -hex 32
 CRON_SECRET="your-64-char-hex-secret-here"
 
 # -----------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
         run: pnpm format:check
 
       - name: Validate operator scripts
-        run: bash -n scripts/deploy-on-box.sh
+        run: |
+          bash -n scripts/deploy-on-box.sh
+          docker compose --file compose.dev.yaml config --quiet
 
   type-check:
     runs-on: ubuntu-latest
@@ -79,6 +81,7 @@ jobs:
 
       - name: Test
         run: |
+          pnpm dev:setup:test
           pnpm release:audit:test
           pnpm release:auth:test
           pnpm verify:vercel-api:test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to TPMJS! This guide will help you g
 - **Node.js**: 22.x or higher
 - **pnpm**: 10.x or higher
 - **Git**: Latest stable version
+- **Containers**: Docker with Compose v2, or Podman Compose
 
 Install pnpm globally if you haven't already:
 
@@ -29,24 +30,21 @@ cd tpmjs
 pnpm install
 ```
 
-3. **Set up environment variables:**
+3. **Provision the local environment and database:**
 
 ```bash
-cp .env.example apps/web/.env.local
-# Edit .env.local with your database credentials
-# (start a local Postgres container first — see packages/db/README.md)
+pnpm dev:setup
 ```
 
-4. **Generate Prisma client:**
+This starts an isolated PostgreSQL 17 instance on `127.0.0.1:55433`, applies the
+checked-in migrations, creates `apps/web/.env.local` with generated local-only
+secrets if it does not exist, and seeds two executable starter tools. Existing
+environment files and the persistent database volume are never overwritten.
+
+4. **Run the development server:**
 
 ```bash
-pnpm --filter=@tpmjs/db db:generate
-```
-
-5. **Run development server:**
-
-```bash
-pnpm dev --filter=@tpmjs/web
+pnpm --filter=@tpmjs/web dev
 ```
 
 ## Development Workflow
@@ -93,6 +91,9 @@ pnpm --filter=@tpmjs/db db:push
 
 # Create migrations (production)
 pnpm --filter=@tpmjs/db db:migrate
+
+# Apply checked-in migrations without creating new ones
+pnpm --filter=@tpmjs/db db:migrate:deploy
 
 # Open Prisma Studio
 pnpm --filter=@tpmjs/db db:studio

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ const tools = [registrySearchTool, registryExecuteTool];
 
 - [Node.js](https://nodejs.org/) >= 22
 - [pnpm](https://pnpm.io/) >= 10
+- Docker with Compose v2, or Podman Compose
 
 ### Setup
 
@@ -136,13 +137,19 @@ const tools = [registrySearchTool, registryExecuteTool];
 git clone https://github.com/tpmjs/tpmjs.git
 cd tpmjs
 pnpm install
+pnpm dev:setup
 ```
+
+`dev:setup` provisions an isolated PostgreSQL 17 database, applies every
+checked-in migration, creates a local environment with generated secrets, and
+seeds an offline starter registry. It is idempotent and preserves both existing
+environment files and database data.
 
 ### Development
 
 ```bash
-# Start the dev server
-pnpm dev --filter=@tpmjs/web
+# Start the web app
+pnpm --filter=@tpmjs/web dev
 
 # Run tests
 pnpm test

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,25 @@
+name: ${TPMJS_DEV_PROJECT_NAME:-tpmjs-dev}
+
+services:
+  postgres:
+    image: postgres:17-bookworm
+    environment:
+      POSTGRES_DB: tpmjs
+      POSTGRES_PASSWORD: tpmjs
+      POSTGRES_USER: tpmjs
+    ports:
+      - "127.0.0.1:${TPMJS_DEV_DB_PORT:-55433}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=tpmjs --dbname=tpmjs"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+    stop_grace_period: 30s
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:
+    labels:
+      org.tpmjs.purpose: local-development

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   "packageManager": "pnpm@10.14.0",
   "scripts": {
     "dev": "turbo dev",
+    "dev:setup": "tsx scripts/dev-setup.ts",
+    "dev:setup:test": "tsx --test scripts/dev-setup.test.ts",
     "build": "turbo build",
     "build:web": "turbo run build --filter=@tpmjs/web...",
     "build:playground": "turbo run build --filter=@tpmjs/playground...",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -2,30 +2,43 @@
 
 Database package for TPMJS NPM Registry. Provides Prisma ORM setup and database client for storing tool metadata.
 
-## Setup
+## One-command setup
 
-### 1. Start a Local Postgres
-
-Run a local PostgreSQL container for development:
+From the repository root:
 
 ```bash
-docker run -d --name tpmjs-dev-pg -p 5432:5432 \
-  -e POSTGRES_USER=tpmjs -e POSTGRES_PASSWORD=tpmjs -e POSTGRES_DB=tpmjs \
-  postgres:17
+pnpm dev:setup
+```
+
+This starts PostgreSQL 17 on `127.0.0.1:55433`, waits for its healthcheck,
+applies the migration ledger, generates Prisma Client, seeds an executable
+starter package, and verifies the registry counter invariants. The named volume
+is persistent and the command is safe to rerun.
+
+## Manual setup
+
+The individual steps remain available when you need a custom database.
+
+### 1. Start local PostgreSQL
+
+```bash
+docker compose --file compose.dev.yaml up --detach postgres
 ```
 
 ### 2. Configure Environment
 
 ```bash
-cp .env.example .env
-# Edit .env and set DATABASE_URL=postgresql://tpmjs:tpmjs@localhost:5432/tpmjs
+cp .env.example apps/web/.env.local
+# The default URL is postgresql://tpmjs:tpmjs@127.0.0.1:55433/tpmjs
 ```
 
-### 3. Push the Schema
+### 3. Apply migrations and seed
 
 ```bash
-pnpm db:push
-pnpm db:seed
+export DATABASE_URL=postgresql://tpmjs:tpmjs@127.0.0.1:55433/tpmjs
+export DATABASE_URL_UNPOOLED="$DATABASE_URL"
+pnpm --filter=@tpmjs/db db:migrate:deploy
+pnpm --filter=@tpmjs/db db:seed
 ```
 
 ## Usage
@@ -62,6 +75,7 @@ await prisma.syncCheckpoint.update({
 - `pnpm db:generate` - Generate Prisma client
 - `pnpm db:push` - Push schema to database (for development)
 - `pnpm db:migrate` - Create and run migrations (for production)
+- `pnpm db:migrate:deploy` - Apply existing migrations without creating new ones
 - `pnpm db:studio` - Open Prisma Studio GUI
 - `pnpm db:seed` - Seed initial data
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,6 +10,7 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
+    "db:migrate:deploy": "prisma migrate deploy",
     "db:verify-counter-invariants": "tsx scripts/verify-counter-invariants.ts",
     "db:studio": "prisma studio",
     "db:seed": "tsx prisma/seed.ts",

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -5,44 +5,132 @@ const prisma = new PrismaClient();
 async function main() {
   console.log('Seeding sync checkpoints...');
 
-  // Create initial sync checkpoints
-  await prisma.syncCheckpoint.upsert({
-    where: { source: 'changes-feed' },
-    update: {},
-    create: {
-      source: 'changes-feed',
-      checkpoint: {
-        sequence: '0',
-        lastProcessed: null,
+  const seededToolCount = await prisma.$transaction(async (tx) => {
+    // Create initial sync checkpoints
+    await tx.syncCheckpoint.upsert({
+      where: { source: 'changes-feed' },
+      update: {},
+      create: {
+        source: 'changes-feed',
+        checkpoint: {
+          sequence: '0',
+          lastProcessed: null,
+        },
       },
-    },
+    });
+
+    await tx.syncCheckpoint.upsert({
+      where: { source: 'keyword-search' },
+      update: {},
+      create: {
+        source: 'keyword-search',
+        checkpoint: {
+          lastRun: null,
+          totalProcessed: 0,
+        },
+      },
+    });
+
+    await tx.syncCheckpoint.upsert({
+      where: { source: 'metrics' },
+      update: {},
+      create: {
+        source: 'metrics',
+        checkpoint: {
+          lastRun: null,
+          totalProcessed: 0,
+        },
+      },
+    });
+
+    console.log('Seeding the offline starter registry...');
+
+    const starterPackage = await tx.package.upsert({
+      where: { npmPackageName: '@tpmjs/hello' },
+      update: {},
+      create: {
+        npmPackageName: '@tpmjs/hello',
+        npmVersion: '0.0.3',
+        npmPublishedAt: new Date('2026-01-25T01:59:09.872Z'),
+        npmDescription: 'Example TPMJS tools - Hello World and Hello Name',
+        npmRepository: { type: 'git', url: 'https://github.com/tpmjs/tpmjs.git' },
+        npmHomepage: 'https://tpmjs.com',
+        npmLicense: 'MIT',
+        npmKeywords: ['tpmjs', 'ai-sdk', 'hello', 'example'],
+        category: 'text-analysis',
+        frameworks: ['vercel-ai'],
+        tier: 'rich',
+        discoveryMethod: 'seed',
+        isOfficial: true,
+      },
+    });
+
+    const starterTools = [
+      {
+        name: 'helloWorldTool',
+        description: 'Returns a simple Hello, World! greeting with an optional timestamp',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            includeTimestamp: {
+              type: 'boolean',
+              description: 'Whether to include a timestamp in the response',
+            },
+          },
+          additionalProperties: false,
+        },
+        signature:
+          '(includeTimestamp?: boolean) => Promise<{ message: string; timestamp?: string }>',
+        tags: ['example', 'greeting', 'text'],
+      },
+      {
+        name: 'helloNameTool',
+        description: 'Returns a personalized greeting for the provided name',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'The name of the person to greet' },
+          },
+          required: ['name'],
+          additionalProperties: false,
+        },
+        signature: '(name: string) => Promise<{ message: string; timestamp: string }>',
+        tags: ['example', 'greeting', 'text'],
+      },
+    ] as const;
+
+    for (const starterTool of starterTools) {
+      await tx.tool.upsert({
+        where: {
+          packageId_name: { packageId: starterPackage.id, name: starterTool.name },
+        },
+        update: {},
+        create: {
+          packageId: starterPackage.id,
+          name: starterTool.name,
+          description: starterTool.description,
+          inputSchema: starterTool.inputSchema,
+          schemaSource: 'author',
+          toolDiscoverySource: 'manual',
+          signature: starterTool.signature,
+          tags: [...starterTool.tags],
+          lastSeenVersion: '0.0.3',
+        },
+      });
+    }
+
+    const transactionToolCount = await tx.tool.count({
+      where: { packageId: starterPackage.id, name: { in: starterTools.map((tool) => tool.name) } },
+    });
+    if (transactionToolCount !== starterTools.length) {
+      throw new Error(
+        `Starter registry verification failed: expected ${starterTools.length} tools, found ${transactionToolCount}`
+      );
+    }
+    return transactionToolCount;
   });
 
-  await prisma.syncCheckpoint.upsert({
-    where: { source: 'keyword-search' },
-    update: {},
-    create: {
-      source: 'keyword-search',
-      checkpoint: {
-        lastRun: null,
-        totalProcessed: 0,
-      },
-    },
-  });
-
-  await prisma.syncCheckpoint.upsert({
-    where: { source: 'metrics' },
-    update: {},
-    create: {
-      source: 'metrics',
-      checkpoint: {
-        lastRun: null,
-        totalProcessed: 0,
-      },
-    },
-  });
-
-  console.log('Seed completed successfully');
+  console.log(`Seed completed successfully (${seededToolCount} executable starter tools)`);
 }
 
 main()

--- a/scripts/dev-setup-lib.ts
+++ b/scripts/dev-setup-lib.ts
@@ -1,0 +1,79 @@
+import { parseEnv } from 'node:util';
+
+export const DEFAULT_DEV_DB_PORT = 55433;
+export const DEFAULT_DEV_PROJECT_NAME = 'tpmjs-dev';
+
+export type LocalDatabaseConfig = {
+  port: number;
+  projectName: string;
+  url: string;
+};
+
+export type LocalSecrets = {
+  apiKeyEncryption: string;
+  auth: string;
+  cron: string;
+};
+
+export function resolveLocalDatabaseConfig(environment: NodeJS.ProcessEnv): LocalDatabaseConfig {
+  const rawPort = environment.TPMJS_DEV_DB_PORT?.trim() || String(DEFAULT_DEV_DB_PORT);
+  if (!/^\d+$/.test(rawPort)) {
+    throw new Error(`TPMJS_DEV_DB_PORT must be an integer; received ${JSON.stringify(rawPort)}`);
+  }
+
+  const port = Number(rawPort);
+  if (!Number.isSafeInteger(port) || port < 1024 || port > 65535) {
+    throw new Error(`TPMJS_DEV_DB_PORT must be between 1024 and 65535; received ${rawPort}`);
+  }
+
+  const projectName = environment.TPMJS_DEV_PROJECT_NAME?.trim() || DEFAULT_DEV_PROJECT_NAME;
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(projectName)) {
+    throw new Error(
+      'TPMJS_DEV_PROJECT_NAME must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, or underscores'
+    );
+  }
+
+  return {
+    port,
+    projectName,
+    url: `postgresql://tpmjs:tpmjs@127.0.0.1:${port}/tpmjs`,
+  };
+}
+
+function envLine(name: string, value: string): string {
+  return `${name}=${JSON.stringify(value)}`;
+}
+
+export function renderLocalWebEnvironment(
+  database: LocalDatabaseConfig,
+  secrets: LocalSecrets
+): string {
+  return `${[
+    '# Generated once by `pnpm dev:setup`. This file is gitignored.',
+    '# Optional integrations can be added from the repository-root .env.example.',
+    envLine('DATABASE_URL', database.url),
+    envLine('DATABASE_URL_UNPOOLED', database.url),
+    envLine('BETTER_AUTH_SECRET', secrets.auth),
+    envLine('BETTER_AUTH_URL', 'http://localhost:3000'),
+    envLine('API_KEY_ENCRYPTION_SECRET', secrets.apiKeyEncryption),
+    envLine('CRON_SECRET', secrets.cron),
+    envLine('NEXT_PUBLIC_APP_URL', 'http://localhost:3000'),
+    envLine('NEXT_PUBLIC_API_URL', 'http://localhost:3000/api'),
+    envLine('NODE_ENV', 'development'),
+  ].join('\n')}\n`;
+}
+
+export function assertEnvironmentUsesLocalDatabase(
+  contents: string,
+  database: LocalDatabaseConfig
+): void {
+  const environment = parseEnv(contents);
+  const databaseVariables = ['DATABASE_URL', 'DATABASE_URL_UNPOOLED'] as const;
+  const mismatches = databaseVariables.filter((name) => environment[name] !== database.url);
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `apps/web/.env.local already exists and ${mismatches.join(', ')} does not point at the managed local database (${database.url}). The file was not changed. Reconcile it explicitly, then rerun pnpm dev:setup.`
+    );
+  }
+}

--- a/scripts/dev-setup.test.ts
+++ b/scripts/dev-setup.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseEnv } from 'node:util';
+import {
+  assertEnvironmentUsesLocalDatabase,
+  DEFAULT_DEV_DB_PORT,
+  DEFAULT_DEV_PROJECT_NAME,
+  renderLocalWebEnvironment,
+  resolveLocalDatabaseConfig,
+} from './dev-setup-lib';
+
+test('uses an isolated, loopback-only database configuration by default', () => {
+  assert.deepEqual(resolveLocalDatabaseConfig({}), {
+    port: DEFAULT_DEV_DB_PORT,
+    projectName: DEFAULT_DEV_PROJECT_NAME,
+    url: 'postgresql://tpmjs:tpmjs@127.0.0.1:55433/tpmjs',
+  });
+});
+
+test('accepts a deliberate port and Compose project override', () => {
+  assert.deepEqual(
+    resolveLocalDatabaseConfig({
+      TPMJS_DEV_DB_PORT: '55439',
+      TPMJS_DEV_PROJECT_NAME: 'tpmjs-dev-alice',
+    }),
+    {
+      port: 55439,
+      projectName: 'tpmjs-dev-alice',
+      url: 'postgresql://tpmjs:tpmjs@127.0.0.1:55439/tpmjs',
+    }
+  );
+});
+
+test('rejects invalid ports and unsafe project names before invoking Compose', () => {
+  assert.throws(
+    () => resolveLocalDatabaseConfig({ TPMJS_DEV_DB_PORT: 'not-a-port' }),
+    /must be an integer/
+  );
+  assert.throws(
+    () => resolveLocalDatabaseConfig({ TPMJS_DEV_DB_PORT: '80' }),
+    /between 1024 and 65535/
+  );
+  assert.throws(
+    () => resolveLocalDatabaseConfig({ TPMJS_DEV_PROJECT_NAME: 'TPMJS dev' }),
+    /must start with/
+  );
+});
+
+test('renders a complete local environment with generated secrets', () => {
+  const database = resolveLocalDatabaseConfig({});
+  const rendered = renderLocalWebEnvironment(database, {
+    apiKeyEncryption: 'encryption-secret',
+    auth: 'auth-secret',
+    cron: 'cron-secret',
+  });
+  const parsed = parseEnv(rendered);
+
+  assert.equal(parsed.DATABASE_URL, database.url);
+  assert.equal(parsed.DATABASE_URL_UNPOOLED, database.url);
+  assert.equal(parsed.BETTER_AUTH_SECRET, 'auth-secret');
+  assert.equal(parsed.API_KEY_ENCRYPTION_SECRET, 'encryption-secret');
+  assert.equal(parsed.CRON_SECRET, 'cron-secret');
+  assert.equal(parsed.NEXT_PUBLIC_APP_URL, 'http://localhost:3000');
+});
+
+test('preserves compatible environments and rejects ambiguous database targets', () => {
+  const database = resolveLocalDatabaseConfig({});
+  assert.doesNotThrow(() =>
+    assertEnvironmentUsesLocalDatabase(
+      `DATABASE_URL=${database.url}\nDATABASE_URL_UNPOOLED=${database.url}\n`,
+      database
+    )
+  );
+  assert.throws(
+    () =>
+      assertEnvironmentUsesLocalDatabase(
+        'DATABASE_URL=postgresql://remote.example/tpmjs\nDATABASE_URL_UNPOOLED=postgresql://remote.example/tpmjs\n',
+        database
+      ),
+    /file was not changed/i
+  );
+  assert.throws(
+    () => assertEnvironmentUsesLocalDatabase('', database),
+    /DATABASE_URL, DATABASE_URL_UNPOOLED/
+  );
+});

--- a/scripts/dev-setup.ts
+++ b/scripts/dev-setup.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env tsx
+
+import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { constants, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  assertEnvironmentUsesLocalDatabase,
+  type LocalDatabaseConfig,
+  renderLocalWebEnvironment,
+  resolveLocalDatabaseConfig,
+} from './dev-setup-lib';
+
+type ComposeCommand = {
+  command: string;
+  prefix: string[];
+};
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const composeFile = path.join(repositoryRoot, 'compose.dev.yaml');
+const webEnvironmentFile = path.join(repositoryRoot, 'apps/web/.env.local');
+
+function commandResult(
+  command: string,
+  args: string[],
+  environment: NodeJS.ProcessEnv,
+  stdio: 'ignore' | 'inherit' | 'pipe' = 'inherit'
+) {
+  return spawnSync(command, args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    env: environment,
+    stdio,
+  });
+}
+
+function run(command: string, args: string[], environment: NodeJS.ProcessEnv, label: string): void {
+  const result = commandResult(command, args, environment);
+  if (result.error) {
+    throw new Error(`${label} could not start: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit code ${result.status ?? 'unknown'}`);
+  }
+}
+
+function detectCompose(environment: NodeJS.ProcessEnv): ComposeCommand {
+  const candidates: ComposeCommand[] = [
+    { command: 'docker', prefix: ['compose'] },
+    { command: 'podman', prefix: ['compose'] },
+  ];
+  for (const candidate of candidates) {
+    const composeResult = commandResult(
+      candidate.command,
+      [...candidate.prefix, 'version'],
+      environment,
+      'ignore'
+    );
+    const engineResult = commandResult(candidate.command, ['info'], environment, 'ignore');
+    if (
+      !composeResult.error &&
+      composeResult.status === 0 &&
+      !engineResult.error &&
+      engineResult.status === 0
+    ) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    'Docker Compose v2 or Podman Compose is required. Install one, start its container engine, and rerun pnpm dev:setup.'
+  );
+}
+
+function generatedSecret(bytes = 32): string {
+  return randomBytes(bytes).toString('base64url');
+}
+
+function ensureWebEnvironment(database: LocalDatabaseConfig): 'created' | 'preserved' {
+  if (existsSync(webEnvironmentFile)) {
+    assertEnvironmentUsesLocalDatabase(readFileSync(webEnvironmentFile, 'utf8'), database);
+    return 'preserved';
+  }
+
+  const contents = renderLocalWebEnvironment(database, {
+    apiKeyEncryption: generatedSecret(),
+    auth: generatedSecret(),
+    cron: randomBytes(32).toString('hex'),
+  });
+  try {
+    writeFileSync(webEnvironmentFile, contents, { flag: 'wx', mode: 0o600 });
+    return 'created';
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    assertEnvironmentUsesLocalDatabase(readFileSync(webEnvironmentFile, 'utf8'), database);
+    return 'preserved';
+  }
+}
+
+function composeArgs(compose: ComposeCommand, args: string[]): string[] {
+  return [...compose.prefix, '--file', composeFile, ...args];
+}
+
+async function waitForDatabase(
+  compose: ComposeCommand,
+  environment: NodeJS.ProcessEnv
+): Promise<void> {
+  for (let attempt = 1; attempt <= 60; attempt += 1) {
+    const result = commandResult(
+      compose.command,
+      composeArgs(compose, [
+        'exec',
+        '--no-TTY',
+        'postgres',
+        'pg_isready',
+        '--username=tpmjs',
+        '--dbname=tpmjs',
+      ]),
+      environment,
+      'pipe'
+    );
+    if (!result.error && result.status === 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  commandResult(
+    compose.command,
+    composeArgs(compose, ['logs', '--no-color', '--tail=100', 'postgres']),
+    environment
+  );
+  throw new Error('Local PostgreSQL did not become ready within 30 seconds');
+}
+
+async function main(): Promise<void> {
+  if (process.argv.length > 2) {
+    throw new Error('pnpm dev:setup does not accept positional arguments');
+  }
+  await access(path.join(repositoryRoot, 'node_modules'), constants.R_OK).catch(() => {
+    throw new Error('Dependencies are not installed. Run pnpm install, then pnpm dev:setup.');
+  });
+
+  const database = resolveLocalDatabaseConfig(process.env);
+  const childEnvironment = {
+    ...process.env,
+    DATABASE_URL: database.url,
+    DATABASE_URL_UNPOOLED: database.url,
+    TPMJS_DEV_DB_PORT: String(database.port),
+    TPMJS_DEV_PROJECT_NAME: database.projectName,
+  };
+  const compose = detectCompose(childEnvironment);
+  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  const environmentStatus = ensureWebEnvironment(database);
+
+  console.log(`Local environment ${environmentStatus}: apps/web/.env.local`);
+  console.log(`Starting PostgreSQL on 127.0.0.1:${database.port}...`);
+  run(
+    compose.command,
+    composeArgs(compose, ['config', '--quiet']),
+    childEnvironment,
+    'Compose validation'
+  );
+  run(
+    compose.command,
+    composeArgs(compose, ['up', '--detach', 'postgres']),
+    childEnvironment,
+    'PostgreSQL startup'
+  );
+  await waitForDatabase(compose, childEnvironment);
+
+  console.log('Applying the checked-in migration history...');
+  run(
+    pnpmCommand,
+    ['--filter=@tpmjs/db', 'db:migrate:deploy'],
+    childEnvironment,
+    'Database migration'
+  );
+  run(
+    pnpmCommand,
+    ['--filter=@tpmjs/db', 'db:generate'],
+    childEnvironment,
+    'Prisma client generation'
+  );
+  console.log('Seeding the offline starter registry...');
+  run(pnpmCommand, ['--filter=@tpmjs/db', 'db:seed'], childEnvironment, 'Database seed');
+  run(
+    pnpmCommand,
+    ['--filter=@tpmjs/db', 'db:verify-counter-invariants'],
+    childEnvironment,
+    'Database invariant verification'
+  );
+
+  console.log('\nTPMJS development is ready.');
+  console.log('Start the web app with: pnpm --filter=@tpmjs/web dev');
+  console.log(`Local database: ${database.url}`);
+  console.log(
+    'Your database volume is persistent; rerunning pnpm dev:setup is safe and idempotent.'
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(`dev:setup failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- add an isolated, loopback-only PostgreSQL 17 Compose service with a persistent named volume
- add `pnpm dev:setup` with Docker/Podman detection, generated local secrets, checked-in migrations, atomic idempotent seed data, and counter-invariant verification
- seed the real `@tpmjs/hello` package so a fresh registry renders useful tool pages without a network sync
- document the one-command and manual workflows, and validate the Compose/test contracts in CI

The original issue assumed pgvector, but the current Prisma schema stores embeddings as JSONB and has no vector extension or vector columns. This intentionally matches the real PostgreSQL 17 production topology.

## Verification

- fresh database: all 7 migrations applied
- idempotent rerun: 0 pending migrations; env checksum and named volume preserved
- durable state: 1 package, 2 tools, 3 checkpoints; registry counter invariants pass
- browser: homepage and `helloWorldTool` detail page render from the seeded database with zero browser errors
- `pnpm dev:setup:test` (5/5)
- `pnpm type-check` (238/238 tasks)
- `pnpm type-coverage` (99.13%)
- `pnpm test` (1,079 passed, 12 intentional skips)
- `pnpm lint`, `pnpm format:check`, `pnpm find-deadcode`, `pnpm check-architecture`

Closes #123