### PR TITLE
fix(bridge): align public HTTP polling contract

### DIFF
--- a/.changeset/calm-bridges-poll.md
+++ b/.changeset/calm-bridges-poll.md
@@ -1,0 +1,5 @@
+---
+'@tpmjs/bridge': patch
+---
+
+Align the bridge's exported protocol types, CLI help, and documentation with its authenticated HTTP-polling runtime.

--- a/apps/web/src/data/blog/posts.ts
+++ b/apps/web/src/data/blog/posts.ts
@@ -645,7 +645,7 @@ Each tool runs in an isolated Deno executor on Railway. The collection stores en
 
 ### 2. Bridge tools
 
-Bridge tools come from MCP servers running on your local machine. You run the TPMJS bridge CLI, which connects your local servers (filesystem access, database tools, IDE integrations) to the cloud. The bridge maintains a WebSocket connection and routes tool calls back to your machine.
+Bridge tools come from MCP servers running on your local machine. You run the TPMJS bridge CLI, which connects your local servers (filesystem access, database tools, IDE integrations) to the cloud. The bridge polls an authenticated HTTP endpoint and routes tool calls back to your machine.
 
 This means your cloud-hosted collection can include tools that run locally. An agent using your MCP endpoint can read your local files, query your local database, or interact with your IDE — all through the same \`tools/call\` interface.
 

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -98,11 +98,11 @@ await bridge.start();
 await bridge.stop();
 ```
 
-Exports: `Bridge`, `BridgeOptions`, config helpers (`loadConfig`, `saveConfig`, `createDefaultConfig`, `loadCredentials`, `saveCredentials`, `deleteCredentials`, `ensureConfigDir`, `getConfigPath`, `getCredentialsPath`), and the types `BridgeConfig`, `BridgeCredentials`, `BridgeToServerMessage`, `ServerToBridgeMessage`.
+Exports: `Bridge`, `BridgeOptions`, config helpers (`loadConfig`, `saveConfig`, `createDefaultConfig`, `loadCredentials`, `saveCredentials`, `deleteCredentials`, `ensureConfigDir`, `getConfigPath`, `getCredentialsPath`), and typed HTTP contracts including `BridgePostRequest`, `BridgePollResponse`, `BridgeSuccessResponse`, `BridgeErrorResponse`, and `BridgeToolCall`. The former `BridgeToServerMessage` and `ServerToBridgeMessage` names remain as deprecated compatibility aliases.
 
 ## How it works
 
-`start` connects to each configured stdio MCP server, `POST`s the discovered tools to TPMJS (`/api/bridge`), then polls that endpoint for pending tool calls, executes them against the local server, and posts results back — with a periodic heartbeat. On shutdown it `DELETE`s its registration and disconnects every server.
+`start` connects to each configured MCP server, `POST`s the discovered tools to TPMJS (`/api/bridge`), then polls that endpoint over authenticated HTTP for pending tool calls, executes them against the configured server, and posts typed results back — with a periodic heartbeat. On shutdown it `DELETE`s its registration and disconnects every server.
 
 ## Links
 

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -34,6 +34,7 @@
     "build": "tsdown --logLevel warn",
     "dev": "tsdown --watch",
     "start": "node dist/cli.js",
+    "test": "vitest run",
     "type-check": "tsc --checkers 1 --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
     "clean": "rm -rf dist .turbo"
   },

--- a/packages/bridge/src/bridge.test.ts
+++ b/packages/bridge/src/bridge.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mcp = vi.hoisted(() => {
+  const tool = {
+    name: 'echo',
+    description: 'Echo a value',
+    inputSchema: {
+      type: 'object' as const,
+      properties: { value: { type: 'string' } },
+    },
+  };
+
+  const state = {
+    instances: [] as MockMCPClientManager[],
+    callToolError: undefined as Error | undefined,
+    result: {
+      content: [{ type: 'text' as const, text: 'echoed' }],
+      isError: false,
+    },
+  };
+
+  class MockMCPClientManager {
+    disconnected = false;
+
+    constructor() {
+      state.instances.push(this);
+    }
+
+    async connect() {
+      return [tool];
+    }
+
+    listAllTools() {
+      return [
+        {
+          serverId: 'local',
+          serverName: 'Local server',
+          tool,
+        },
+      ];
+    }
+
+    async callTool() {
+      if (state.callToolError) throw state.callToolError;
+      return state.result;
+    }
+
+    async disconnectAll() {
+      this.disconnected = true;
+    }
+  }
+
+  return { MockMCPClientManager, state };
+});
+
+vi.mock('@tpmjs/mcp-client', () => ({ MCPClientManager: mcp.MockMCPClientManager }));
+
+import { Bridge } from './bridge.js';
+
+const server = {
+  id: 'local',
+  name: 'Local server',
+  transport: 'stdio' as const,
+  command: 'node',
+  args: ['server.js'],
+};
+
+interface FetchRecord {
+  method: string;
+  body?: { type?: string; [key: string]: unknown };
+}
+
+function installBridgeApi(toolCall: boolean, toolResultStatus = 200): FetchRecord[] {
+  const records: FetchRecord[] = [];
+  let returnedCall = false;
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      const body =
+        typeof init?.body === 'string' ? (JSON.parse(init.body) as FetchRecord['body']) : undefined;
+      records.push({ method, body });
+
+      if (method === 'GET') {
+        const calls =
+          toolCall && !returnedCall
+            ? [
+                {
+                  callId: 'call-1',
+                  serverId: 'local',
+                  toolName: 'echo',
+                  args: { value: 'hello' },
+                  timestamp: 1,
+                },
+              ]
+            : [];
+        returnedCall = true;
+        return Response.json({ success: true, calls });
+      }
+
+      if (body?.type === 'tool_result' && toolResultStatus !== 200) {
+        return new Response('delivery unavailable', { status: toolResultStatus });
+      }
+
+      return Response.json({ success: true });
+    })
+  );
+
+  return records;
+}
+
+describe('Bridge HTTP polling contract', () => {
+  beforeEach(() => {
+    mcp.state.instances.length = 0;
+    mcp.state.callToolError = undefined;
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('registers tools and returns successful calls as typed tool_result payloads', async () => {
+    const records = installBridgeApi(true);
+    const bridge = new Bridge({
+      apiKey: 'test-key',
+      apiUrl: 'https://example.test',
+      servers: [server],
+      pollInterval: 60_000,
+      heartbeatInterval: 60_000,
+    });
+
+    await bridge.start();
+    await vi.waitFor(() => {
+      expect(records.some((record) => record.body?.type === 'tool_result')).toBe(true);
+    });
+
+    expect(records[0]).toMatchObject({
+      method: 'POST',
+      body: {
+        type: 'register',
+        clientVersion: '0.1.0',
+        tools: [{ serverId: 'local', serverName: 'Local server', name: 'echo' }],
+      },
+    });
+    expect(records.find((record) => record.body?.type === 'tool_result')).toEqual({
+      method: 'POST',
+      body: {
+        type: 'tool_result',
+        callId: 'call-1',
+        result: mcp.state.result,
+      },
+    });
+
+    await bridge.stop();
+    expect(mcp.state.instances[0]?.disconnected).toBe(true);
+  });
+
+  it('uses tool_result with a structured error when local execution fails', async () => {
+    mcp.state.callToolError = new Error('local server failed');
+    const records = installBridgeApi(true);
+    const bridge = new Bridge({
+      apiKey: 'test-key',
+      apiUrl: 'https://example.test',
+      servers: [server],
+      pollInterval: 60_000,
+      heartbeatInterval: 60_000,
+    });
+
+    await bridge.start();
+    await vi.waitFor(() => {
+      expect(records.some((record) => record.body?.type === 'tool_result')).toBe(true);
+    });
+
+    expect(records.find((record) => record.body?.type === 'tool_result')).toEqual({
+      method: 'POST',
+      body: {
+        type: 'tool_result',
+        callId: 'call-1',
+        error: { code: 'EXECUTION_FAILED', message: 'local server failed' },
+      },
+    });
+
+    await bridge.stop();
+  });
+
+  it('cleans up MCP connections when HTTP registration fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('temporarily unavailable', { status: 503 }))
+    );
+    const bridge = new Bridge({
+      apiKey: 'test-key',
+      apiUrl: 'https://example.test',
+      servers: [server],
+    });
+
+    await expect(bridge.start()).rejects.toThrow(
+      'Bridge register failed with HTTP 503: temporarily unavailable'
+    );
+    expect(mcp.state.instances[0]?.disconnected).toBe(true);
+  });
+
+  it('does not relabel a successful execution when result delivery fails', async () => {
+    const records = installBridgeApi(true, 503);
+    const bridge = new Bridge({
+      apiKey: 'test-key',
+      apiUrl: 'https://example.test',
+      servers: [server],
+      pollInterval: 60_000,
+      heartbeatInterval: 60_000,
+    });
+
+    await bridge.start();
+    await vi.waitFor(() => {
+      expect(records.filter((record) => record.body?.type === 'tool_result')).toHaveLength(1);
+    });
+
+    expect(records.find((record) => record.body?.type === 'tool_result')?.body).toEqual({
+      type: 'tool_result',
+      callId: 'call-1',
+      result: mcp.state.result,
+    });
+
+    await bridge.stop();
+  });
+});

--- a/packages/bridge/src/bridge.ts
+++ b/packages/bridge/src/bridge.ts
@@ -1,13 +1,12 @@
 import type { MCPServerConfig } from '@tpmjs/mcp-client';
 import { MCPClientManager } from '@tpmjs/mcp-client';
 import pc from 'picocolors';
-
-interface BridgeToolCall {
-  callId: string;
-  serverId: string;
-  toolName: string;
-  args: Record<string, unknown>;
-}
+import type {
+  BridgePollResponse,
+  BridgePostRequest,
+  BridgeSuccessResponse,
+  BridgeToolCall,
+} from './types.js';
 
 export interface BridgeOptions {
   /** TPMJS API key */
@@ -80,7 +79,13 @@ export class Bridge {
 
     // 2. Register with TPMJS
     this.log('\nConnecting to TPMJS...');
-    await this.registerTools();
+    try {
+      await this.registerTools();
+    } catch (error) {
+      this.isRunning = false;
+      await this.mcpManager.disconnectAll().catch(() => undefined);
+      throw error;
+    }
 
     // 3. Start polling for tool calls
     this.startPolling();
@@ -126,30 +131,20 @@ export class Bridge {
   private async registerTools(): Promise<void> {
     const allTools = this.mcpManager.listAllTools();
 
-    const response = await fetch(`${this.options.apiUrl}/api/bridge`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.options.apiKey}`,
-      },
-      body: JSON.stringify({
-        type: 'register',
-        tools: allTools.map(({ serverId, serverName, tool }) => ({
-          serverId,
-          serverName,
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-        })),
-        clientVersion: '0.1.0',
-        clientOS: process.platform,
-      }),
-    });
+    const request: BridgePostRequest = {
+      type: 'register',
+      tools: allTools.map(({ serverId, serverName, tool }) => ({
+        serverId,
+        serverName,
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      })),
+      clientVersion: '0.1.0',
+      clientOS: process.platform,
+    };
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Failed to register: ${error}`);
-    }
+    await this.postMessage(request, 'register');
 
     this.log(`${pc.green('✓')} Connected to TPMJS`);
     this.log(`Registered ${allTools.length} tools`);
@@ -167,14 +162,16 @@ export class Bridge {
           },
         });
 
-        if (response.ok) {
-          const data = (await response.json()) as { calls?: BridgeToolCall[] };
-          const calls = data.calls || [];
+        if (!response.ok) {
+          throw new Error(`Bridge poll failed with HTTP ${response.status}`);
+        }
 
-          // Process each tool call
-          for (const call of calls) {
-            await this.handleToolCall(call);
-          }
+        const data = (await response.json()) as BridgePollResponse;
+        const calls = Array.isArray(data.calls) ? data.calls : [];
+
+        // Process each tool call
+        for (const call of calls) {
+          await this.handleToolCall(call);
         }
       } catch (error) {
         if (this.options.verbose) {
@@ -196,14 +193,7 @@ export class Bridge {
       if (!this.isRunning) return;
 
       try {
-        await fetch(`${this.options.apiUrl}/api/bridge`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.options.apiKey}`,
-          },
-          body: JSON.stringify({ type: 'heartbeat' }),
-        });
+        await this.postMessage({ type: 'heartbeat' }, 'heartbeat');
       } catch {
         // Ignore heartbeat errors
       }
@@ -223,49 +213,58 @@ export class Bridge {
       this.log(`Tool call: ${serverId}/${toolName}`);
     }
 
+    let outcome: BridgePostRequest;
+    let executionError: Error | undefined;
+
     try {
       const result = await this.mcpManager.callTool(serverId, toolName, args);
-
-      await fetch(`${this.options.apiUrl}/api/bridge`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.options.apiKey}`,
-        },
-        body: JSON.stringify({
-          type: 'tool_result',
-          callId,
-          result: {
-            content: result.content,
-            isError: result.isError,
-          },
-        }),
-      });
-
-      if (this.options.verbose) {
-        this.log(`  ${pc.green('✓')} Result sent`);
-      }
+      outcome = { type: 'tool_result', callId, result };
     } catch (error) {
-      await fetch(`${this.options.apiUrl}/api/bridge`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.options.apiKey}`,
+      executionError = error instanceof Error ? error : new Error(String(error));
+      outcome = {
+        type: 'tool_result',
+        callId,
+        error: {
+          code: 'EXECUTION_FAILED',
+          message: executionError.message,
         },
-        body: JSON.stringify({
-          type: 'tool_result',
-          callId,
-          error: {
-            code: 'EXECUTION_FAILED',
-            message: (error as Error).message,
-          },
-        }),
-      });
-
-      if (this.options.verbose) {
-        this.log(`  ${pc.red('✗')} Error: ${(error as Error).message}`);
-      }
+      };
     }
+
+    // Delivery failures are transport failures, not tool execution failures.
+    // Keeping those paths separate prevents a successful call from being
+    // falsely reported as EXECUTION_FAILED when TPMJS rejects the response.
+    await this.postMessage(outcome, executionError ? 'tool error' : 'tool result');
+
+    if (this.options.verbose) {
+      this.log(
+        executionError
+          ? `  ${pc.red('✗')} Error: ${executionError.message}`
+          : `  ${pc.green('✓')} Result sent`
+      );
+    }
+  }
+
+  private async postMessage(
+    message: BridgePostRequest,
+    operation: string
+  ): Promise<BridgeSuccessResponse> {
+    const response = await fetch(`${this.options.apiUrl}/api/bridge`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.options.apiKey}`,
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      const suffix = detail ? `: ${detail}` : '';
+      throw new Error(`Bridge ${operation} failed with HTTP ${response.status}${suffix}`);
+    }
+
+    return (await response.json()) as BridgeSuccessResponse;
   }
 
   private log(message: string): void {

--- a/packages/bridge/src/cli.ts
+++ b/packages/bridge/src/cli.ts
@@ -154,7 +154,7 @@ program
   .command('start')
   .description('Start the bridge')
   .option('-v, --verbose', 'Verbose output')
-  .option('--url <url>', 'Custom WebSocket URL')
+  .option('--url <url>', 'Custom TPMJS API base URL')
   .action(async (options) => {
     const config = loadConfig();
     const credentials = loadCredentials();

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -13,6 +13,13 @@ export {
 export type {
   BridgeConfig,
   BridgeCredentials,
+  BridgeErrorResponse,
+  BridgePollResponse,
+  BridgePostRequest,
+  BridgeSuccessResponse,
+  BridgeToolCall,
+  BridgeToolDefinition,
+  BridgeToolError,
   BridgeToServerMessage,
   ServerToBridgeMessage,
 } from './types.js';

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -1,4 +1,4 @@
-import type { MCPServerConfig, MCPTool } from '@tpmjs/mcp-client';
+import type { MCPServerConfig, MCPTool, MCPToolResult } from '@tpmjs/mcp-client';
 
 /**
  * Bridge configuration file structure
@@ -20,65 +20,76 @@ export interface BridgeCredentials {
   email?: string;
 }
 
-/**
- * Message from bridge to TPMJS
- */
-export type BridgeToServerMessage =
+/** A tool exposed by one of the bridge's configured MCP servers. */
+export interface BridgeToolDefinition {
+  serverId: string;
+  serverName: string;
+  name: string;
+  description?: string;
+  inputSchema: MCPTool['inputSchema'];
+}
+
+/** A tool invocation returned by the TPMJS bridge polling endpoint. */
+export interface BridgeToolCall {
+  callId: string;
+  serverId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  timestamp: number;
+}
+
+/** A structured tool-call failure returned to TPMJS. */
+export interface BridgeToolError {
+  code: string;
+  message: string;
+}
+
+/** HTTP POST payloads accepted by `/api/bridge`. */
+export type BridgePostRequest =
   | {
       type: 'register';
-      tools: Array<{
-        serverId: string;
-        serverName: string;
-        name: string;
-        description?: string;
-        inputSchema: MCPTool['inputSchema'];
-      }>;
+      tools: BridgeToolDefinition[];
+      clientVersion: string;
+      clientOS: string;
     }
   | {
       type: 'tool_result';
       callId: string;
-      result: {
-        content: Array<{
-          type: string;
-          text?: string;
-          mimeType?: string;
-          data?: string;
-        }>;
-        isError?: boolean;
-      };
+      result: MCPToolResult;
+      error?: never;
     }
   | {
-      type: 'tool_error';
+      type: 'tool_result';
       callId: string;
-      error: {
-        code: string;
-        message: string;
-      };
+      result?: never;
+      error: BridgeToolError;
     }
   | {
       type: 'heartbeat';
-      timestamp: number;
     };
 
-/**
- * Message from TPMJS to bridge
- */
+/** HTTP GET response returned while polling `/api/bridge`. */
+export interface BridgePollResponse {
+  success: true;
+  calls: BridgeToolCall[];
+}
+
+/** Successful HTTP response returned by bridge POST and DELETE requests. */
+export interface BridgeSuccessResponse {
+  success: true;
+  message?: string;
+}
+
+/** Error response returned by the bridge API. */
+export interface BridgeErrorResponse {
+  error: string;
+}
+
+/** @deprecated Use {@link BridgePostRequest}; the bridge uses HTTP polling, not a socket. */
+export type BridgeToServerMessage = BridgePostRequest;
+
+/** @deprecated Use the specific HTTP response type for the request being made. */
 export type ServerToBridgeMessage =
-  | {
-      type: 'tool_call';
-      callId: string;
-      serverId: string;
-      toolName: string;
-      args: Record<string, unknown>;
-    }
-  | {
-      type: 'ping';
-    }
-  | {
-      type: 'registered';
-      toolCount: number;
-    }
-  | {
-      type: 'error';
-      message: string;
-    };
+  | BridgePollResponse
+  | BridgeSuccessResponse
+  | BridgeErrorResponse;

--- a/scripts/coverage-baselines.ts
+++ b/scripts/coverage-baselines.ts
@@ -19,6 +19,10 @@ export const coverageBaselines: Record<string, CoverageBaseline> = {
     directory: 'packages/cli',
     thresholds: { branches: 3.4, functions: 10.2, lines: 3.2, statements: 3.5 },
   },
+  '@tpmjs/bridge': {
+    directory: 'packages/bridge',
+    thresholds: { branches: 19.2, functions: 30.5, lines: 32.1, statements: 31.2 },
+  },
   '@tpmjs/compose': {
     directory: 'packages/compose',
     thresholds: { branches: 93.1, functions: 91.6, lines: 100, statements: 97.9 },


### PR DESCRIPTION
Closes #117.

## What changed

- replace the fictional WebSocket message model with exported types for the actual authenticated HTTP register, poll, heartbeat, result, and error contract
- keep the old message type names as deprecated compatibility aliases
- make the bridge runtime construct those exported request types directly
- distinguish tool execution failures from HTTP result-delivery failures
- disconnect MCP clients when registration fails
- correct CLI, package README, and public blog wording
- add a patch changeset and the bridge workspace to the honest coverage ratchet

The reported unused ws dependency was already absent on current main; this closes the remaining runtime/type/documentation drift.

## Verification

- 4 bridge contract tests pass
- repository tests pass: 1,139 passed, 12 skipped
- exact coverage ratchet passes; bridge is 32.13% lines / 31.28% statements / 19.23% branches / 30.56% functions
- formatting, lint, 238/238 type-check tasks, 98.96% type coverage, dead-code analysis, and architecture checks pass
- production web build passes: 10/10 tasks and 99/99 static pages