### PR TITLE
feat(release): bootstrap npm trusted publishers

### DIFF
--- a/.github/workflows/npm-trust-bootstrap.yml
+++ b/.github/workflows/npm-trust-bootstrap.yml
@@ -1,0 +1,52 @@
+name: Bootstrap npm Trusted Publishing
+
+on:
+  workflow_dispatch:
+
+concurrency: npm-trust-bootstrap
+
+jobs:
+  bootstrap:
+    if: github.repository == 'tpmjs/tpmjs'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.14.0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install npm trusted-publishing client
+        run: npm install --global npm@11.18.0
+
+      - name: Verify one-time npm credential
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Audit source and npm registry state
+        run: pnpm release:audit --format json --output release-audit.json
+
+      - name: Configure the release workflow for every existing npm package
+        run: pnpm release:trust-bootstrap --audit release-audit.json --repo tpmjs/tpmjs --file release.yml
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Preserve the audited bootstrap set
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: npm-trust-bootstrap-${{ github.sha }}
+          path: release-audit.json
+          if-no-files-found: error

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,6 +69,11 @@ An npm maintainer with an interactive session and 2FA can configure a package wi
 npm trust github @tpmjs/PACKAGE --file release.yml --repo tpmjs/tpmjs --allow-publish
 ```
 
+For a scope-wide migration, the manual **Bootstrap npm Trusted Publishing** workflow derives every
+existing npm package from the fail-closed release audit and configures the same publisher for each.
+It uses `NPM_TOKEN` only inside GitHub Actions; remove that legacy secret after the bootstrap run and
+the normal release lane remains entirely OIDC-based.
+
 Trusted Publishing cannot bootstrap a name that does not exist on npm. A genuinely new package must be published once by a maintainer, then configured with the command above before normal automated releases. The preflight fails explicitly for that state.
 
 During the July 2026 migration, the required commands for the pending releases are:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "release:audit:test": "tsx --test scripts/release-audit.test.ts",
     "release:auth": "tsx scripts/release-auth.ts",
     "release:auth:test": "tsx --test scripts/release-auth.test.ts",
+    "release:trust-bootstrap": "tsx scripts/release-trust-bootstrap.ts",
     "release:build": "tsx scripts/release-build.ts",
     "release:build:test": "tsx --test scripts/release-build.test.ts",
     "release:preview": "pnpm release:status && pnpm release:audit",

--- a/scripts/release-auth-lib.ts
+++ b/scripts/release-auth-lib.ts
@@ -28,6 +28,11 @@ export interface OidcAuthorizationReport {
   denied: OidcDenial[];
 }
 
+export interface NpmTrustPublisher {
+  repository: string;
+  workflow: string;
+}
+
 type Fetcher = typeof fetch;
 
 function asRecord(value: unknown, description: string): Record<string, unknown> {
@@ -78,6 +83,52 @@ export function releaseCandidates(audit: unknown): ReleaseCandidate[] {
     );
   }
   return candidates;
+}
+
+/**
+ * Return every public workspace package that already exists on npm.
+ *
+ * Trusted publishers are configured per package, not per npm scope. Bootstrapping
+ * the complete published workspace set once avoids discovering a missing grant
+ * only when a future version is already queued for release.
+ */
+export function publishedPackageNames(audit: unknown): string[] {
+  const document = asRecord(audit, 'Release audit');
+  const summary = asRecord(document.summary, 'Release audit summary');
+  if (summary.safe !== true) {
+    throw new Error('Release audit is not safe; refusing to configure npm trust');
+  }
+  if (!Array.isArray(document.packages)) {
+    throw new Error('Release audit packages must be an array');
+  }
+
+  const names = new Set<string>();
+  for (const [index, value] of document.packages.entries()) {
+    const entry = asRecord(value, `Release audit package ${index}`);
+    if (entry.safe !== true) {
+      throw new Error(`Release audit package ${index} is not safe`);
+    }
+    const latest = entry.latest;
+    if (latest === null) continue;
+    if (typeof latest !== 'string' || latest.length === 0) {
+      throw new Error(`Release audit package ${index}.latest must be a string or null`);
+    }
+    names.add(requiredString(entry, 'name', `Release audit package ${index}`));
+  }
+  return [...names].sort((left, right) => left.localeCompare(right));
+}
+
+export function npmTrustGithubArgs(packageName: string, publisher: NpmTrustPublisher): string[] {
+  return [
+    'trust',
+    'github',
+    packageName,
+    '--file',
+    publisher.workflow,
+    '--repo',
+    publisher.repository,
+    '--allow-publish',
+  ];
 }
 
 export function githubOidcUrl(requestUrl: string): string {

--- a/scripts/release-auth.test.ts
+++ b/scripts/release-auth.test.ts
@@ -5,6 +5,8 @@ import {
   authorizeNpmPackages,
   githubOidcUrl,
   npmOidcExchangeUrl,
+  npmTrustGithubArgs,
+  publishedPackageNames,
   releaseCandidates,
   requestGitHubOidcToken,
 } from './release-auth-lib';
@@ -12,9 +14,27 @@ import {
 const audit = {
   summary: { safe: true, publishCount: 2 },
   packages: [
-    { name: '@tpmjs/current', version: '1.0.0', state: 'current', safe: true },
-    { name: '@tpmjs/existing', version: '1.1.0', state: 'publish', safe: true },
-    { name: '@tpmjs/new', version: '0.1.0', state: 'new-package', safe: true },
+    {
+      name: '@tpmjs/current',
+      version: '1.0.0',
+      latest: '1.0.0',
+      state: 'current',
+      safe: true,
+    },
+    {
+      name: '@tpmjs/existing',
+      version: '1.1.0',
+      latest: '1.0.0',
+      state: 'publish',
+      safe: true,
+    },
+    {
+      name: '@tpmjs/new',
+      version: '0.1.0',
+      latest: null,
+      state: 'new-package',
+      safe: true,
+    },
   ],
 };
 
@@ -33,6 +53,33 @@ test('fails closed on an unsafe audit or inconsistent publish count', () => {
   assert.throws(
     () => releaseCandidates({ ...audit, summary: { safe: true, publishCount: 1 } }),
     /publish count mismatch/
+  );
+});
+
+test('derives all existing npm packages for one-time trust bootstrap', () => {
+  assert.deepEqual(publishedPackageNames(audit), ['@tpmjs/current', '@tpmjs/existing']);
+  assert.throws(
+    () => publishedPackageNames({ ...audit, summary: { safe: false, publishCount: 2 } }),
+    /not safe/
+  );
+});
+
+test('constructs exact npm trust arguments without a shell', () => {
+  assert.deepEqual(
+    npmTrustGithubArgs('@tpmjs/tools-vercel', {
+      repository: 'tpmjs/tpmjs',
+      workflow: 'release.yml',
+    }),
+    [
+      'trust',
+      'github',
+      '@tpmjs/tools-vercel',
+      '--file',
+      'release.yml',
+      '--repo',
+      'tpmjs/tpmjs',
+      '--allow-publish',
+    ]
   );
 });
 

--- a/scripts/release-trust-bootstrap.ts
+++ b/scripts/release-trust-bootstrap.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env tsx
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { npmTrustGithubArgs, publishedPackageNames } from './release-auth-lib';
+
+interface CliOptions {
+  audit: string;
+  repository: string;
+  workflow: string;
+}
+
+function optionValue(args: readonly string[], index: number, option: string): string {
+  const value = args[index + 1];
+  if (!value) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+function parseOptions(args: readonly string[]): CliOptions {
+  let audit = 'release-audit.json';
+  let repository = process.env.GITHUB_REPOSITORY ?? '';
+  let workflow = 'release.yml';
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    switch (argument) {
+      case '--audit':
+        audit = optionValue(args, index, argument);
+        index += 1;
+        break;
+      case '--repo':
+        repository = optionValue(args, index, argument);
+        index += 1;
+        break;
+      case '--file':
+        workflow = optionValue(args, index, argument);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!repository.includes('/')) throw new Error('--repo must be an owner/repository pair');
+  if (!workflow.endsWith('.yml') && !workflow.endsWith('.yaml')) {
+    throw new Error('--file must be a GitHub Actions workflow filename');
+  }
+  return { audit, repository, workflow };
+}
+
+function main(): void {
+  const options = parseOptions(process.argv.slice(2));
+  if (!process.env.NODE_AUTH_TOKEN) {
+    throw new Error('NODE_AUTH_TOKEN is required for the one-time npm trust bootstrap');
+  }
+
+  const packages = publishedPackageNames(JSON.parse(readFileSync(options.audit, 'utf8')));
+  if (packages.length === 0) {
+    console.log('npm trust bootstrap: no existing npm packages found');
+    return;
+  }
+
+  console.log(
+    `npm trust bootstrap: configuring ${packages.length} package${packages.length === 1 ? '' : 's'} for ${options.repository}/${options.workflow}`
+  );
+  for (const [index, packageName] of packages.entries()) {
+    console.log(`[${index + 1}/${packages.length}] ${packageName}`);
+    const result = spawnSync(
+      'npm',
+      npmTrustGithubArgs(packageName, {
+        repository: options.repository,
+        workflow: options.workflow,
+      }),
+      { stdio: 'inherit', env: process.env }
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`npm trust bootstrap failed for ${packageName} (exit ${result.status})`);
+    }
+  }
+  console.log(`npm trust bootstrap: configured ${packages.length} packages`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Outcome

Adds a one-time, auditable GitHub Actions bootstrap for npm Trusted Publishing across every existing public TPMJS workspace package.

- derives the package set from the fail-closed release audit (214 existing packages today)
- configures the exact `tpmjs/tpmjs` + `release.yml` publisher without shell interpolation
- verifies the legacy npm credential before any mutation
- keeps the normal release lane OIDC-only
- adds focused policy tests and operator documentation

After this workflow succeeds and the OIDC release is proven, the legacy `NPM_TOKEN` secret and transient bootstrap workflow will be removed.

## Verification

- release auth tests: 9/9
- focused TypeScript compilation: pass
- Biome: pass
- pre-commit type-check: 238/238 cached tasks
- pre-push tests: 22/22 cached tasks