### PR TITLE
perf: scope TypeScript cache collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
+    env:
+      TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+      TURBO_SCM_HEAD: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -194,6 +197,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    env:
+      TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+      TURBO_SCM_HEAD: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Type check
-        run: pnpm exec turbo run type-check --affected
+        run: |
+          affected_count="$(pnpm exec turbo ls --affected --output=json | jq '.packages.count')"
+          if [ "$affected_count" -eq 0 ]; then
+            echo 'No workspaces require type checking'
+            exit 0
+          fi
+          pnpm exec turbo run type-check --affected
 
   type-coverage:
     runs-on: ubuntu-latest
@@ -216,7 +222,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm exec turbo run build --affected
+        run: |
+          affected_count="$(pnpm exec turbo ls --affected --output=json | jq '.packages.count')"
+          if [ "$affected_count" -eq 0 ]; then
+            echo 'No workspaces require building'
+            exit 0
+          fi
+          pnpm exec turbo run build --affected
 
   executor:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            **/*.tsbuildinfo
             .turbo
+            apps/*/tsconfig.tsbuildinfo
+            apps/*/.next/cache/tsconfig.tsbuildinfo
+            packages/*/tsconfig.tsbuildinfo
+            packages/tools/*/tsconfig.tsbuildinfo
+            packages/tools/official/*/tsconfig.tsbuildinfo
           key: ${{ runner.os }}-typescript-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-typescript-${{ hashFiles('pnpm-lock.yaml') }}-

--- a/docs/BUILD_AND_RELEASE.md
+++ b/docs/BUILD_AND_RELEASE.md
@@ -64,8 +64,11 @@ trigger hundreds of unrelated tool-package builds. Changes to shared packages
 still include every transitive dependent, while a missing comparison base
 safely falls back to the full graph. `pnpm build` and `pnpm type-check` remain
 the explicit full-repository commands. CI queries the affected package count
-first and exits successfully when it is zero, avoiding a runner-side empty-set
-edge case for documentation- or workflow-only changes. TypeScript cache paths
+first and exits successfully when it is zero. The comparison range uses exact
+GitHub event SHAs rather than a local `main` branch name: pull requests compare
+their base SHA with the checked merge SHA, and pushes compare the event's
+`before` SHA with the new SHA. This prevents a missing local branch from making
+Turbo conservatively rebuild all 235 workspaces. TypeScript cache paths
 enumerate only workspace output depths; a recursive `**/*.tsbuildinfo` glob is
 forbidden because it traverses the installed dependency tree during post-job
 cleanup. On-box compiler artifacts are namespaced by the absolute

--- a/docs/BUILD_AND_RELEASE.md
+++ b/docs/BUILD_AND_RELEASE.md
@@ -63,9 +63,11 @@ Turbo's dependency-aware `--affected` graph, so an executor-only change cannot
 trigger hundreds of unrelated tool-package builds. Changes to shared packages
 still include every transitive dependent, while a missing comparison base
 safely falls back to the full graph. `pnpm build` and `pnpm type-check` remain
-the explicit full-repository commands. On-box compiler artifacts are namespaced
-by the absolute release-workspace path because Turbopack caches are not portable
-between source roots.
+the explicit full-repository commands. TypeScript cache paths enumerate only
+workspace output depths; a recursive `**/*.tsbuildinfo` glob is forbidden
+because it traverses the installed dependency tree during post-job cleanup.
+On-box compiler artifacts are namespaced by the absolute release-workspace path
+because Turbopack caches are not portable between source roots.
 
 Podman layer reuse remains enabled for both images. A tiny release-provenance
 file invalidates only the metadata tail of each Dockerfile, so a new Git commit
@@ -113,6 +115,7 @@ fails if a maintainer accidentally:
 - moves release compilation back to the data volume;
 - restores the duplicate architecture build;
 - removes dependency-aware affected builds or their required Git history;
+- restores recursive dependency-tree traversal to TypeScript cache collection;
 - disables Podman layers; or
 - disables the executor lockfile or restores static CDN imports; or
 - permits stale image provenance.

--- a/docs/BUILD_AND_RELEASE.md
+++ b/docs/BUILD_AND_RELEASE.md
@@ -63,11 +63,14 @@ Turbo's dependency-aware `--affected` graph, so an executor-only change cannot
 trigger hundreds of unrelated tool-package builds. Changes to shared packages
 still include every transitive dependent, while a missing comparison base
 safely falls back to the full graph. `pnpm build` and `pnpm type-check` remain
-the explicit full-repository commands. TypeScript cache paths enumerate only
-workspace output depths; a recursive `**/*.tsbuildinfo` glob is forbidden
-because it traverses the installed dependency tree during post-job cleanup.
-On-box compiler artifacts are namespaced by the absolute release-workspace path
-because Turbopack caches are not portable between source roots.
+the explicit full-repository commands. CI queries the affected package count
+first and exits successfully when it is zero, avoiding a runner-side empty-set
+edge case for documentation- or workflow-only changes. TypeScript cache paths
+enumerate only workspace output depths; a recursive `**/*.tsbuildinfo` glob is
+forbidden because it traverses the installed dependency tree during post-job
+cleanup. On-box compiler artifacts are namespaced by the absolute
+release-workspace path because Turbopack caches are not portable between source
+roots.
 
 Podman layer reuse remains enabled for both images. A tiny release-provenance
 file invalidates only the metadata tail of each Dockerfile, so a new Git commit

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -189,6 +189,11 @@ requireText(
   'turbo ls --affected --output=json',
   'CI must skip type checking cleanly when no workspaces are affected'
 );
+requireText(
+  typeCheckJob,
+  'github.event.pull_request.base.sha || github.event.before',
+  'affected type checking must compare exact event SHAs instead of a local branch name'
+);
 
 const buildJob = ci.slice(ci.indexOf('  build:'), ci.indexOf('  executor:'));
 requireText(buildJob, '.turbo', 'the build job must preserve Turbo task artifacts');
@@ -202,6 +207,11 @@ requireText(
   buildJob,
   'turbo ls --affected --output=json',
   'CI must skip building cleanly when no workspaces are affected'
+);
+requireText(
+  buildJob,
+  'github.event.pull_request.base.sha || github.event.before',
+  'affected builds must compare exact event SHAs instead of a local branch name'
 );
 
 if (failures.length > 0) {

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -110,7 +110,14 @@ for (const [name, dockerfile] of [
 }
 
 requireText(ci, 'apps/web/.next/cache', 'CI must preserve Next.js incremental compiler state');
-requireText(ci, '**/*.tsbuildinfo', 'CI must preserve incremental TypeScript state');
+requireText(
+  ci,
+  'packages/tools/official/*/tsconfig.tsbuildinfo',
+  'CI must preserve incremental TypeScript state without traversing dependency trees'
+);
+if (ci.includes('**/*.tsbuildinfo')) {
+  failures.push('TypeScript cache paths must not recursively traverse node_modules');
+}
 requireText(ci, '  type-coverage:', 'type coverage must run independently from type checking');
 requireText(ci, 'path: .type-coverage', 'CI must preserve incremental type-coverage analysis');
 requireText(

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -184,6 +184,11 @@ requireText(
   'turbo run type-check --affected',
   'CI must type-check only the dependency-aware affected workspace graph'
 );
+requireText(
+  typeCheckJob,
+  'turbo ls --affected --output=json',
+  'CI must skip type checking cleanly when no workspaces are affected'
+);
 
 const buildJob = ci.slice(ci.indexOf('  build:'), ci.indexOf('  executor:'));
 requireText(buildJob, '.turbo', 'the build job must preserve Turbo task artifacts');
@@ -192,6 +197,11 @@ requireText(
   buildJob,
   'turbo run build --affected',
   'CI must build only the dependency-aware affected workspace graph'
+);
+requireText(
+  buildJob,
+  'turbo ls --affected --output=json',
+  'CI must skip building cleanly when no workspaces are affected'
 );
 
 if (failures.length > 0) {


### PR DESCRIPTION
## What changed

- replace the recursive `**/*.tsbuildinfo` cache path with explicit TPMJS workspace depths
- pin Turborepo change detection to exact GitHub event SHAs for both PR and push runs
- query the affected workspace count and skip empty task graphs
- add regression ratchets for all three performance invariants
- document the deterministic CI comparison and cache boundaries

## Root causes

1. The affected type-check itself completed in 0.8s on main, but `actions/cache` spent 104s resolving a recursive glob through installed `node_modules` before saving only 37KB.
2. `actions/checkout` had full history but no local branch named `main`; Turborepo 2.7 could not resolve the inferred name and conservatively rebuilt all 235 workspaces.

## Validation

- exact SHA range selects 0 packages for this root-only PR and 1 package for the executor release
- type-check: 4m43s before → 41s after
- build: 5m23s before → 51s after
- cache collection after type-check: 104s before → 0.7s after
- all nine GitHub CI jobs green
- build-performance ratchet and workflow YAML validation pass
- pre-push full test suite passes
