### PR TITLE
perf(ci): promote validated compiler caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,30 +33,19 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/reuse-pr-validation.mjs
 
-      - name: Import compiler state from validated pull request
-        id: compiler_state
+      - name: Import TypeScript state from validated pull request
+        id: typescript_state
         if: steps.provenance.outputs.reuse == 'true'
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          pattern: pr-compiler-state-*
+          name: pr-compiler-state-typescript
           path: .
-          merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ steps.provenance.outputs.source_run_id }}
 
-      - name: Promote validated build state to main cache scope
-        if: steps.compiler_state.outcome == 'success'
-        continue-on-error: true
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            apps/web/.next/cache
-            .turbo
-          key: ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
-
       - name: Promote validated TypeScript state to main cache scope
-        if: steps.compiler_state.outcome == 'success'
+        if: steps.typescript_state.outcome == 'success'
         continue-on-error: true
         uses: actions/cache/save@v5
         with:
@@ -68,6 +57,50 @@ jobs:
             packages/tools/*/tsconfig.tsbuildinfo
             packages/tools/official/*/tsconfig.tsbuildinfo
           key: ${{ runner.os }}-typescript-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+
+      - name: Restore inherited main build state
+        id: inherited_build_state
+        if: steps.provenance.outputs.reuse == 'true'
+        continue-on-error: true
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            apps/web/.next/cache
+            .turbo
+          key: ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      - name: Import build delta from validated pull request
+        id: build_delta
+        if: steps.provenance.outputs.reuse == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-compiler-state-build
+          path: .ci/imported-build-state
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.provenance.outputs.source_run_id }}
+
+      - name: Apply validated Turbo build delta
+        id: build_state
+        if: steps.build_delta.outcome == 'success'
+        continue-on-error: true
+        run: >-
+          node scripts/compiler-cache-delta.mjs apply
+          .ci/imported-build-state .turbo/cache
+
+      - name: Promote validated build state to main cache scope
+        if: >-
+          steps.inherited_build_state.outcome == 'success' &&
+          steps.build_state.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            apps/web/.next/cache
+            .turbo
+          key: ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
 
   lint:
     needs: validation_provenance
@@ -222,6 +255,7 @@ jobs:
           pnpm release:build:test
           pnpm verify:vercel-api:test
           node --test scripts/reuse-pr-validation.test.mjs
+          node --test scripts/compiler-cache-delta.test.mjs
           pnpm test
 
       - name: Report and enforce test coverage
@@ -315,6 +349,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-
 
+      - name: Snapshot inherited Turbo build state
+        run: >-
+          node scripts/compiler-cache-delta.mjs snapshot
+          .turbo/cache .ci/build-cache-before.json
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -327,19 +366,21 @@ jobs:
           fi
           pnpm exec turbo run build --affected
 
+      - name: Prepare validated Turbo build delta
+        run: >-
+          node scripts/compiler-cache-delta.mjs collect
+          .turbo/cache .ci/build-cache-before.json .ci/compiler-state-build
+
       - name: Export validated build state
         if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: pr-compiler-state-build
-          path: |
-            apps/web/.next/cache
-            .turbo
-          include-hidden-files: true
-          if-no-files-found: warn
+          path: .ci/compiler-state-build/
+          if-no-files-found: error
           retention-days: 1
-          compression-level: 1
+          compression-level: 0
 
   executor:
     needs: validation_provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       reuse: ${{ steps.provenance.outputs.reuse }}
+      source_run_id: ${{ steps.provenance.outputs.source_run_id }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -31,6 +32,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/reuse-pr-validation.mjs
+
+      - name: Import compiler state from validated pull request
+        id: compiler_state
+        if: steps.provenance.outputs.reuse == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: pr-compiler-state-*
+          path: .
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.provenance.outputs.source_run_id }}
+
+      - name: Promote validated build state to main cache scope
+        if: steps.compiler_state.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            apps/web/.next/cache
+            .turbo
+          key: ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+
+      - name: Promote validated TypeScript state to main cache scope
+        if: steps.compiler_state.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            .turbo
+            apps/*/tsconfig.tsbuildinfo
+            apps/*/.next/cache/tsconfig.tsbuildinfo
+            packages/*/tsconfig.tsbuildinfo
+            packages/tools/*/tsconfig.tsbuildinfo
+            packages/tools/official/*/tsconfig.tsbuildinfo
+          key: ${{ runner.os }}-typescript-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
 
   lint:
     needs: validation_provenance
@@ -108,6 +145,24 @@ jobs:
             exit 0
           fi
           pnpm exec turbo run type-check --affected
+
+      - name: Export validated TypeScript state
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-compiler-state-typescript
+          path: |
+            .turbo
+            apps/*/tsconfig.tsbuildinfo
+            apps/*/.next/cache/tsconfig.tsbuildinfo
+            packages/*/tsconfig.tsbuildinfo
+            packages/tools/*/tsconfig.tsbuildinfo
+            packages/tools/official/*/tsconfig.tsbuildinfo
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 1
+          compression-level: 1
 
   type-coverage:
     needs: validation_provenance
@@ -271,6 +326,20 @@ jobs:
             exit 0
           fi
           pnpm exec turbo run build --affected
+
+      - name: Export validated build state
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-compiler-state-build
+          path: |
+            apps/web/.next/cache
+            .turbo
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 1
+          compression-level: 1
 
   executor:
     needs: validation_provenance

--- a/docs/BUILD_AND_RELEASE.md
+++ b/docs/BUILD_AND_RELEASE.md
@@ -46,6 +46,20 @@ pull-request merge ref available to the base branch. The provenance proof
 therefore removes the truly duplicate main run without adding an external
 cache service or placing TPMJS infrastructure on Vercel.
 
+Successful pull-request build and type-check jobs also export their
+reconstructable Turbo, Next.js, and TypeScript incremental state as one-day
+workflow artifacts. Once the merge provenance check identifies the exact
+successful source run, the trusted `main` push imports those artifacts and
+saves them under the existing default-branch cache keys. Later pull requests
+can therefore reuse work from earlier merged changes even though GitHub keeps
+their original merge-ref caches isolated.
+
+Cache promotion is deliberately best-effort and is never validation evidence.
+An absent, expired, malformed, or temporarily unavailable artifact simply
+leaves the cache cold; future jobs rebuild it. Promotion errors cannot turn a
+failed PR into a valid merge, cannot replace the exact-tree proof, and cannot
+fail an already-proven `main` workflow.
+
 `verify` is read-only. It proves that both systemd services are active, both
 live images carry the expected revision, the executor serves protocol 1.1, the
 web app can reach PostgreSQL, and the public health endpoint reports the same
@@ -224,6 +238,8 @@ fails if a maintainer accidentally:
 - restores the duplicate architecture build;
 - repeats exact green pull-request validation on an identical merge tree or
   lets uncertain provenance skip full validation;
+- lets validated compiler state become stranded in pull-request-only cache
+  scope or makes optional cache promotion a correctness dependency;
 - removes dependency-aware affected builds or their required Git history;
 - restores recursive dependency-tree traversal to TypeScript cache collection;
 - restores duplicate standard tsup configs, uses a monolithic tsdown workspace

--- a/docs/BUILD_AND_RELEASE.md
+++ b/docs/BUILD_AND_RELEASE.md
@@ -46,13 +46,22 @@ pull-request merge ref available to the base branch. The provenance proof
 therefore removes the truly duplicate main run without adding an external
 cache service or placing TPMJS infrastructure on Vercel.
 
-Successful pull-request build and type-check jobs also export their
-reconstructable Turbo, Next.js, and TypeScript incremental state as one-day
-workflow artifacts. Once the merge provenance check identifies the exact
-successful source run, the trusted `main` push imports those artifacts and
-saves them under the existing default-branch cache keys. Later pull requests
-can therefore reuse work from earlier merged changes even though GitHub keeps
-their original merge-ref caches isolated.
+Successful pull-request type-check jobs export their small reconstructable
+Turbo and TypeScript incremental state as a one-day workflow artifact. Build
+jobs snapshot the inherited Turbo cache before compilation and export only the
+new content-addressed entries, not the inherited Turbo and Next.js baseline.
+For a documentation-only change this delta is just a manifest instead of the
+roughly 1 GB baseline observed during the implementation proof.
+
+Once the merge provenance check identifies the exact successful source run,
+the trusted `main` push saves the TypeScript state, restores the latest main
+build baseline, and overlays the validated Turbo delta without overwriting an
+existing content-addressed entry. It then saves the result under the existing
+default-branch cache key. The prior Next.js compiler cache remains part of that
+baseline; a Turbo hit restores the validated build output itself. Later pull
+requests can therefore reuse work from earlier merged changes even though
+GitHub keeps their original merge-ref caches isolated, without transferring
+the whole inherited build cache through a second artifact channel.
 
 Cache promotion is deliberately best-effort and is never validation evidence.
 An absent, expired, malformed, or temporarily unavailable artifact simply

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -29,6 +29,7 @@ const executorDenoLock = JSON.parse(read('apps/railway-executor/deno.lock'));
 const webDockerfile = read('Dockerfile');
 const ci = read('.github/workflows/ci.yml');
 const reusePrValidation = read('scripts/reuse-pr-validation.mjs');
+const compilerCacheDelta = read('scripts/compiler-cache-delta.mjs');
 const sandboxTests = read('.github/workflows/sandbox-tests.yml');
 const release = read('.github/workflows/release.yml');
 const releasePreview = read('.github/workflows/release-preview.yml');
@@ -287,21 +288,33 @@ requireText(
   'run-id: ${{ steps.provenance.outputs.source_run_id }}',
   'main cache promotion must import only the exact validated pull-request run'
 );
+for (const artifact of ['pr-compiler-state-typescript', 'pr-compiler-state-build']) {
+  requireText(ci, `name: ${artifact}`, `main cache promotion must import the exact ${artifact}`);
+}
 requireText(
   ci,
-  'pattern: pr-compiler-state-*',
-  'main cache promotion must import the validated compiler-state artifacts'
+  "if: steps.typescript_state.outcome == 'success'",
+  'TypeScript cache promotion must require a successful exact artifact import'
 );
 requireText(
   ci,
-  "if: steps.compiler_state.outcome == 'success'",
-  'cache promotion must remain conditional on a successful artifact import'
+  "steps.inherited_build_state.outcome == 'success' &&",
+  'build cache promotion must require a successfully restored main baseline'
 );
-const bestEffortPromotionSteps = ci.match(
-  /name: Promote validated [^\n]+\n\s+if: steps\.compiler_state\.outcome == 'success'\n\s+continue-on-error: true/g
+requireText(
+  ci,
+  "steps.build_state.outcome == 'success'",
+  'build cache promotion must require a successfully applied validated delta'
 );
-if (bestEffortPromotionSteps?.length !== 2) {
-  failures.push('both main cache promotions must remain best-effort optimizations');
+for (const promotion of [
+  'Promote validated TypeScript state to main cache scope',
+  'Promote validated build state to main cache scope',
+]) {
+  const start = ci.indexOf(`- name: ${promotion}`);
+  const end = ci.indexOf('\n      - name:', start + 1);
+  const section = ci.slice(start, end < 0 ? ci.length : end);
+  requireText(section, 'continue-on-error: true', `${promotion} must remain best-effort`);
+  requireText(section, 'uses: actions/cache/save@v5', `${promotion} must use an explicit save`);
 }
 const bestEffortExportSteps = ci.match(
   /name: Export validated [^\n]+\n\s+if: github\.event_name == 'pull_request'\n\s+continue-on-error: true/g
@@ -309,10 +322,13 @@ const bestEffortExportSteps = ci.match(
 if (bestEffortExportSteps?.length !== 2) {
   failures.push('both pull-request compiler-state exports must remain best-effort optimizations');
 }
-for (const cacheKey of ['next-build-', 'typescript-']) {
+for (const [cacheKey, expectedCount] of [
+  ['next-build-', 3],
+  ['typescript-', 2],
+]) {
   const exactKey =
     'key: ${{ runner.os }}-' + cacheKey + "${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}";
-  if (ci.split(exactKey).length - 1 !== 2) {
+  if (ci.split(exactKey).length - 1 !== expectedCount) {
     failures.push(`${cacheKey} restore and promotion must use the same exact cache key`);
   }
 }
@@ -320,6 +336,11 @@ requireText(
   ci,
   'node --test scripts/reuse-pr-validation.test.mjs',
   'CI must exercise the validation provenance contract tests'
+);
+requireText(
+  ci,
+  'node --test scripts/compiler-cache-delta.test.mjs',
+  'CI must exercise the compiler-cache delta contract tests'
 );
 requireText(
   reusePrValidation,
@@ -335,6 +356,16 @@ requireText(
   reusePrValidation,
   'run?.path === CI_WORKFLOW_PATH',
   'validation reuse must require the authoritative CI workflow'
+);
+requireText(
+  compilerCacheDelta,
+  'const TURBO_CACHE_ENTRY = /^[0-9a-f]{16}',
+  'compiler-state promotion must admit only content-addressed Turbo cache entries'
+);
+requireText(
+  compilerCacheDelta,
+  'copyFileSync(source, join(cacheDir, name), constants.COPYFILE_EXCL)',
+  'compiler-state promotion must never overwrite an inherited cache entry'
 );
 
 const fullyValidatedJobs = [
@@ -496,8 +527,27 @@ requireText(
 );
 requireText(
   buildJob,
-  'include-hidden-files: true',
-  'build state export must include the hidden Turbo cache explicitly'
+  'compiler-cache-delta.mjs snapshot',
+  'build jobs must snapshot inherited Turbo state before compiling'
+);
+requireText(
+  buildJob,
+  'compiler-cache-delta.mjs collect',
+  'build jobs must export only newly validated content-addressed cache entries'
+);
+const buildExport = buildJob.slice(buildJob.indexOf('- name: Export validated build state'));
+requireText(
+  buildExport,
+  'path: .ci/compiler-state-build/',
+  'build promotion artifacts must contain the bounded validated delta staging directory'
+);
+if (buildExport.includes('apps/web/.next/cache') || buildExport.includes('\n            .turbo')) {
+  failures.push('build promotion artifacts must not re-export the inherited compiler baseline');
+}
+requireText(
+  buildExport,
+  'compression-level: 0',
+  'already-compressed Turbo deltas must avoid redundant artifact compression'
 );
 requireText(buildJob, 'retention-days: 1', 'build promotion artifacts must remain short-lived');
 

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -284,6 +284,40 @@ requireText(
 );
 requireText(
   ci,
+  'run-id: ${{ steps.provenance.outputs.source_run_id }}',
+  'main cache promotion must import only the exact validated pull-request run'
+);
+requireText(
+  ci,
+  'pattern: pr-compiler-state-*',
+  'main cache promotion must import the validated compiler-state artifacts'
+);
+requireText(
+  ci,
+  "if: steps.compiler_state.outcome == 'success'",
+  'cache promotion must remain conditional on a successful artifact import'
+);
+const bestEffortPromotionSteps = ci.match(
+  /name: Promote validated [^\n]+\n\s+if: steps\.compiler_state\.outcome == 'success'\n\s+continue-on-error: true/g
+);
+if (bestEffortPromotionSteps?.length !== 2) {
+  failures.push('both main cache promotions must remain best-effort optimizations');
+}
+const bestEffortExportSteps = ci.match(
+  /name: Export validated [^\n]+\n\s+if: github\.event_name == 'pull_request'\n\s+continue-on-error: true/g
+);
+if (bestEffortExportSteps?.length !== 2) {
+  failures.push('both pull-request compiler-state exports must remain best-effort optimizations');
+}
+for (const cacheKey of ['next-build-', 'typescript-']) {
+  const exactKey =
+    'key: ${{ runner.os }}-' + cacheKey + "${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}";
+  if (ci.split(exactKey).length - 1 !== 2) {
+    failures.push(`${cacheKey} restore and promotion must use the same exact cache key`);
+  }
+}
+requireText(
+  ci,
   'node --test scripts/reuse-pr-validation.test.mjs',
   'CI must exercise the validation provenance contract tests'
 );
@@ -421,6 +455,21 @@ requireText(
   'github.event.pull_request.base.sha || github.event.before',
   'affected type checking must compare exact event SHAs instead of a local branch name'
 );
+requireText(
+  typeCheckJob,
+  'name: pr-compiler-state-typescript',
+  'successful pull requests must export reusable TypeScript state'
+);
+requireText(
+  typeCheckJob,
+  'include-hidden-files: true',
+  'TypeScript state export must include the hidden Turbo cache explicitly'
+);
+requireText(
+  typeCheckJob,
+  'retention-days: 1',
+  'TypeScript promotion artifacts must remain short-lived'
+);
 
 const buildJob = ci.slice(ci.indexOf('  build:'), ci.indexOf('  executor:'));
 requireText(buildJob, '.turbo', 'the build job must preserve Turbo task artifacts');
@@ -440,6 +489,17 @@ requireText(
   'github.event.pull_request.base.sha || github.event.before',
   'affected builds must compare exact event SHAs instead of a local branch name'
 );
+requireText(
+  buildJob,
+  'name: pr-compiler-state-build',
+  'successful pull requests must export reusable build state'
+);
+requireText(
+  buildJob,
+  'include-hidden-files: true',
+  'build state export must include the hidden Turbo cache explicitly'
+);
+requireText(buildJob, 'retention-days: 1', 'build promotion artifacts must remain short-lived');
 
 if (sandboxTests.includes('run: pnpm build')) {
   failures.push('sandbox integration tests must not rebuild the unrelated monorepo');

--- a/scripts/compiler-cache-delta.mjs
+++ b/scripts/compiler-cache-delta.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import {
+  constants,
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MANIFEST_VERSION = 1;
+const TURBO_CACHE_ENTRY = /^[0-9a-f]{16}(?:-meta\.json|\.tar\.zst)$/;
+
+function cacheEntries(cacheDir) {
+  try {
+    return readdirSync(cacheDir)
+      .filter((name) => TURBO_CACHE_ENTRY.test(name) && lstatSync(join(cacheDir, name)).isFile())
+      .sort();
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+function readManifest(path, purpose) {
+  const manifest = JSON.parse(readFileSync(path, 'utf8'));
+  if (
+    manifest?.version !== MANIFEST_VERSION ||
+    !Array.isArray(manifest.files) ||
+    !manifest.files.every((name) => typeof name === 'string' && TURBO_CACHE_ENTRY.test(name))
+  ) {
+    throw new Error(`${purpose} manifest is invalid`);
+  }
+  return manifest;
+}
+
+export function snapshotCompilerCache({ cacheDir, manifestPath }) {
+  const files = cacheEntries(cacheDir);
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  writeFileSync(manifestPath, `${JSON.stringify({ version: MANIFEST_VERSION, files }, null, 2)}\n`);
+  return { files: files.length };
+}
+
+export function collectCompilerCacheDelta({ cacheDir, baselinePath, outputDir }) {
+  const baseline = new Set(readManifest(baselinePath, 'baseline').files);
+  const files = cacheEntries(cacheDir).filter((name) => !baseline.has(name));
+
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(outputDir, { recursive: true });
+  for (const name of files) copyFileSync(join(cacheDir, name), join(outputDir, name));
+  writeFileSync(
+    join(outputDir, 'manifest.json'),
+    `${JSON.stringify({ version: MANIFEST_VERSION, files }, null, 2)}\n`
+  );
+  return { files: files.length };
+}
+
+export function applyCompilerCacheDelta({ inputDir, cacheDir }) {
+  const manifest = readManifest(join(inputDir, 'manifest.json'), 'delta');
+  mkdirSync(cacheDir, { recursive: true });
+
+  let added = 0;
+  let alreadyPresent = 0;
+  for (const name of manifest.files) {
+    const source = join(inputDir, name);
+    if (!lstatSync(source).isFile()) throw new Error(`delta entry is not a file: ${name}`);
+
+    try {
+      copyFileSync(source, join(cacheDir, name), constants.COPYFILE_EXCL);
+      added += 1;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+      alreadyPresent += 1;
+    }
+  }
+
+  return { added, alreadyPresent };
+}
+
+function usage() {
+  return [
+    'Usage:',
+    '  compiler-cache-delta.mjs snapshot <cache-dir> <manifest>',
+    '  compiler-cache-delta.mjs collect <cache-dir> <baseline> <output-dir>',
+    '  compiler-cache-delta.mjs apply <input-dir> <cache-dir>',
+  ].join('\n');
+}
+
+function main([command, ...args]) {
+  let result;
+  if (command === 'snapshot' && args.length === 2) {
+    result = snapshotCompilerCache({ cacheDir: args[0], manifestPath: args[1] });
+  } else if (command === 'collect' && args.length === 3) {
+    result = collectCompilerCacheDelta({
+      cacheDir: args[0],
+      baselinePath: args[1],
+      outputDir: args[2],
+    });
+  } else if (command === 'apply' && args.length === 2) {
+    result = applyCompilerCacheDelta({ inputDir: args[0], cacheDir: args[1] });
+  } else {
+    throw new Error(usage());
+  }
+  console.log(JSON.stringify({ command, ...result }));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2));
+}

--- a/scripts/compiler-cache-delta.test.mjs
+++ b/scripts/compiler-cache-delta.test.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  applyCompilerCacheDelta,
+  collectCompilerCacheDelta,
+  snapshotCompilerCache,
+} from './compiler-cache-delta.mjs';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'tpmjs-compiler-cache-'));
+  const cacheDir = join(root, 'cache');
+  mkdirSync(cacheDir);
+  return {
+    root,
+    cacheDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+test('collects only content-addressed entries added after the snapshot', () => {
+  const state = fixture();
+  try {
+    const baselinePath = join(state.root, 'baseline.json');
+    const outputDir = join(state.root, 'delta');
+    writeFileSync(join(state.cacheDir, '1111111111111111.tar.zst'), 'old');
+    writeFileSync(join(state.cacheDir, 'not-a-turbo-entry'), 'ignored');
+    assert.deepEqual(
+      snapshotCompilerCache({ cacheDir: state.cacheDir, manifestPath: baselinePath }),
+      {
+        files: 1,
+      }
+    );
+
+    writeFileSync(join(state.cacheDir, '2222222222222222.tar.zst'), 'new-data');
+    writeFileSync(join(state.cacheDir, '2222222222222222-meta.json'), '{"new":true}');
+    assert.deepEqual(
+      collectCompilerCacheDelta({ cacheDir: state.cacheDir, baselinePath, outputDir }),
+      { files: 2 }
+    );
+    assert.deepEqual(JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8')).files, [
+      '2222222222222222-meta.json',
+      '2222222222222222.tar.zst',
+    ]);
+    assert.equal(readFileSync(join(outputDir, '2222222222222222.tar.zst'), 'utf8'), 'new-data');
+  } finally {
+    state.cleanup();
+  }
+});
+
+test('emits a valid empty delta when a job produces no new cache state', () => {
+  const state = fixture();
+  try {
+    const baselinePath = join(state.root, 'baseline.json');
+    const outputDir = join(state.root, 'delta');
+    snapshotCompilerCache({ cacheDir: state.cacheDir, manifestPath: baselinePath });
+    mkdirSync(outputDir);
+    writeFileSync(join(outputDir, 'stale-file'), 'must be removed');
+
+    assert.deepEqual(
+      collectCompilerCacheDelta({ cacheDir: state.cacheDir, baselinePath, outputDir }),
+      { files: 0 }
+    );
+    assert.deepEqual(JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8')).files, []);
+    assert.throws(() => readFileSync(join(outputDir, 'stale-file')), /ENOENT/);
+  } finally {
+    state.cleanup();
+  }
+});
+
+test('applies only declared safe cache entries and never overwrites an existing entry', () => {
+  const state = fixture();
+  try {
+    const inputDir = join(state.root, 'delta');
+    const destination = join(state.root, 'destination');
+    mkdirSync(inputDir);
+    mkdirSync(destination);
+    const existing = '3333333333333333.tar.zst';
+    const added = '4444444444444444.tar.zst';
+    writeFileSync(join(inputDir, existing), 'replacement');
+    writeFileSync(join(inputDir, added), 'new');
+    writeFileSync(
+      join(inputDir, 'manifest.json'),
+      JSON.stringify({ version: 1, files: [existing, added] })
+    );
+    writeFileSync(join(destination, existing), 'original');
+
+    assert.deepEqual(applyCompilerCacheDelta({ inputDir, cacheDir: destination }), {
+      added: 1,
+      alreadyPresent: 1,
+    });
+    assert.equal(readFileSync(join(destination, existing), 'utf8'), 'original');
+    assert.equal(readFileSync(join(destination, added), 'utf8'), 'new');
+  } finally {
+    state.cleanup();
+  }
+});
+
+test('rejects traversal names before applying an untrusted artifact manifest', () => {
+  const state = fixture();
+  try {
+    const inputDir = join(state.root, 'delta');
+    mkdirSync(inputDir);
+    writeFileSync(
+      join(inputDir, 'manifest.json'),
+      JSON.stringify({ version: 1, files: ['../outside.tar.zst'] })
+    );
+    assert.throws(
+      () => applyCompilerCacheDelta({ inputDir, cacheDir: state.cacheDir }),
+      /manifest is invalid/
+    );
+  } finally {
+    state.cleanup();
+  }
+});


### PR DESCRIPTION
Closes #168

## What changed
- export successful PR TypeScript state as a one-day artifact
- snapshot inherited Turbo build entries and export only newly validated content-addressed build entries
- import artifacts only from the exact successful source run established by merge-tree provenance
- save TypeScript state directly, then overlay the bounded build delta on the latest main baseline and save the existing default-branch cache keys
- reject unsafe delta names and never overwrite inherited content-addressed entries
- keep every transport and promotion step best-effort so cache state is never validation evidence
- add focused tests, architecture ratchets, and operator documentation

## Why
GitHub isolates pull-request caches from main and sibling PRs. After #167 removed duplicate main validation, the default-branch compiler baseline would otherwise become increasingly stale. The first end-to-end proof exposed a 996,155,499-byte full-baseline artifact. The bounded design reduced the same documentation-only build artifact to 174 bytes and reduced the build job from 1m21s to 53s.

## Verification
- all nine authoritative PR jobs green in run 29958914821
- node --test scripts/reuse-pr-validation.test.mjs scripts/compiler-cache-delta.test.mjs
- pnpm lint
- pnpm format:check
- pnpm check-architecture
- pnpm test via the pre-push hook
- Turbo affected graph: 0 package workspaces

No changeset: this changes CI cache transport, not a published package API.