### PR TITLE
feat(tool): make every access surface executable

### DIFF
--- a/.changeset/swift-tools-execute.md
+++ b/.changeset/swift-tools-execute.md
@@ -1,0 +1,9 @@
+---
+'@tpmjs/cli': patch
+'@tpmjs/ui': patch
+---
+
+Route `tpm tool execute` through the canonical registry execution contract, accept
+stable `package::toolName` identifiers, reject ambiguous legacy names, honor the
+configured timeout, and expose registry tools safely from the local MCP server.
+Tabs now implement roving focus plus Arrow, Home, and End keyboard navigation.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ See [HOW_TO_PUBLISH_A_TOOL.md](./HOW_TO_PUBLISH_A_TOOL.md) for the full publishi
 ```bash
 npm install -g @tpmjs/cli
 
-tpmjs tool search "csv parser"
-tpmjs tool execute @tpmjs/tools-csv-parse --input '{"csv":"name,role\nAda,engineer"}'
-tpmjs tool trending
+tpm tool search "csv parser"
+tpm tool execute '@tpmjs/tools-csv-parse::csvParseTool' --input '{"csv":"name,role\nAda,engineer"}'
+tpm tool trending
 ```
 
 ### Connect via MCP

--- a/apps/web/src/app/docs/cli/page.tsx
+++ b/apps/web/src/app/docs/cli/page.tsx
@@ -58,7 +58,7 @@ tpm tool trending
 tpm tool info @tpmjs/official-firecrawl scrapeTool
 
 # Execute a tool
-tpm tool execute firecrawl-scrape --input '{"url":"https://example.com"}'
+tpm tool execute '@tpmjs/official-firecrawl::scrapeTool' --input '{"url":"https://example.com"}'
 
 # Generate MCP config for your AI client
 tpm mcp config ajax/my-collection`}
@@ -209,13 +209,13 @@ tpm tool info @tpmjs/official-firecrawl scrapeTool`}
           </div>
           <CodeBlock
             code={`# Execute with inline JSON
-tpm tool execute firecrawl-scrape --input '{"url":"https://example.com"}'
+tpm tool execute '@tpmjs/official-firecrawl::scrapeTool' --input '{"url":"https://example.com"}'
 
 # Execute with input from file
-tpm tool execute my-tool --input-file params.json
+tpm tool execute '@scope/package::toolName' --input-file params.json
 
 # Stream results
-tpm tool execute my-tool --stream`}
+tpm tool execute '@scope/package::toolName' --stream`}
             language="bash"
             showCopy={true}
           />

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -444,7 +444,7 @@ tpm auth login
 tpm tool search firecrawl
 
 # Execute a tool
-tpm tool execute firecrawl-scrape --input '{"url":"https://example.com"}'
+tpm tool execute '@tpmjs/official-firecrawl::scrapeTool' --input '{"url":"https://example.com"}'
 
 # Show trending tools
 tpm tool trending`}
@@ -476,13 +476,13 @@ tpm tool search [query]
 tpm tool info <package> <tool>
 
 # Execute with JSON input
-tpm tool execute <tool> --input '{"key":"value"}'
+tpm tool execute '@scope/package::toolName' --input '{"key":"value"}'
 
 # Execute with input from file
-tpm tool execute <tool> --input-file params.json
+tpm tool execute '@scope/package::toolName' --input-file params.json
 
 # Stream results
-tpm tool execute <tool> --stream
+tpm tool execute '@scope/package::toolName' --stream
 
 # Initialize a new tool package
 tpm tool init my-tool --template rich
@@ -1438,9 +1438,9 @@ export TPMJS_EXECUTOR_URL=https://executor.mycompany.com`}
                 </p>
                 <CodeBlock
                   language="bash"
-                  code={`claude mcp add tpmjs-my-collection \\
-  https://tpmjs.com/@<username>/collections/<collection-slug>/mcp \\
-  -t http -H "Authorization: Bearer YOUR_TPMJS_API_KEY"`}
+                  code={`claude mcp add --transport http tpmjs-my-collection \\
+  https://tpmjs.com/api/mcp/<username>/<collection-slug>/http \\
+  --header "Authorization: Bearer $TPMJS_API_KEY"`}
                 />
                 <p className="text-foreground-secondary mt-4">
                   This automatically adds the server to your Claude Code configuration.

--- a/apps/web/src/app/docs/platform-guide/page.tsx
+++ b/apps/web/src/app/docs/platform-guide/page.tsx
@@ -801,9 +801,9 @@ Invalid usernames:
               <DocSubSection title="Claude Code CLI">
                 <CodeBlock
                   language="bash"
-                  code={`claude mcp add tpmjs-my-collection \\
-  https://tpmjs.com/@YOUR_USERNAME/collections/YOUR_COLLECTION_SLUG/mcp \\
-  -t http -H "Authorization: Bearer YOUR_TPMJS_API_KEY"`}
+                  code={`claude mcp add --transport http tpmjs-my-collection \\
+  https://tpmjs.com/api/mcp/YOUR_USERNAME/YOUR_COLLECTION_SLUG/http \\
+  --header "Authorization: Bearer $TPMJS_API_KEY"`}
                 />
               </DocSubSection>
             </DocSection>

--- a/apps/web/src/app/tool/[...slug]/ToolDetailClient.tsx
+++ b/apps/web/src/app/tool/[...slug]/ToolDetailClient.tsx
@@ -8,7 +8,6 @@ import { Container } from '@tpmjs/ui/Container/Container';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
 import { ProgressBar } from '@tpmjs/ui/ProgressBar/ProgressBar';
 import { Spinner } from '@tpmjs/ui/Spinner/Spinner';
-import { Tabs } from '@tpmjs/ui/Tabs/Tabs';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { AppHeader } from '~/components/AppHeader';
@@ -18,8 +17,9 @@ import { LikeButton } from '~/components/LikeButton';
 import { Markdown } from '~/components/Markdown';
 import { Rating } from '~/components/Rating';
 import { ToolPlayground } from '~/components/ToolPlayground';
+import { ToolSurfaceSwitcher } from '~/components/ToolSurfaceSwitcher';
 import { useTrackView } from '~/hooks/useTrackView';
-import { type InstallSurface, trackEvent, trackInstallCommandCopy } from '~/lib/analytics';
+import { trackEvent } from '~/lib/analytics';
 import {
   isPersistentlyImportBroken,
   PERSISTENT_IMPORT_FAILURE_THRESHOLD,
@@ -99,7 +99,6 @@ interface ToolDetailClientProps {
 export function ToolDetailClient({ tool, slug }: ToolDetailClientProps): React.ReactElement {
   const [recheckLoading, setRecheckLoading] = useState(false);
   const [extractSchemaLoading, setExtractSchemaLoading] = useState(false);
-  const [surface, setSurface] = useState<InstallSurface>('sdk');
 
   // Track page view
   useTrackView('tool', tool.id);
@@ -388,146 +387,11 @@ export function ToolDetailClient({ tool, slug }: ToolDetailClientProps): React.R
             {/* biome-ignore lint/suspicious/noExplicitAny: Prisma Tool type compatibility with component props */}
             <ToolPlayground tool={tool as any} />
 
-            {/* Use this tool — every surface */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Use this tool</CardTitle>
-                <CardDescription>
-                  One tool, every surface — SDK, MCP, REST, CLI, or Skill. Pick the one that fits
-                  where your agent runs.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <Tabs
-                  tabs={[
-                    { id: 'sdk', label: 'SDK' },
-                    { id: 'mcp', label: 'MCP' },
-                    { id: 'rest', label: 'REST' },
-                    { id: 'cli', label: 'CLI' },
-                    { id: 'skill', label: 'Skill' },
-                  ]}
-                  activeTab={surface}
-                  onTabChange={(id) => {
-                    const next = id as InstallSurface;
-                    setSurface(next);
-                    trackEvent('install_surface', {
-                      surface: next,
-                      tool: toolAnalyticsId,
-                    });
-                  }}
-                />
-
-                {surface === 'sdk' && (
-                  <div className="space-y-4">
-                    <p className="text-sm text-foreground-secondary">
-                      Install the package and pass the tool straight to the Vercel AI SDK.
-                    </p>
-                    <CodeBlock
-                      code={`npm install ${pkg.npmPackageName}`}
-                      language="bash"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                    <CodeBlock
-                      code={`import { generateText } from 'ai';
-import { openai } from '@ai-sdk/openai';
-import { ${tool.name} } from '${pkg.npmPackageName}';
-
-const result = await generateText({
-  model: openai('gpt-4o'),
-  tools: { ${tool.name} },
-  prompt: 'Your prompt here...',
-});`}
-                      language="typescript"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                    <p className="text-xs text-foreground-tertiary">
-                      Prefer no install? Load it from the registry with <code>@tpmjs/compose</code>:{' '}
-                      <code>{`fromRegistry('${pkg.npmPackageName}::${tool.name}')`}</code>.
-                    </p>
-                  </div>
-                )}
-
-                {surface === 'mcp' && (
-                  <div className="space-y-4">
-                    <p className="text-sm text-foreground-secondary">
-                      Add the TPMJS registry as one MCP server; your agent then calls this tool by
-                      id via <code>execute_tool</code>.
-                    </p>
-                    <CodeBlock
-                      code={`claude mcp add tpmjs-registry \\
-  https://tpmjs.com/api/mcp/registry/http -t http`}
-                      language="bash"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                    <CodeBlock
-                      code={`{ "toolId": "${pkg.npmPackageName}::${tool.name}", "params": { /* see Parameters */ } }`}
-                      language="json"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                  </div>
-                )}
-
-                {surface === 'rest' && (
-                  <div className="space-y-4">
-                    <p className="text-sm text-foreground-secondary">
-                      Call the tool over plain HTTP — no SDK, and no signup for public tools.
-                    </p>
-                    <CodeBlock
-                      code={`curl -s https://tpmjs.com/api/registry/execute \\
-  -H 'content-type: application/json' \\
-  -d '{"toolId":"${pkg.npmPackageName}::${tool.name}","params":{}}'`}
-                      language="bash"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                  </div>
-                )}
-
-                {surface === 'cli' && (
-                  <div className="space-y-4">
-                    <p className="text-sm text-foreground-secondary">
-                      Use the <code>tpm</code> command line (from <code>@tpmjs/cli</code>).
-                    </p>
-                    <CodeBlock
-                      code={`npm install -g @tpmjs/cli`}
-                      language="bash"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                    <CodeBlock
-                      code={`tpm tool info ${pkg.npmPackageName} ${tool.name}
-tpm tool execute ${tool.name} --input '{}'`}
-                      language="bash"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                  </div>
-                )}
-
-                {surface === 'skill' && (
-                  <div className="space-y-4">
-                    <p className="text-sm text-foreground-secondary">
-                      Add this tool to a{' '}
-                      <Link href="/collections" className="text-primary hover:underline">
-                        collection
-                      </Link>{' '}
-                      — each collection is served as a live <strong>Skill</strong> endpoint your
-                      agent can query to learn how and when to use its tools, not just call them.
-                    </p>
-                    <CodeBlock
-                      code={`GET https://tpmjs.com/@<user>/collections/<slug>/skills`}
-                      language="bash"
-                      showCopy={true}
-                      onCopy={() => trackInstallCommandCopy(toolAnalyticsId, surface)}
-                    />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+            <ToolSurfaceSwitcher
+              packageName={pkg.npmPackageName}
+              toolName={tool.name}
+              analyticsToolId={toolAnalyticsId}
+            />
 
             {/* AI Agent Information */}
             {tool.aiAgent && (

--- a/apps/web/src/components/ToolSurfaceSwitcher.test.ts
+++ b/apps/web/src/components/ToolSurfaceSwitcher.test.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('ToolSurfaceSwitcher', () => {
+  it('renders an accessible five-tab contract with CLI as the initial surface', async () => {
+    // The web Vitest config preserves JSX without Next's automatic runtime.
+    vi.stubGlobal('React', React);
+    const { ToolSurfaceSwitcher } = await import('./ToolSurfaceSwitcher');
+    const html = renderToStaticMarkup(
+      React.createElement(ToolSurfaceSwitcher, {
+        packageName: '@example/agent-tools',
+        toolName: 'searchWeb',
+        analyticsToolId: 'tool-1',
+      })
+    );
+
+    expect(html).toContain('aria-label="Tool access surface"');
+    expect(html.match(/role="tab"/g)).toHaveLength(5);
+    expect(html).toContain('role="tabpanel"');
+    expect(html).toContain('aria-labelledby="tab-cli"');
+    expect(html).toContain('@example/agent-tools::searchWeb');
+    expect(html).toContain('Terminal agents and local automation');
+    expect(html).not.toContain('execute_tool arguments');
+  });
+});

--- a/apps/web/src/components/ToolSurfaceSwitcher.test.ts
+++ b/apps/web/src/components/ToolSurfaceSwitcher.test.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+// eslint-disable-next-line import/no-internal-modules -- React documents this entry point for server rendering.
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/apps/web/src/components/ToolSurfaceSwitcher.tsx
+++ b/apps/web/src/components/ToolSurfaceSwitcher.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@tpmjs/ui/Card/Card';
+import { CodeBlock } from '@tpmjs/ui/CodeBlock/CodeBlock';
+import { Tabs } from '@tpmjs/ui/Tabs/Tabs';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { trackEvent, trackInstallCommandCopy } from '~/lib/analytics';
+import {
+  buildToolSurfaces,
+  type ToolSurfaceDefinition,
+  type ToolSurfaceId,
+} from '~/lib/tool-surfaces';
+
+interface ToolSurfaceSwitcherProps {
+  packageName: string;
+  toolName: string;
+  analyticsToolId: string;
+}
+
+function isToolSurfaceId(id: string, surfaces: ToolSurfaceDefinition[]): id is ToolSurfaceId {
+  return surfaces.some((surface) => surface.id === id);
+}
+
+export function ToolSurfaceSwitcher({
+  packageName,
+  toolName,
+  analyticsToolId,
+}: ToolSurfaceSwitcherProps): React.ReactElement {
+  const surfaces = useMemo(
+    () => buildToolSurfaces({ packageName, toolName }),
+    [packageName, toolName]
+  );
+  const [activeId, setActiveId] = useState<ToolSurfaceId>('cli');
+  const activeSurface = surfaces.find((surface) => surface.id === activeId) ?? surfaces[0];
+  if (!activeSurface) throw new Error('Tool surface contract is empty');
+
+  const selectSurface = (id: string): void => {
+    if (!isToolSurfaceId(id, surfaces)) return;
+    setActiveId(id);
+    trackEvent('install_surface', { surface: id, tool: analyticsToolId });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <p className="font-mono text-xs uppercase tracking-[0.16em] text-primary">
+          One tool · five surfaces
+        </p>
+        <CardTitle>Use this tool</CardTitle>
+        <CardDescription>
+          Choose where your agent runs. Every example targets the same canonical registry tool.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Tabs
+          tabs={surfaces.map(({ id, label }) => ({ id, label }))}
+          activeTab={activeSurface.id}
+          onTabChange={selectSurface}
+          aria-label="Tool access surface"
+          size="sm"
+        />
+
+        <section
+          id={`tabpanel-${activeSurface.id}`}
+          role="tabpanel"
+          aria-labelledby={`tab-${activeSurface.id}`}
+          className="space-y-4 rounded-sm border border-border-subtle bg-background-secondary/30 p-4"
+        >
+          <div className="space-y-1">
+            <p className="font-mono text-[11px] uppercase tracking-wider text-foreground-tertiary">
+              Best for · {activeSurface.bestFor}
+            </p>
+            <p className="text-sm text-foreground-secondary">{activeSurface.description}</p>
+          </div>
+
+          {activeSurface.snippets.map((snippet) => (
+            <div key={snippet.label} className="space-y-2">
+              <p className="font-mono text-xs text-foreground-tertiary">{snippet.label}</p>
+              <CodeBlock
+                code={snippet.code}
+                language={snippet.language}
+                showCopy={true}
+                onCopy={() =>
+                  trackInstallCommandCopy(analyticsToolId, activeSurface.id, snippet.label)
+                }
+              />
+            </div>
+          ))}
+
+          {activeSurface.id === 'skill' && (
+            <Link
+              href="/collections"
+              className="inline-flex font-mono text-xs text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Browse collections →
+            </Link>
+          )}
+
+          {activeSurface.note && (
+            <p className="text-xs leading-relaxed text-foreground-tertiary">{activeSurface.note}</p>
+          )}
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/home/ProtocolSection.tsx
+++ b/apps/web/src/components/home/ProtocolSection.tsx
@@ -39,7 +39,7 @@ const claudeCodePrompts = [
   },
   {
     label: 'search & execute',
-    text: 'Use `tpm tool search "weather"` to find weather tools on TPMJS, pick the best one, then run it with `tpm tool execute <package>/<tool> --input \'{"city":"London"}\'` to get the current weather.',
+    text: 'Use `tpm tool search "weather"` to find weather tools on TPMJS, pick the best one, then run its canonical ID with `tpm tool execute \'<package>::<toolName>\' --input \'{"city":"London"}\'`.',
   },
 ];
 
@@ -155,7 +155,8 @@ function ProtocolCard({
 
 export function ProtocolSection() {
   const [active, setActive] = useState<Protocol>('cli');
-  const activeProtocol = protocols.find((p) => p.id === active)!;
+  const activeProtocol = protocols.find((p) => p.id === active) ?? protocols[0];
+  if (!activeProtocol) throw new Error('Protocol contract is empty');
 
   return (
     <section className="py-20 bg-background border-t border-border">

--- a/apps/web/src/lib/analytics.test.ts
+++ b/apps/web/src/lib/analytics.test.ts
@@ -36,14 +36,17 @@ describe('activation-funnel analytics', () => {
     const track = vi.fn();
     vi.stubGlobal('window', { umami: { track } });
 
-    trackInstallCommandCopy('tool-id', 'mcp');
+    trackInstallCommandCopy('tool-id', 'mcp', 'Connect with Claude Code');
     trackPlaygroundExecution('tool-id', 'success');
     trackCollectionMcpCopy('collection-id', 'http_url');
     trackSignup('started');
     trackSignup('completed');
 
     expect(track.mock.calls).toEqual([
-      ['install_command_copy', { tool: 'tool-id', surface: 'mcp' }],
+      [
+        'install_command_copy',
+        { tool: 'tool-id', surface: 'mcp', snippet: 'Connect with Claude Code' },
+      ],
       ['playground_execute', { tool: 'tool-id', outcome: 'success' }],
       ['collection_mcp_copy', { collection: 'collection-id', format: 'http_url' }],
       ['signup_started', { method: 'email' }],

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,3 +1,5 @@
+import type { ToolSurfaceId } from './tool-surfaces';
+
 /**
  * Emit a custom Umami event for the activation funnel (search → view → use).
  *
@@ -7,7 +9,7 @@
  */
 type UmamiApi = { track?: (name: string, data?: Record<string, unknown>) => void };
 
-export type InstallSurface = 'sdk' | 'mcp' | 'rest' | 'cli' | 'skill';
+export type InstallSurface = ToolSurfaceId;
 export type PlaygroundOutcome = 'success' | 'failure';
 
 export function trackEvent(name: string, data?: Record<string, unknown>): void {
@@ -21,8 +23,12 @@ export function trackEvent(name: string, data?: Record<string, unknown>): void {
 }
 
 /** Record a successful copy without sending the copied command itself. */
-export function trackInstallCommandCopy(tool: string, surface: InstallSurface): void {
-  trackEvent('install_command_copy', { tool, surface });
+export function trackInstallCommandCopy(
+  tool: string,
+  surface: InstallSurface,
+  snippet?: string
+): void {
+  trackEvent('install_command_copy', { tool, surface, ...(snippet && { snippet }) });
 }
 
 /** Record only the terminal outcome; prompts, output, and errors stay private. */

--- a/apps/web/src/lib/tool-surfaces.test.ts
+++ b/apps/web/src/lib/tool-surfaces.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildToolSurfaces, TOOL_SURFACE_IDS } from './tool-surfaces';
+
+const packageName = '@example/agent-tools';
+const toolName = 'search-web';
+const surfaces = buildToolSurfaces({ packageName, toolName });
+
+function surface(id: (typeof TOOL_SURFACE_IDS)[number]) {
+  const match = surfaces.find((candidate) => candidate.id === id);
+  if (!match) throw new Error(`Missing ${id} surface`);
+  return match;
+}
+
+describe('buildToolSurfaces', () => {
+  it('returns each product surface exactly once in activation order', () => {
+    expect(surfaces.map(({ id }) => id)).toEqual(TOOL_SURFACE_IDS);
+    expect(new Set(surfaces.map(({ id }) => id)).size).toBe(5);
+  });
+
+  it('uses the canonical tool ID for CLI and REST execution', () => {
+    expect(surface('cli').snippets[1]?.code).toContain(
+      "tpm tool execute '@example/agent-tools::search-web'"
+    );
+    expect(surface('rest').snippets[0]?.code).toContain(
+      `'${JSON.stringify({ toolId: '@example/agent-tools::search-web', params: {} })}'`
+    );
+  });
+
+  it('renders the actual MCP execute_tool argument schema and authenticated setup', () => {
+    expect(surface('mcp').snippets[0]?.code).toContain('claude mcp add --transport http');
+    expect(surface('mcp').snippets[0]?.code).toContain('Authorization: Bearer $TPMJS_API_KEY');
+    expect(JSON.parse(surface('mcp').snippets[1]?.code ?? '{}')).toEqual({
+      packageName,
+      toolName,
+      arguments: {},
+    });
+  });
+
+  it('loads arbitrary export names safely through the registry SDK adapter', () => {
+    const sdkCode = surface('sdk').snippets[1]?.code;
+    expect(sdkCode).toContain("fromRegistry('@example/agent-tools::search-web')");
+    expect(sdkCode).not.toContain('import { search-web }');
+  });
+
+  it('points portable skills at the markdown artifact, not the conversational endpoint', () => {
+    expect(surface('skill').snippets[0]?.code).toBe(
+      'https://tpmjs.com/@<user>/collections/<slug>/skills.md'
+    );
+  });
+});

--- a/apps/web/src/lib/tool-surfaces.ts
+++ b/apps/web/src/lib/tool-surfaces.ts
@@ -1,0 +1,138 @@
+export const TOOL_SURFACE_IDS = ['cli', 'mcp', 'rest', 'sdk', 'skill'] as const;
+
+export type ToolSurfaceId = (typeof TOOL_SURFACE_IDS)[number];
+
+export interface ToolSurfaceSnippet {
+  label: string;
+  language: 'bash' | 'json' | 'typescript';
+  code: string;
+}
+
+export interface ToolSurfaceDefinition {
+  id: ToolSurfaceId;
+  label: string;
+  bestFor: string;
+  description: string;
+  snippets: ToolSurfaceSnippet[];
+  note?: string;
+}
+
+export interface ToolSurfaceInput {
+  packageName: string;
+  toolName: string;
+}
+
+/**
+ * Build the copy-paste contract for every supported TPMJS access surface.
+ *
+ * Keep this data-only: the same definitions can be tested without a browser and
+ * rendered by any future tool-detail experience.
+ */
+export function buildToolSurfaces({
+  packageName,
+  toolName,
+}: ToolSurfaceInput): ToolSurfaceDefinition[] {
+  const toolId = `${packageName}::${toolName}`;
+
+  return [
+    {
+      id: 'cli',
+      label: 'CLI',
+      bestFor: 'Terminal agents and local automation',
+      description: 'Execute the canonical registry tool ID from any shell.',
+      snippets: [
+        {
+          label: 'Install once',
+          language: 'bash',
+          code: 'npm install --global @tpmjs/cli',
+        },
+        {
+          label: 'Execute',
+          language: 'bash',
+          code: `tpm tool execute '${toolId}' --input '{}'`,
+        },
+      ],
+      note: 'Public tools can be executed without signing in, subject to the public rate limit.',
+    },
+    {
+      id: 'mcp',
+      label: 'MCP',
+      bestFor: 'Long-lived agents and MCP clients',
+      description: 'Connect once, then discover and execute registry tools through two meta-tools.',
+      snippets: [
+        {
+          label: 'Connect with Claude Code',
+          language: 'bash',
+          code: `claude mcp add --transport http tpmjs-registry \\
+  https://tpmjs.com/api/mcp/registry/http \\
+  --header "Authorization: Bearer $TPMJS_API_KEY"`,
+        },
+        {
+          label: 'execute_tool arguments',
+          language: 'json',
+          code: JSON.stringify(
+            {
+              packageName,
+              toolName,
+              arguments: {},
+            },
+            null,
+            2
+          ),
+        },
+      ],
+      note: 'Execution requires a TPMJS API key with the mcp:execute scope; discovery remains public.',
+    },
+    {
+      id: 'rest',
+      label: 'REST',
+      bestFor: 'Services in any language',
+      description: 'Call the hosted executor over plain HTTP with no TPMJS SDK.',
+      snippets: [
+        {
+          label: 'POST /api/registry/execute',
+          language: 'bash',
+          code: `curl --silent --show-error https://tpmjs.com/api/registry/execute \\
+  --header 'content-type: application/json' \\
+  --data '${JSON.stringify({ toolId, params: {} })}'`,
+        },
+      ],
+      note: 'Authentication is optional for public tools and raises the execution rate limit.',
+    },
+    {
+      id: 'sdk',
+      label: 'SDK',
+      bestFor: 'TypeScript agent applications',
+      description: 'Resolve an AI SDK-compatible tool from the registry at runtime.',
+      snippets: [
+        {
+          label: 'Install',
+          language: 'bash',
+          code: 'pnpm add @tpmjs/compose ai',
+        },
+        {
+          label: 'Load from the registry',
+          language: 'typescript',
+          code: `import { fromRegistry } from '@tpmjs/compose/adapters/registry';
+
+const tool = await fromRegistry('${toolId}');`,
+        },
+      ],
+      note: "The adapter preserves the registry schema and executes in TPMJS's isolated executor.",
+    },
+    {
+      id: 'skill',
+      label: 'Skill',
+      bestFor: 'Portable agent context',
+      description: 'Add the tool to a collection, then give an agent its generated skill document.',
+      snippets: [
+        {
+          label: 'Collection skill document',
+          language: 'bash',
+          code: 'https://tpmjs.com/@<user>/collections/<slug>/skills.md',
+        },
+      ],
+      note: 'Skills are collection-level: they teach when and how tools work together, not only how to call one export.',
+    },
+  ];
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,7 +24,7 @@ tpm tool trending
 tpm tool info @tpmjs/official-firecrawl scrapeTool
 
 # Execute a tool
-tpm tool execute firecrawl-scrape --input '{"url":"https://example.com"}'
+tpm tool execute '@tpmjs/official-firecrawl::scrapeTool' --input '{"url":"https://example.com"}'
 
 # Generate MCP config for your AI client
 tpm mcp config ajax/my-collection
@@ -65,11 +65,10 @@ tpm tool info <package> <tool>    # Get detailed tool information
 Run a tool directly from the registry:
 
 ```bash
-tpm tool execute <tool>                              # Execute a tool
-tpm tool execute my-tool --input '{"key":"value"}'   # With JSON input
-tpm tool execute my-tool --input-file params.json    # Input from file
-tpm tool execute my-tool --stream                    # Stream output
-tpm tool execute my-tool --timeout 60                # Custom timeout (default: 300s)
+tpm tool execute '@scope/package::toolName' --input '{"key":"value"}' # Execute with JSON input
+tpm tool execute '@scope/package::toolName' --input-file params.json  # Read input from a file
+tpm tool execute '@scope/package::toolName' --stream                 # Stream-compatible output
+tpm tool execute '@scope/package::toolName' --timeout 60             # Custom timeout (default: 300s)
 ```
 
 Input can also be piped via stdin.

--- a/packages/cli/src/commands/mcp/serve.ts
+++ b/packages/cli/src/commands/mcp/serve.ts
@@ -1,7 +1,8 @@
+import { createHash } from 'node:crypto';
 import * as http from 'node:http';
 import * as readline from 'node:readline';
 import { Command, Flags } from '@oclif/core';
-import { getClient } from '../../lib/api-client.js';
+import { canonicalToolId, getClient, type Tool } from '../../lib/api-client.js';
 import { createOutput } from '../../lib/output.js';
 
 interface MCPRequest {
@@ -20,6 +21,18 @@ interface MCPResponse {
     message: string;
     data?: unknown;
   };
+}
+
+interface ServedTool {
+  registryId: string;
+  tool: Tool;
+}
+
+/** Produce a spec-safe, readable, collision-resistant MCP tool name. */
+function mcpToolName(tool: Tool, registryId: string): string {
+  const readable = tool.name.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 100) || 'tool';
+  const suffix = createHash('sha256').update(registryId).digest('hex').slice(0, 8);
+  return `${readable}__${suffix}`;
 }
 
 export default class MCPServe extends Command {
@@ -59,7 +72,33 @@ export default class MCPServe extends Command {
   };
 
   private client = getClient();
-  private tools: Map<string, unknown> = new Map();
+  private tools = new Map<string, ServedTool>();
+
+  private registerTool(tool: Tool): void {
+    const registryId = canonicalToolId(tool);
+    if (!registryId) return;
+    this.tools.set(mcpToolName(tool, registryId), { registryId, tool });
+  }
+
+  private async selectTools(flags: { collection?: string; tool?: string[] }): Promise<Tool[]> {
+    if (flags.collection) {
+      const collectionId = await this.client.resolveCollectionId(flags.collection);
+      const response = await this.client.getCollection(collectionId);
+      return response.data?.tools?.map(({ tool }) => tool) ?? [];
+    }
+
+    if (flags.tool && flags.tool.length > 0) {
+      const responses = await Promise.all(
+        flags.tool.map((toolId) => this.client.getToolBySlug(toolId))
+      );
+      return responses.flatMap((response) =>
+        response.success && response.data ? [response.data] : []
+      );
+    }
+
+    const response = await this.client.getTrendingTools({ limit: 10 });
+    return response.data ?? [];
+  }
 
   async run(): Promise<void> {
     const { flags } = await this.parse(MCPServe);
@@ -82,32 +121,8 @@ export default class MCPServe extends Command {
     const spinner = output.spinner('Loading tools...');
 
     try {
-      if (flags.collection) {
-        // Load tools from collection - search for tools with collection filter
-        // For now, just load trending tools if collection specified
-        const response = await this.client.getTrendingTools({ limit: 20 });
-        if (response.data && response.data.length > 0) {
-          for (const tool of response.data) {
-            this.tools.set(tool.slug, tool);
-          }
-        }
-      } else if (flags.tool && flags.tool.length > 0) {
-        // Load specific tools by slug
-        for (const toolId of flags.tool) {
-          const response = await this.client.getToolBySlug(toolId);
-          if (response.success && response.data) {
-            this.tools.set(response.data.slug, response.data);
-          }
-        }
-      } else {
-        // Load trending tools as default
-        const response = await this.client.getTrendingTools({ limit: 10 });
-        if (response.data && response.data.length > 0) {
-          for (const tool of response.data) {
-            this.tools.set(tool.slug, tool);
-          }
-        }
-      }
+      const selectedTools = await this.selectTools(flags);
+      for (const tool of selectedTools) this.registerTool(tool);
 
       spinner.stop();
       output.info(`Loaded ${this.tools.size} tool(s)`);
@@ -235,10 +250,10 @@ export default class MCPServe extends Command {
           jsonrpc: '2.0',
           id,
           result: {
-            tools: Array.from(this.tools.entries()).map(([slug, tool]) => ({
-              name: slug,
-              description: (tool as Record<string, unknown>).description || '',
-              inputSchema: (tool as Record<string, unknown>).inputSchema || {
+            tools: Array.from(this.tools.entries()).map(([name, served]) => ({
+              name,
+              description: served.tool.description || '',
+              inputSchema: served.tool.inputSchema || {
                 type: 'object',
                 properties: {},
               },
@@ -262,7 +277,16 @@ export default class MCPServe extends Command {
         }
 
         try {
-          const response = await this.client.executeTool(toolName, toolArgs || {});
+          const served = this.tools.get(toolName);
+          if (!served) {
+            return {
+              jsonrpc: '2.0',
+              id,
+              error: { code: -32602, message: `Unknown tool: ${toolName}` },
+            };
+          }
+
+          const response = await this.client.executeTool(served.registryId, toolArgs || {});
           return {
             jsonrpc: '2.0',
             id,

--- a/packages/cli/src/commands/playground.ts
+++ b/packages/cli/src/commands/playground.ts
@@ -1,6 +1,6 @@
 import * as readline from 'node:readline';
 import { Command, Flags } from '@oclif/core';
-import { getClient } from '../lib/api-client.js';
+import { canonicalToolId, getClient } from '../lib/api-client.js';
 import { createOutput } from '../lib/output.js';
 
 export default class Playground extends Command {
@@ -79,36 +79,7 @@ export default class Playground extends Command {
     const prompt = () => {
       const prefix = this.selectedTool ? `[${this.selectedTool}]` : '[no tool]';
       this.rl?.question(`${prefix} > `, async (input) => {
-        const trimmed = input.trim();
-
-        if (!trimmed) {
-          prompt();
-          return;
-        }
-
-        if (trimmed.startsWith('.')) {
-          await this.handleCommand(trimmed, output, verbose);
-          if (trimmed !== '.exit') {
-            prompt();
-          }
-          return;
-        }
-
-        // Try to execute as JSON input
-        if (!this.selectedTool) {
-          output.warning('No tool selected. Use .select to choose a tool first.');
-          prompt();
-          return;
-        }
-
-        try {
-          const params = JSON.parse(trimmed);
-          await this.executeTool(params, output, verbose);
-        } catch {
-          output.error('Invalid JSON input. Enter valid JSON or use a command (.help)');
-        }
-
-        prompt();
+        if (await this.processInput(input, output, verbose)) prompt();
       });
     };
 
@@ -118,6 +89,33 @@ export default class Playground extends Command {
     await new Promise<void>((resolve) => {
       this.rl?.on('close', resolve);
     });
+  }
+
+  private async processInput(
+    input: string,
+    output: ReturnType<typeof createOutput>,
+    verbose: boolean
+  ): Promise<boolean> {
+    const trimmed = input.trim();
+    if (!trimmed) return true;
+
+    if (trimmed.startsWith('.')) {
+      await this.handleCommand(trimmed, output, verbose);
+      return trimmed !== '.exit';
+    }
+
+    if (!this.selectedTool) {
+      output.warning('No tool selected. Use .select to choose a tool first.');
+      return true;
+    }
+
+    try {
+      const params = JSON.parse(trimmed) as Record<string, unknown>;
+      await this.executeTool(params, output, verbose);
+    } catch {
+      output.error('Invalid JSON input. Enter valid JSON or use a command (.help)');
+    }
+    return true;
   }
 
   private async handleCommand(
@@ -149,7 +147,7 @@ export default class Playground extends Command {
 
       case '.select':
         if (args.length === 0) {
-          output.warning('Usage: .select <tool-slug>');
+          output.warning('Usage: .select <package::toolName>');
         } else {
           this.selectedTool = args[0];
           output.success(`Selected: ${this.selectedTool}`);
@@ -191,11 +189,12 @@ export default class Playground extends Command {
       output.text('Available tools:');
 
       for (const tool of response.data) {
-        output.listItem(`${tool.slug} - ${tool.name}`);
+        const toolId = canonicalToolId(tool);
+        if (toolId) output.listItem(`${toolId} - ${tool.description}`);
       }
 
       output.text('');
-      output.text('Use .select <slug> to select a tool');
+      output.text('Use .select <package::toolName> to select a tool');
     } catch {
       spinner.fail('Failed to load tools');
     }

--- a/packages/cli/src/commands/tool/execute.ts
+++ b/packages/cli/src/commands/tool/execute.ts
@@ -1,14 +1,91 @@
 import { Args, Command, Flags } from '@oclif/core';
-import { getClient } from '../../lib/api-client.js';
+import { getClient, type TpmClient } from '../../lib/api-client.js';
 import { createOutput } from '../../lib/output.js';
+
+type Output = ReturnType<typeof createOutput>;
+
+interface ParameterFlags {
+  input?: string;
+  'input-file'?: string;
+}
+
+function parseParameters(json: string): Record<string, unknown> {
+  const value: unknown = JSON.parse(json);
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Tool input must be a JSON object');
+  }
+  return value as Record<string, unknown>;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf-8').trim();
+}
+
+async function loadParameters(
+  flags: ParameterFlags,
+  output: Output
+): Promise<Record<string, unknown> | null> {
+  try {
+    if (flags.input) return parseParameters(flags.input);
+
+    if (flags['input-file']) {
+      const fs = await import('node:fs');
+      return parseParameters(fs.readFileSync(flags['input-file'], 'utf-8'));
+    }
+
+    if (!process.stdin.isTTY) {
+      const stdin = await readStdin();
+      return stdin ? parseParameters(stdin) : {};
+    }
+
+    return {};
+  } catch (error) {
+    output.error(error instanceof Error ? error.message : 'Failed to parse tool input');
+    return null;
+  }
+}
+
+async function printStream(
+  client: TpmClient,
+  toolId: string,
+  params: Record<string, unknown>,
+  output: Output,
+  verbose: boolean
+): Promise<void> {
+  output.info(`Executing ${toolId} (stream-compatible output)...`);
+  output.divider();
+
+  for await (const event of client.executeToolStream(toolId, params)) {
+    if (event.type === 'text') process.stdout.write(event.data);
+    else if (event.type === 'error') output.error(event.data);
+    else if (event.type === 'done') {
+      output.text('');
+      output.divider();
+      output.success('Execution complete');
+    } else if (verbose) output.info(`Event: ${event.type}`);
+  }
+}
+
+function printResult(result: unknown, output: Output, json: boolean): void {
+  if (json) {
+    output.json(result);
+    return;
+  }
+
+  output.success('Execution complete');
+  output.divider();
+  output.text(typeof result === 'string' ? result : JSON.stringify(result, null, 2));
+}
 
 export default class ToolExecute extends Command {
   static description = 'Execute a TPMJS tool';
 
   static examples = [
-    '<%= config.bin %> <%= command.id %> firecrawl-scrape --input \'{"url":"https://example.com"}\'',
-    '<%= config.bin %> <%= command.id %> my-tool --input-file params.json',
-    '<%= config.bin %> <%= command.id %> my-tool --stream',
+    '<%= config.bin %> <%= command.id %> "@tpmjs/official-firecrawl::scrapeTool" --input \'{"url":"https://example.com"}\'',
+    '<%= config.bin %> <%= command.id %> "@scope/package::toolName" --input-file params.json',
+    '<%= config.bin %> <%= command.id %> "@scope/package::toolName" --stream',
   ];
 
   static flags = {
@@ -22,7 +99,7 @@ export default class ToolExecute extends Command {
     }),
     stream: Flags.boolean({
       char: 's',
-      description: 'Stream output (for tools that support it)',
+      description: 'Emit the atomic registry result through streaming-compatible output',
       default: false,
     }),
     timeout: Flags.integer({
@@ -43,7 +120,7 @@ export default class ToolExecute extends Command {
 
   static args = {
     tool: Args.string({
-      description: 'Tool slug or ID',
+      description: 'Canonical tool ID (package::toolName); unique legacy names are also accepted',
       required: true,
     }),
   };
@@ -51,95 +128,21 @@ export default class ToolExecute extends Command {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(ToolExecute);
     const output = createOutput(flags);
-    const client = getClient();
-
-    // Parse input parameters
-    let params: Record<string, unknown> = {};
-
-    if (flags.input) {
-      try {
-        params = JSON.parse(flags.input);
-      } catch {
-        output.error('Invalid JSON in --input flag');
-        return;
-      }
-    } else if (flags['input-file']) {
-      try {
-        const fs = await import('node:fs');
-        const content = fs.readFileSync(flags['input-file'], 'utf-8');
-        params = JSON.parse(content);
-      } catch (error) {
-        output.error(
-          `Failed to read input file: ${error instanceof Error ? error.message : 'Unknown error'}`
-        );
-        return;
-      }
-    }
-
-    // Check stdin for piped input
-    if (!flags.input && !flags['input-file'] && !process.stdin.isTTY) {
-      try {
-        const chunks: Buffer[] = [];
-        for await (const chunk of process.stdin) {
-          chunks.push(chunk);
-        }
-        const stdinContent = Buffer.concat(chunks).toString('utf-8').trim();
-        if (stdinContent) {
-          params = JSON.parse(stdinContent);
-        }
-      } catch {
-        output.error('Failed to parse JSON from stdin');
-        return;
-      }
-    }
+    const client = getClient({ timeout: flags.timeout * 1000 });
+    const params = await loadParameters(flags, output);
+    if (!params) return;
 
     const spinner = flags.stream ? null : output.spinner(`Executing ${args.tool}...`);
 
     try {
       if (flags.stream) {
-        // Streaming execution
-        output.info(`Executing ${args.tool} with streaming...`);
-        output.divider();
-
-        const stream = client.executeToolStream(args.tool, params);
-
-        for await (const event of stream) {
-          if (event.type === 'text') {
-            process.stdout.write(event.data);
-          } else if (event.type === 'error') {
-            output.error(event.data);
-          } else if (event.type === 'done') {
-            output.text('');
-            output.divider();
-            output.success('Execution complete');
-          } else if (flags.verbose) {
-            output.info(`Event: ${event.type}`);
-          }
-        }
-      } else {
-        // Non-streaming execution
-        const result = await client.executeTool(args.tool, params);
-
-        spinner?.stop();
-
-        if (flags.json) {
-          output.json(result);
-          return;
-        }
-
-        output.success('Execution complete');
-        output.divider();
-
-        if (typeof result === 'string') {
-          output.text(result);
-        } else if (result && typeof result === 'object') {
-          // Pretty print the result
-          const formatted = JSON.stringify(result, null, 2);
-          output.text(formatted);
-        } else {
-          output.text(String(result));
-        }
+        await printStream(client, args.tool, params, output, flags.verbose);
+        return;
       }
+
+      const result = await client.executeTool(args.tool, params);
+      spinner?.stop();
+      printResult(result, output, flags.json);
     } catch (error) {
       spinner?.fail('Execution failed');
       output.error(

--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -10,7 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ApiError, TpmClient } from './api-client.js';
+import { ApiError, canonicalToolId, type Tool, TpmClient } from './api-client.js';
 
 // Mock the config module
 vi.mock('./config.js', () => ({
@@ -363,22 +363,167 @@ describe('TpmClient', () => {
   });
 
   describe('tool execution', () => {
-    it('should execute a tool with parameters', async () => {
+    it('executes a canonical tool ID through the registry contract and unwraps the result', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ result: 'executed successfully' }),
+        json: async () => ({
+          success: true,
+          toolId: '@example/tools::parseCsv',
+          result: { rows: 2 },
+          executionTimeMs: 14,
+        }),
       });
 
-      const result = await client.executeTool('my-tool', { input: 'test' });
+      const result = await client.executeTool('@example/tools::parseCsv', { csv: 'a\n1' });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.test.com/tools/my-tool/execute',
+        'https://api.test.com/registry/execute',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ input: 'test' }),
+          body: JSON.stringify({
+            toolId: '@example/tools::parseCsv',
+            params: { csv: 'a\n1' },
+          }),
         })
       );
-      expect(result).toEqual({ result: 'executed successfully' });
+      expect(result).toEqual({ rows: 2 });
+    });
+
+    it('resolves a unique legacy tool name before execution', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              {
+                id: 'tool-1',
+                name: 'parseCsv',
+                package: { npmPackageName: '@example/tools' },
+              },
+            ],
+            pagination: { limit: 10, offset: 0, hasMore: false },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            toolId: '@example/tools::parseCsv',
+            result: 'ok',
+            executionTimeMs: 9,
+          }),
+        });
+
+      await expect(client.executeTool('parseCsv', {})).resolves.toBe('ok');
+
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://api.test.com/tools?q=parseCsv&limit=10',
+        expect.any(Object)
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://api.test.com/registry/execute',
+        expect.objectContaining({
+          body: JSON.stringify({ toolId: '@example/tools::parseCsv', params: {} }),
+        })
+      );
+    });
+
+    it('refuses ambiguous legacy names instead of executing the wrong package', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'one', name: 'search', package: { npmPackageName: '@one/tools' } },
+            { id: 'two', name: 'search', package: { npmPackageName: '@two/tools' } },
+          ],
+          pagination: { limit: 10, offset: 0, hasMore: false },
+        }),
+      });
+
+      await expect(client.executeTool('search', {})).rejects.toThrow(
+        'Tool "search" is ambiguous. Use package::toolName.'
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('turns an atomic registry result into stream-compatible events', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          toolId: '@example/tools::parseCsv',
+          result: { rows: 2 },
+          executionTimeMs: 11,
+        }),
+      });
+
+      const events = [];
+      for await (const event of client.executeToolStream('@example/tools::parseCsv', {})) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        { type: 'text', data: '{\n  "rows": 2\n}' },
+        { type: 'done', data: '' },
+      ]);
+    });
+
+    it('surfaces structured API error messages', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          success: false,
+          error: { code: 'TOOL_ERROR', message: 'Required parameter missing' },
+        }),
+      });
+
+      await expect(client.executeTool('@example/tools::parseCsv', {})).rejects.toThrow(
+        'Required parameter missing'
+      );
+    });
+  });
+
+  describe('tool identity routes', () => {
+    it('preserves the path boundary in scoped package names', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: { id: 'tool-1' } }),
+      });
+
+      await client.getTool('@example/tools', 'parseCsv');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.test.com/tools/%40example/tools/parseCsv',
+        expect.any(Object)
+      );
+    });
+
+    it('resolves canonical IDs through the same scoped route', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: { id: 'tool-1' } }),
+      });
+
+      await client.getToolBySlug('@example/tools::parseCsv');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.test.com/tools/%40example/tools/parseCsv',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('canonicalToolId', () => {
+    it('uses the package relation returned by the registry', () => {
+      expect(
+        canonicalToolId({
+          name: 'parseCsv',
+          package: { npmPackageName: '@example/tools' },
+        } as Tool)
+      ).toBe('@example/tools::parseCsv');
     });
   });
 

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -31,7 +31,7 @@ export interface PaginatedResponse<T> {
 export interface Tool {
   id: string;
   name: string;
-  slug: string;
+  slug?: string;
   description: string;
   category: string;
   tier: string;
@@ -52,6 +52,20 @@ export interface Tool {
     npmDownloadsLastMonth: number;
     isOfficial: boolean;
   };
+}
+
+interface RegistryExecuteResponse {
+  success: boolean;
+  toolId: string;
+  result?: unknown;
+  executionTimeMs: number;
+  error?: { code: string; message: string };
+}
+
+/** Return the stable registry identifier represented by a tool response. */
+export function canonicalToolId(tool: Tool): string | null {
+  const packageName = tool.package?.npmPackageName ?? tool.npmPackageName;
+  return packageName && tool.name ? `${packageName}::${tool.name}` : null;
 }
 
 export interface ToolSearchOptions extends PaginationOptions {
@@ -114,6 +128,7 @@ export interface Collection {
   _count?: {
     tools: number;
   };
+  tools?: Array<{ tool: Tool }>;
 }
 
 export interface CreateCollectionInput {
@@ -263,14 +278,17 @@ export class TpmClient {
         signal: controller.signal,
       });
 
-      const data = (await response.json()) as T & { message?: string; error?: string };
+      const data = (await response.json()) as T & {
+        message?: string;
+        error?: string | { message?: string };
+      };
 
       if (!response.ok) {
-        throw new ApiError(
-          data.message || data.error || `HTTP ${response.status}`,
-          response.status,
-          data
-        );
+        const errorMessage =
+          data.message ||
+          (typeof data.error === 'string' ? data.error : data.error?.message) ||
+          `HTTP ${response.status}`;
+        throw new ApiError(errorMessage, response.status, data);
       }
 
       return data as T;
@@ -304,12 +322,16 @@ export class TpmClient {
   }
 
   async getTool(packageName: string, toolName: string): Promise<ApiResponse<Tool>> {
-    return this.request(
-      `/tools/${encodeURIComponent(packageName)}/${encodeURIComponent(toolName)}`
-    );
+    const packagePath = packageName.split('/').map(encodeURIComponent).join('/');
+    return this.request(`/tools/${packagePath}/${encodeURIComponent(toolName)}`);
   }
 
   async getToolBySlug(slug: string): Promise<ApiResponse<Tool>> {
+    const separatorIndex = slug.lastIndexOf('::');
+    if (separatorIndex > 0 && separatorIndex < slug.length - 2) {
+      return this.getTool(slug.slice(0, separatorIndex), slug.slice(separatorIndex + 2));
+    }
+
     // Search for the tool by slug
     const searchResult = await this.searchTools({ query: slug, limit: 1 });
     if (searchResult.data && searchResult.data.length > 0) {
@@ -339,77 +361,54 @@ export class TpmClient {
     });
   }
 
-  async executeTool(slug: string, params: Record<string, unknown>): Promise<unknown> {
-    return this.request(`/tools/${encodeURIComponent(slug)}/execute`, {
+  private async resolveToolId(identifier: string): Promise<string> {
+    const separatorIndex = identifier.lastIndexOf('::');
+    if (separatorIndex > 0 && separatorIndex < identifier.length - 2) return identifier;
+
+    const searchResult = await this.searchTools({ query: identifier, limit: 10 });
+    const exactMatches = searchResult.data.filter(
+      (tool) => tool.id === identifier || tool.slug === identifier || tool.name === identifier
+    );
+    const candidates = exactMatches.length > 0 ? exactMatches : searchResult.data;
+
+    if (candidates.length !== 1) {
+      throw new Error(
+        candidates.length === 0
+          ? `Tool "${identifier}" was not found. Use package::toolName.`
+          : `Tool "${identifier}" is ambiguous. Use package::toolName.`
+      );
+    }
+
+    const candidate = candidates[0];
+    if (!candidate) throw new Error(`Tool "${identifier}" was not found.`);
+    const resolved = canonicalToolId(candidate);
+    if (!resolved) throw new Error(`Tool "${identifier}" has no canonical registry ID.`);
+    return resolved;
+  }
+
+  async executeTool(identifier: string, params: Record<string, unknown>): Promise<unknown> {
+    const toolId = await this.resolveToolId(identifier);
+    const response = await this.request<RegistryExecuteResponse>('/registry/execute', {
       method: 'POST',
-      body: JSON.stringify(params),
+      body: JSON.stringify({ toolId, params }),
     });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || `Execution failed for ${toolId}`);
+    }
+    return response.result;
   }
 
   async *executeToolStream(
-    slug: string,
+    identifier: string,
     params: Record<string, unknown>
   ): AsyncGenerator<{ type: string; data: string }> {
-    const url = `${this.baseUrl}/tools/${encodeURIComponent(slug)}/execute`;
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      Accept: 'text/event-stream',
+    const result = await this.executeTool(identifier, params);
+    yield {
+      type: 'text',
+      data: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
     };
-
-    if (this.apiKey) {
-      headers.Authorization = `Bearer ${this.apiKey}`;
-    }
-
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ ...params, stream: true }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new ApiError(errorText || `HTTP ${response.status}`, response.status);
-    }
-
-    if (!response.body) {
-      throw new ApiError('No response body', 0);
-    }
-
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          yield { type: 'done', data: '' };
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6);
-            if (data === '[DONE]') {
-              yield { type: 'done', data: '' };
-              return;
-            }
-            try {
-              const parsed = JSON.parse(data);
-              yield { type: parsed.type || 'text', data: parsed.content || parsed.data || data };
-            } catch {
-              yield { type: 'text', data };
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
+    yield { type: 'done', data: '' };
   }
 
   // Agents
@@ -459,7 +458,9 @@ export class TpmClient {
     }
 
     // Strip username prefix if present (e.g., "ajax/dog-research-tools" -> "dog-research-tools")
-    const slug = identifier.includes('/') ? identifier.split('/').pop()! : identifier;
+    const slug = identifier.includes('/')
+      ? (identifier.split('/').at(-1) ?? identifier)
+      : identifier;
 
     // List user's collections and find by slug or name
     const result = await this.listCollections({ limit: 50 });
@@ -498,7 +499,7 @@ export class TpmClient {
   }
 
   async getCollection(id: string): Promise<ApiResponse<Collection>> {
-    return this.request(`/collections/${id}`);
+    return this.request(`/collections/${id}?toolsLimit=100`);
   }
 
   async createCollection(input: CreateCollectionInput): Promise<ApiResponse<Collection>> {

--- a/packages/skills.md
+++ b/packages/skills.md
@@ -52,8 +52,8 @@ Execute any tool from the registry without installing it. The execution server i
 
 ```bash
 # CLI — direct execution
-tpm tool execute firecrawl-scrape --input '{"url":"https://example.com"}'
-tpm tool execute my-tool --input-file params.json --stream
+tpm tool execute '@tpmjs/official-firecrawl::scrapeTool' --input '{"url":"https://example.com"}'
+tpm tool execute '@scope/package::toolName' --input-file params.json --stream
 
 # CLI — execute from a collection via MCP
 tpm run -c username/collection -t toolName --args '{"key":"value"}' --env API_KEY=xxx

--- a/packages/ui/src/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/Tabs/Tabs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { Tabs } from './Tabs';
 import type { Tab } from './types';
@@ -117,15 +117,15 @@ describe('Tabs', () => {
       const handleChange = vi.fn();
       render(<Tabs tabs={mockTabs} activeTab="all" onTabChange={handleChange} />);
       const recentTab = screen.getByTestId('tab-recent');
-      const badge = recentTab.querySelector('span[aria-label]');
+      const badge = recentTab.querySelector('span[aria-hidden="true"]');
       expect(badge).not.toBeInTheDocument();
     });
 
-    it('count badge has aria-label', () => {
+    it('includes the count in the tab accessible name', () => {
       const handleChange = vi.fn();
       render(<Tabs tabs={mockTabs} activeTab="all" onTabChange={handleChange} />);
-      const badge = screen.getByText('1234');
-      expect(badge).toHaveAttribute('aria-label', '1234 items');
+      expect(screen.getByTestId('tab-all')).toHaveAttribute('aria-label', 'All Tools, 1234 items');
+      expect(screen.getByText('1234')).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('applies active styling to count badge on active tab', () => {
@@ -212,6 +212,40 @@ describe('Tabs', () => {
         'aria-controls',
         'tabpanel-featured'
       );
+    });
+
+    it('keeps only the active tab in the sequential focus order', () => {
+      render(<Tabs tabs={mockTabs} activeTab="featured" onTabChange={vi.fn()} />);
+
+      expect(screen.getByTestId('tab-all')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('tab-featured')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('tab-recent')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('moves and selects tabs with arrow keys', () => {
+      const handleChange = vi.fn();
+      render(<Tabs tabs={mockTabs} activeTab="all" onTabChange={handleChange} />);
+
+      fireEvent.keyDown(screen.getByTestId('tab-all'), { key: 'ArrowRight' });
+
+      expect(handleChange).toHaveBeenCalledWith('featured');
+      expect(screen.getByTestId('tab-featured')).toHaveFocus();
+    });
+
+    it('wraps backward and supports Home and End', () => {
+      const handleChange = vi.fn();
+      render(<Tabs tabs={mockTabs} activeTab="all" onTabChange={handleChange} />);
+      const first = screen.getByTestId('tab-all');
+
+      fireEvent.keyDown(first, { key: 'ArrowLeft' });
+      expect(handleChange).toHaveBeenLastCalledWith('recent');
+      expect(screen.getByTestId('tab-recent')).toHaveFocus();
+
+      fireEvent.keyDown(screen.getByTestId('tab-recent'), { key: 'Home' });
+      expect(handleChange).toHaveBeenLastCalledWith('all');
+
+      fireEvent.keyDown(first, { key: 'End' });
+      expect(handleChange).toHaveBeenLastCalledWith('recent');
     });
   });
 

--- a/packages/ui/src/Tabs/Tabs.tsx
+++ b/packages/ui/src/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@tpmjs/utils/cn';
-import { forwardRef } from 'react';
+import { forwardRef, type KeyboardEvent } from 'react';
 import type { Tab, TabsProps } from './types';
 import { tabButtonVariants, tabCountVariants, tabsContainerVariants } from './variants';
 
@@ -39,6 +39,24 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
     { className, tabs, activeTab, onTabChange, size = 'md', variant = 'default', ...props },
     ref
   ) => {
+    const moveFocus = (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number): void => {
+      let nextIndex: number | null = null;
+      if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % tabs.length;
+      if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+      if (event.key === 'Home') nextIndex = 0;
+      if (event.key === 'End') nextIndex = tabs.length - 1;
+      if (nextIndex === null || nextIndex < 0) return;
+
+      const nextTab = tabs[nextIndex];
+      if (!nextTab) return;
+
+      event.preventDefault();
+      onTabChange(nextTab.id);
+      const buttons =
+        event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+      buttons?.[nextIndex]?.focus();
+    };
+
     return (
       <div
         className={cn(
@@ -52,7 +70,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
         ref={ref}
         {...props}
       >
-        {tabs.map((tab) => {
+        {tabs.map((tab, index) => {
           const isActive = tab.id === activeTab;
 
           return (
@@ -62,13 +80,16 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
               role="tab"
               aria-selected={isActive}
               aria-controls={`tabpanel-${tab.id}`}
+              aria-label={tab.count === undefined ? undefined : `${tab.label}, ${tab.count} items`}
               id={`tab-${tab.id}`}
+              tabIndex={isActive ? 0 : -1}
               className={tabButtonVariants({
                 size,
                 active: isActive ? 'true' : 'false',
                 variant,
               })}
               onClick={() => onTabChange(tab.id)}
+              onKeyDown={(event) => moveFocus(event, index)}
               data-testid={`tab-${tab.id}`}
             >
               <span>{tab.label}</span>
@@ -77,7 +98,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
                   className={tabCountVariants({
                     active: isActive ? 'true' : 'false',
                   })}
-                  aria-label={`${tab.count} items`}
+                  aria-hidden="true"
                 >
                   {tab.count.toString()}
                 </span>


### PR DESCRIPTION
## Summary

- extract the tool page activation UI into one tested CLI / MCP / REST / SDK / Skill contract
- repair tpm tool execute to use canonical package::toolName IDs and POST /api/registry/execute
- make legacy names fail safely when ambiguous, honor CLI timeout, and fix scoped package routing
- make local MCP tool names spec-safe and execute their canonical registry IDs
- reconcile public CLI and MCP documentation with the live contracts
- add roving keyboard focus and Arrow / Home / End navigation to shared Tabs

## Proof

- CLI unit tests: 33 passed
- web contract + analytics tests: 9 passed
- server-rendered switcher smoke: passed
- CLI and UI type checks: passed
- Biome and diff checks: passed
- no-Vercel-hosting and single-owner Sentry architecture gates: passed
- live REST execution returned the expected csvParseTool result
- live MCP tools/list confirmed packageName / toolName / arguments

## Local runner note

The normal commit hook cleared secrets, lint, format, and the playground type check. The web type process was stopped after nine minutes of mounted-disk starvation caused by unrelated recursive scans. No failure was emitted. This PR stays draft until the full GitHub CI matrix passes on a clean runner.