### PR TITLE
perf(ci): reuse exact green PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,31 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
+  validation_provenance:
+    name: Validation provenance
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      reuse: ${{ steps.provenance.outputs.reuse }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Find exact successful pull-request validation
+        id: provenance
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/reuse-pr-validation.mjs
+
   lint:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -40,6 +63,8 @@ jobs:
           docker compose --file compose.dev.yaml config --quiet
 
   type-check:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     env:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -85,6 +110,8 @@ jobs:
           pnpm exec turbo run type-check --affected
 
   type-coverage:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -113,6 +140,8 @@ jobs:
         run: pnpm type-coverage
 
   test:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -137,6 +166,7 @@ jobs:
           pnpm release:auth:test
           pnpm release:build:test
           pnpm verify:vercel-api:test
+          node --test scripts/reuse-pr-validation.test.mjs
           pnpm test
 
       - name: Report and enforce test coverage
@@ -151,6 +181,8 @@ jobs:
           if-no-files-found: error
 
   migrations:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -198,6 +230,8 @@ jobs:
           --exit-code
 
   build:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     env:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -239,6 +273,8 @@ jobs:
           pnpm exec turbo run build --affected
 
   executor:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -338,6 +374,8 @@ jobs:
           ' /tmp/executor-missing-export.json
 
   architecture:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -358,6 +396,8 @@ jobs:
         run: pnpm check-architecture
 
   deadcode:
+    needs: validation_provenance
+    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/BUILD_AND_RELEASE.md
+++ b/docs/BUILD_AND_RELEASE.md
@@ -24,6 +24,28 @@ provenance, and smoke-tested as a running container before a live image tag can
 move. The previous image receives a timestamped rollback tag first. A failed
 activation restarts that exact prior image.
 
+### Content-addressed CI reuse
+
+Pull requests run the complete nine-job validation suite. After GitHub creates
+a normal merge commit on `main`, the push workflow proves that the merge tree is
+byte-identical to the pull request's second-parent tree and that the exact
+second-parent SHA already completed this repository's `ci.yml` pull-request
+workflow successfully. Only then does the main workflow reuse that validation
+instead of repeating the same lint, type, test, migration, build, executor,
+architecture, and dead-code work.
+
+This is validation reuse, not branch-name trust. Direct pushes, squash or
+rebase commits, merge-tree changes, missing Git history, unsuccessful or
+unrelated workflow runs, malformed API responses, and GitHub API failures all
+run the complete suite. Pull-request check names remain unchanged. The
+resulting successful main-branch workflow run still attests the exact merge SHA
+that the deployment preflight requires.
+
+GitHub scopes cache visibility by branch and does not make caches created on a
+pull-request merge ref available to the base branch. The provenance proof
+therefore removes the truly duplicate main run without adding an external
+cache service or placing TPMJS infrastructure on Vercel.
+
 `verify` is read-only. It proves that both systemd services are active, both
 live images carry the expected revision, the executor serves protocol 1.1, the
 web app can reach PostgreSQL, and the public health endpoint reports the same
@@ -200,6 +222,8 @@ fails if a maintainer accidentally:
 - bypasses TypeScript without exact-SHA CI proof;
 - moves release compilation back to the data volume;
 - restores the duplicate architecture build;
+- repeats exact green pull-request validation on an identical merge tree or
+  lets uncertain provenance skip full validation;
 - removes dependency-aware affected builds or their required Git history;
 - restores recursive dependency-tree traversal to TypeScript cache collection;
 - restores duplicate standard tsup configs, uses a monolithic tsdown workspace

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -28,6 +28,7 @@ const executorPackage = JSON.parse(read('apps/railway-executor/package.json'));
 const executorDenoLock = JSON.parse(read('apps/railway-executor/deno.lock'));
 const webDockerfile = read('Dockerfile');
 const ci = read('.github/workflows/ci.yml');
+const reusePrValidation = read('scripts/reuse-pr-validation.mjs');
 const sandboxTests = read('.github/workflows/sandbox-tests.yml');
 const release = read('.github/workflows/release.yml');
 const releasePreview = read('.github/workflows/release-preview.yml');
@@ -266,6 +267,76 @@ for (const [name, dockerfile] of [
 }
 
 requireText(ci, 'apps/web/.next/cache', 'CI must preserve Next.js incremental compiler state');
+requireText(
+  ci,
+  'permissions:\n  contents: read\n  actions: read',
+  'CI provenance lookup must retain least-privilege workflow-run read access'
+);
+requireText(
+  ci,
+  '  validation_provenance:',
+  'CI must retain the exact pull-request validation provenance job'
+);
+requireText(
+  ci,
+  'run: node scripts/reuse-pr-validation.mjs',
+  'CI must run the validation provenance decision before expensive jobs'
+);
+requireText(
+  ci,
+  'node --test scripts/reuse-pr-validation.test.mjs',
+  'CI must exercise the validation provenance contract tests'
+);
+requireText(
+  reusePrValidation,
+  "git(['rev-list', '--parents', '-n', '1', sha])",
+  'validation reuse must be limited to normal merge commits'
+);
+requireText(
+  reusePrValidation,
+  "git(['show', '-s', '--format=%T', sourceSha])",
+  'validation reuse must compare the pull-request head tree'
+);
+requireText(
+  reusePrValidation,
+  'run?.path === CI_WORKFLOW_PATH',
+  'validation reuse must require the authoritative CI workflow'
+);
+
+const fullyValidatedJobs = [
+  'lint',
+  'type-check',
+  'type-coverage',
+  'test',
+  'migrations',
+  'build',
+  'executor',
+  'architecture',
+  'deadcode',
+];
+for (const [index, job] of fullyValidatedJobs.entries()) {
+  const start = ci.indexOf(`  ${job}:`);
+  if (start < 0) {
+    failures.push(`CI must retain the ${job} validation job`);
+    continue;
+  }
+  const nextStarts = fullyValidatedJobs
+    .slice(index + 1)
+    .map((nextJob) => ci.indexOf(`  ${nextJob}:`, start + 1))
+    .filter((position) => position >= 0);
+  const end = nextStarts.length > 0 ? Math.min(...nextStarts) : ci.length;
+  const section = ci.slice(start, end);
+  requireText(
+    section,
+    'needs: validation_provenance',
+    `${job} must wait for the validation provenance decision`
+  );
+  requireText(
+    section,
+    "always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true')",
+    `${job} must run for pull requests and whenever exact validation reuse is unproven`
+  );
+}
 requireText(
   ci,
   'packages/tools/official/*/tsconfig.tsbuildinfo',

--- a/scripts/reuse-pr-validation.mjs
+++ b/scripts/reuse-pr-validation.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const CI_WORKFLOW_PATH = '.github/workflows/ci.yml';
+
+function defaultGit(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function rejection(reason) {
+  return { reuse: false, reason };
+}
+
+export async function findReusablePullRequestValidation({
+  sha,
+  repository,
+  token,
+  git = defaultGit,
+  fetchImpl = globalThis.fetch,
+}) {
+  try {
+    if (!sha || !repository || !token) {
+      return rejection('required GitHub provenance input is unavailable');
+    }
+
+    const revision = git(['rev-list', '--parents', '-n', '1', sha]).split(/\s+/);
+    if (revision.length !== 3 || revision[0] !== sha) {
+      return rejection('the pushed revision is not a normal two-parent merge commit');
+    }
+
+    const sourceSha = revision[2];
+    const mergeTree = git(['show', '-s', '--format=%T', sha]);
+    const sourceTree = git(['show', '-s', '--format=%T', sourceSha]);
+    if (!mergeTree || mergeTree !== sourceTree) {
+      return rejection('the merge tree differs from the pull-request head tree');
+    }
+
+    const url = new URL(`https://api.github.com/repos/${repository}/actions/workflows/ci.yml/runs`);
+    url.searchParams.set('head_sha', sourceSha);
+    url.searchParams.set('event', 'pull_request');
+    url.searchParams.set('status', 'completed');
+    url.searchParams.set('per_page', '100');
+
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'User-Agent': 'tpmjs-validation-provenance',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!response.ok) {
+      return rejection(`GitHub workflow lookup returned HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+    if (!Array.isArray(payload?.workflow_runs)) {
+      return rejection('GitHub workflow lookup returned an unexpected response');
+    }
+
+    const sourceRun = payload.workflow_runs.find(
+      (run) =>
+        run?.head_sha === sourceSha &&
+        run?.event === 'pull_request' &&
+        run?.status === 'completed' &&
+        run?.conclusion === 'success' &&
+        run?.path === CI_WORKFLOW_PATH
+    );
+    if (!sourceRun) {
+      return rejection('no successful completed pull-request CI run exists for the exact head SHA');
+    }
+
+    return {
+      reuse: true,
+      reason: 'the merge tree is identical to an exact successfully validated pull-request head',
+      sourceSha,
+      sourceTree,
+      sourceRunId: String(sourceRun.id),
+      sourceRunUrl: sourceRun.html_url ?? '',
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return rejection(`provenance lookup failed safely: ${detail}`);
+  }
+}
+
+function writeOutput(result) {
+  const output = [
+    `reuse=${String(result.reuse)}`,
+    `reason=${result.reason.replaceAll('\n', ' ')}`,
+    `source_sha=${result.sourceSha ?? ''}`,
+    `source_tree=${result.sourceTree ?? ''}`,
+    `source_run_id=${result.sourceRunId ?? ''}`,
+    `source_run_url=${result.sourceRunUrl ?? ''}`,
+  ].join('\n');
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${output}\n`);
+  } else {
+    console.log(output);
+  }
+}
+
+function writeSummary(result) {
+  const heading = result.reuse
+    ? '## Reused exact pull-request validation'
+    : '## Running the complete validation suite';
+  const details = result.reuse
+    ? [
+        `- Source commit: \`${result.sourceSha}\``,
+        `- Source tree: \`${result.sourceTree}\``,
+        `- Source run: [${result.sourceRunId}](${result.sourceRunUrl})`,
+      ]
+    : [];
+  const summary = [heading, '', result.reason, ...details, ''].join('\n');
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+  } else {
+    console.log(summary);
+  }
+}
+
+async function main() {
+  const result = await findReusablePullRequestValidation({
+    sha: process.env.GITHUB_SHA,
+    repository: process.env.GITHUB_REPOSITORY,
+    token: process.env.GITHUB_TOKEN,
+  });
+  writeOutput(result);
+  writeSummary(result);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/reuse-pr-validation.test.mjs
+++ b/scripts/reuse-pr-validation.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findReusablePullRequestValidation } from './reuse-pr-validation.mjs';
+
+const mergeSha = 'a'.repeat(40);
+const firstParent = 'b'.repeat(40);
+const sourceSha = 'c'.repeat(40);
+const sharedTree = 'd'.repeat(40);
+
+function gitFixture({
+  parents = [mergeSha, firstParent, sourceSha],
+  sourceTree = sharedTree,
+} = {}) {
+  return (args) => {
+    if (args[0] === 'rev-list') return parents.join(' ');
+    if (args.at(-1) === mergeSha) return sharedTree;
+    if (args.at(-1) === sourceSha) return sourceTree;
+    throw new Error(`unexpected git command: ${args.join(' ')}`);
+  };
+}
+
+function response(workflowRuns, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => ({ workflow_runs: workflowRuns }),
+  };
+}
+
+function successfulRun(overrides = {}) {
+  return {
+    id: 123,
+    head_sha: sourceSha,
+    event: 'pull_request',
+    status: 'completed',
+    conclusion: 'success',
+    path: '.github/workflows/ci.yml',
+    html_url: 'https://github.com/tpmjs/tpmjs/actions/runs/123',
+    ...overrides,
+  };
+}
+
+function decide({ git = gitFixture(), workflowRuns = [successfulRun()], fetchImpl } = {}) {
+  return findReusablePullRequestValidation({
+    sha: mergeSha,
+    repository: 'tpmjs/tpmjs',
+    token: 'test-token',
+    git,
+    fetchImpl: fetchImpl ?? (async () => response(workflowRuns)),
+  });
+}
+
+test('reuses an exact successful pull-request validation for an identical merge tree', async () => {
+  let requestedUrl;
+  const result = await decide({
+    fetchImpl: async (url) => {
+      requestedUrl = url;
+      return response([successfulRun()]);
+    },
+  });
+
+  assert.equal(result.reuse, true);
+  assert.equal(result.sourceSha, sourceSha);
+  assert.equal(result.sourceTree, sharedTree);
+  assert.equal(result.sourceRunId, '123');
+  assert.equal(requestedUrl.searchParams.get('head_sha'), sourceSha);
+  assert.equal(requestedUrl.searchParams.get('event'), 'pull_request');
+  assert.equal(requestedUrl.searchParams.get('status'), 'completed');
+});
+
+test('rejects a direct push before consulting GitHub', async () => {
+  let fetched = false;
+  const result = await decide({
+    git: gitFixture({ parents: [mergeSha, firstParent] }),
+    fetchImpl: async () => {
+      fetched = true;
+      return response([]);
+    },
+  });
+
+  assert.equal(result.reuse, false);
+  assert.match(result.reason, /not a normal two-parent merge/);
+  assert.equal(fetched, false);
+});
+
+test('rejects a merge whose tree differs from the pull-request head', async () => {
+  const result = await decide({ git: gitFixture({ sourceTree: 'e'.repeat(40) }) });
+
+  assert.equal(result.reuse, false);
+  assert.match(result.reason, /tree differs/);
+});
+
+test('requires the exact workflow, commit, event, status, and successful conclusion', async () => {
+  for (const run of [
+    successfulRun({ head_sha: firstParent }),
+    successfulRun({ event: 'push' }),
+    successfulRun({ status: 'in_progress' }),
+    successfulRun({ conclusion: 'failure' }),
+    successfulRun({ path: '.github/workflows/release.yml' }),
+  ]) {
+    const result = await decide({ workflowRuns: [run] });
+    assert.equal(result.reuse, false);
+  }
+});
+
+test('fails open to complete validation when GitHub is unavailable or malformed', async () => {
+  const unavailable = await decide({
+    fetchImpl: async () => response([], { ok: false, status: 503 }),
+  });
+  const malformed = await decide({
+    fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({}) }),
+  });
+  const rejected = await decide({
+    fetchImpl: async () => {
+      throw new Error('network unavailable');
+    },
+  });
+
+  assert.equal(unavailable.reuse, false);
+  assert.match(unavailable.reason, /HTTP 503/);
+  assert.equal(malformed.reuse, false);
+  assert.match(malformed.reason, /unexpected response/);
+  assert.equal(rejected.reuse, false);
+  assert.match(rejected.reason, /failed safely/);
+});


### PR DESCRIPTION
Closes #166

## What changed
- prove a main merge tree is byte-identical to its second-parent PR head
- require a successful completed pull-request run of the exact authoritative CI workflow and head SHA
- skip the nine duplicate main jobs only when that proof succeeds
- fail open to the complete validation suite for every mismatch or lookup failure
- add contract tests, architecture ratchets, and operator documentation

## Local verification
- `node --test scripts/reuse-pr-validation.test.mjs`
- real GitHub API proof against merge `b45d09ba` and PR run `29953964477`
- direct-push fallback proof
- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check` (238/238 tasks)
- `pnpm check-architecture`
- `pnpm find-deadcode`
- `pnpm test`
- Turbo affected graph: 0 package workspaces

No changeset: this changes maintainer CI infrastructure, not a published package API.