### PR TITLE
feat(web): make public collections one-command MCP servers

### DIFF
--- a/apps/web/src/app/(profile)/[username]/collections/[slug]/CollectionDetailClient.tsx
+++ b/apps/web/src/app/(profile)/[username]/collections/[slug]/CollectionDetailClient.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { Badge } from '@tpmjs/ui/Badge/Badge';
-import { Button } from '@tpmjs/ui/Button/Button';
-import { CodeBlock } from '@tpmjs/ui/CodeBlock/CodeBlock';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
 import Link from 'next/link';
 import { useCallback, useState } from 'react';
 import { AppHeader } from '~/components/AppHeader';
+import { CollectionActivationPanel } from '~/components/collections/CollectionActivationPanel';
 import { ForkButton } from '~/components/ForkButton';
 import { ForkedFromBadge } from '~/components/ForkedFromBadge';
 import { LikeButton } from '~/components/LikeButton';
@@ -15,8 +14,6 @@ import { ShareButton } from '~/components/ShareButton';
 import { SkillsSection } from '~/components/skills/SkillsSection';
 import { UseCasesSection } from '~/components/UseCasesSection';
 import { useTrackView } from '~/hooks/useTrackView';
-import { trackCollectionMcpCopy } from '~/lib/analytics';
-import { useSession } from '~/lib/auth-client';
 
 /**
  * Locked state for private collections viewed by non-owners
@@ -106,218 +103,6 @@ export interface PublicCollection {
   useCasesGeneratedAt?: string | null;
 }
 
-function McpUrlSection({
-  collectionId,
-  username,
-  slug,
-  isOwner,
-}: {
-  collectionId: string;
-  username: string;
-  slug: string;
-  isOwner: boolean;
-}) {
-  const [copiedUrl, setCopiedUrl] = useState<'http' | 'sse' | null>(null);
-  const [showConfig, setShowConfig] = useState(false);
-  const [showApiExample, setShowApiExample] = useState(false);
-
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://tpmjs.com';
-  const httpUrl = `${baseUrl}/api/mcp/${username}/${slug}/http`;
-  const sseUrl = `${baseUrl}/api/mcp/${username}/${slug}/sse`;
-
-  const copyToClipboard = async (url: string, type: 'http' | 'sse') => {
-    await navigator.clipboard.writeText(url);
-    trackCollectionMcpCopy(collectionId, `${type}_url`);
-    setCopiedUrl(type);
-    setTimeout(() => setCopiedUrl(null), 2000);
-  };
-
-  // Claude Code CLI command (correct arg order: options before name and url)
-  const claudeCodeCommand = `claude mcp add tpmjs-${slug} ${httpUrl} -t http`;
-
-  // Claude Desktop native HTTP config
-  const configSnippet = `{
-  "mcpServers": {
-    "tpmjs-${slug}": {
-      "type": "http",
-      "url": "${httpUrl}"
-    }
-  }
-}`;
-
-  const apiExampleSnippet = `// Call a tool with your own credentials
-const response = await fetch("${httpUrl}", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "Authorization": "Bearer YOUR_TPMJS_API_KEY"
-  },
-  body: JSON.stringify({
-    jsonrpc: "2.0",
-    method: "tools/call",
-    params: {
-      name: "tool-name",
-      arguments: { /* tool args */ },
-      env: {
-        // Your env vars for the tools
-        "API_KEY": "your-key-here"
-      }
-    },
-    id: 1
-  })
-});`;
-
-  return (
-    <section className="p-4 bg-gradient-to-br from-primary/5 via-transparent to-primary/5 border border-primary/20 rounded-xl">
-      <div className="flex items-center gap-2 mb-4">
-        <div className="p-1.5 bg-primary/10 rounded-lg">
-          <Icon icon="link" className="w-4 h-4 text-primary" />
-        </div>
-        <h3 className="font-semibold text-foreground">MCP Server URLs</h3>
-      </div>
-
-      <div className="space-y-3">
-        {/* HTTP Transport */}
-        <div className="group">
-          <div className="flex items-center gap-2 mb-1.5">
-            <span className="text-xs font-medium text-foreground-secondary uppercase tracking-wide">
-              HTTP Transport
-            </span>
-            <span className="text-xs text-foreground-tertiary">(recommended)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg font-mono text-sm text-foreground-secondary overflow-x-auto">
-              {httpUrl}
-            </div>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => copyToClipboard(httpUrl, 'http')}
-              className="shrink-0"
-            >
-              <Icon icon={copiedUrl === 'http' ? 'check' : 'copy'} className="w-4 h-4 mr-1" />
-              {copiedUrl === 'http' ? 'Copied!' : 'Copy'}
-            </Button>
-          </div>
-        </div>
-
-        {/* SSE Transport */}
-        <div className="group">
-          <div className="flex items-center gap-2 mb-1.5">
-            <span className="text-xs font-medium text-foreground-secondary uppercase tracking-wide">
-              SSE Transport
-            </span>
-            <span className="text-xs text-foreground-tertiary">(streaming)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg font-mono text-sm text-foreground-secondary overflow-x-auto">
-              {sseUrl}
-            </div>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => copyToClipboard(sseUrl, 'sse')}
-              className="shrink-0"
-            >
-              <Icon icon={copiedUrl === 'sse' ? 'check' : 'copy'} className="w-4 h-4 mr-1" />
-              {copiedUrl === 'sse' ? 'Copied!' : 'Copy'}
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      {/* Note for non-owners */}
-      {!isOwner && (
-        <div className="mt-4 p-3 bg-warning/10 border border-warning/20 rounded-lg">
-          <p className="text-sm text-warning-foreground">
-            <Icon icon="info" className="w-4 h-4 inline mr-1" />
-            You&apos;ll need to provide your own API keys for any tools that require them. Pass
-            credentials via the{' '}
-            <code className="font-mono text-xs bg-surface px-1 rounded">env</code> parameter in your
-            API calls.
-          </p>
-        </div>
-      )}
-
-      {/* Claude Code CLI command */}
-      <div className="mt-4 pt-4 border-t border-border/50">
-        <h4 className="text-sm font-medium text-foreground mb-2">Add to Claude Code</h4>
-        <div className="relative">
-          <pre className="p-3 bg-surface border border-border rounded-lg text-xs font-mono text-foreground-secondary overflow-x-auto whitespace-pre-wrap break-all">
-            {claudeCodeCommand}
-          </pre>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={async () => {
-              await navigator.clipboard.writeText(claudeCodeCommand);
-              trackCollectionMcpCopy(collectionId, 'claude_code');
-            }}
-            className="absolute top-1.5 right-1.5"
-          >
-            <Icon icon="copy" className="w-3.5 h-3.5" />
-          </Button>
-        </div>
-        <p className="mt-1.5 text-xs text-foreground-tertiary">
-          Run <code className="font-mono">/mcp</code> in Claude Code to verify the connection.
-        </p>
-      </div>
-
-      {/* Config snippet toggle */}
-      <div className="mt-4 pt-4 border-t border-border/50 space-y-2">
-        <button
-          type="button"
-          onClick={() => setShowConfig(!showConfig)}
-          className="flex items-center gap-2 text-sm text-primary hover:text-primary/80 transition-colors"
-        >
-          <Icon icon={showConfig ? 'chevronDown' : 'chevronRight'} className="w-4 h-4" />
-          <span>Show Claude Desktop config</span>
-        </button>
-
-        {showConfig && (
-          <div className="mt-3">
-            <CodeBlock
-              language="json"
-              code={configSnippet}
-              onCopy={() => trackCollectionMcpCopy(collectionId, 'claude_config')}
-            />
-          </div>
-        )}
-
-        {!isOwner && (
-          <>
-            <button
-              type="button"
-              onClick={() => setShowApiExample(!showApiExample)}
-              className="flex items-center gap-2 text-sm text-primary hover:text-primary/80 transition-colors"
-            >
-              <Icon icon={showApiExample ? 'chevronDown' : 'chevronRight'} className="w-4 h-4" />
-              <span>Show API usage example</span>
-            </button>
-
-            {showApiExample && (
-              <div className="mt-3">
-                <CodeBlock
-                  language="typescript"
-                  code={apiExampleSnippet}
-                  onCopy={() => trackCollectionMcpCopy(collectionId, 'api_example')}
-                />
-              </div>
-            )}
-          </>
-        )}
-      </div>
-
-      <p className="mt-3 text-xs text-foreground-tertiary">
-        Use these URLs with{' '}
-        <Link href="/docs/sharing" className="text-primary hover:underline">
-          Claude Desktop, Cursor, or any MCP client
-        </Link>
-      </p>
-    </section>
-  );
-}
-
 interface CollectionDetailClientProps {
   collection: PublicCollection;
   username: string;
@@ -327,14 +112,10 @@ export function CollectionDetailClient({
   collection: initialCollection,
   username,
 }: CollectionDetailClientProps) {
-  const { data: session } = useSession();
   const [collection, setCollection] = useState(initialCollection);
 
   // Track page view
   useTrackView('collection', collection.id);
-
-  // Check if current user is the owner
-  const isOwner = session?.user?.id && collection.createdBy?.id === session.user.id;
 
   // Handler for when use cases are generated
   const handleUseCasesGenerated = useCallback(
@@ -419,12 +200,13 @@ export function CollectionDetailClient({
             )}
           </div>
 
-          {/* MCP Server URLs - Available to everyone (non-owners must provide their own credentials) */}
-          <McpUrlSection
+          {/* Public collections are live HTTP MCP servers with a token-free connection path. */}
+          <CollectionActivationPanel
             collectionId={collection.id}
+            name={collection.name}
             username={username}
             slug={collection.slug}
-            isOwner={!!isOwner}
+            toolCount={collection.toolCount}
           />
 
           {/* Tools */}

--- a/apps/web/src/app/collections/CollectionsClient.tsx
+++ b/apps/web/src/app/collections/CollectionsClient.tsx
@@ -204,11 +204,7 @@ export function CollectionsClient({
         <td className="px-4 py-3 text-right">
           {collection.createdBy.username && collection.slug && (
             <CopyDropdown
-              options={getCollectionCopyOptions(
-                collection.createdBy.username,
-                collection.slug,
-                collection.name
-              )}
+              options={getCollectionCopyOptions(collection.createdBy.username, collection.slug)}
               buttonLabel="Copy"
               onCopy={(option) => {
                 if (option.id) trackCollectionMcpCopy(collection.id, option.id);

--- a/apps/web/src/app/collections/[id]/page.tsx
+++ b/apps/web/src/app/collections/[id]/page.tsx
@@ -7,8 +7,8 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { AppHeader } from '~/components/AppHeader';
+import { CollectionActivationPanel } from '~/components/collections/CollectionActivationPanel';
 import { LikeButton } from '~/components/LikeButton';
-import { trackCollectionMcpCopy } from '~/lib/analytics';
 
 interface CollectionTool {
   id: string;
@@ -45,145 +45,6 @@ interface PublicCollection {
     image: string | null;
   };
   tools: CollectionTool[];
-}
-
-function McpUrlSection({
-  collectionId,
-  username,
-  slug,
-}: {
-  collectionId: string;
-  username: string;
-  slug: string;
-}) {
-  const [copiedUrl, setCopiedUrl] = useState<'http' | 'sse' | null>(null);
-  const [showConfig, setShowConfig] = useState(false);
-
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://tpmjs.com';
-  const httpUrl = `${baseUrl}/api/mcp/${username}/${slug}/http`;
-  const sseUrl = `${baseUrl}/api/mcp/${username}/${slug}/sse`;
-
-  const copyToClipboard = async (url: string, type: 'http' | 'sse') => {
-    await navigator.clipboard.writeText(url);
-    trackCollectionMcpCopy(collectionId, `${type}_url`);
-    setCopiedUrl(type);
-    setTimeout(() => setCopiedUrl(null), 2000);
-  };
-
-  const configSnippet = `{
-  "mcpServers": {
-    "tpmjs-collection": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "${httpUrl}",
-        "--header",
-        "Authorization: Bearer YOUR_TPMJS_API_KEY"
-      ]
-    }
-  }
-}`;
-
-  return (
-    <div className="mb-8 p-4 bg-gradient-to-br from-primary/5 via-transparent to-primary/5 border border-primary/20 rounded-xl">
-      <div className="flex items-center gap-2 mb-4">
-        <div className="p-1.5 bg-primary/10 rounded-lg">
-          <Icon icon="link" size="sm" className="text-primary" />
-        </div>
-        <h3 className="font-semibold text-foreground">MCP Server URLs</h3>
-      </div>
-
-      <div className="space-y-3">
-        {/* HTTP Transport */}
-        <div className="group">
-          <div className="flex items-center gap-2 mb-1.5">
-            <span className="text-xs font-medium text-foreground-secondary uppercase tracking-wide">
-              HTTP Transport
-            </span>
-            <span className="text-xs text-foreground-tertiary">(recommended)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg font-mono text-sm text-foreground-secondary overflow-x-auto">
-              {httpUrl}
-            </div>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => copyToClipboard(httpUrl, 'http')}
-              className="shrink-0"
-            >
-              <Icon icon={copiedUrl === 'http' ? 'check' : 'copy'} size="xs" className="mr-1" />
-              {copiedUrl === 'http' ? 'Copied!' : 'Copy'}
-            </Button>
-          </div>
-        </div>
-
-        {/* SSE Transport */}
-        <div className="group">
-          <div className="flex items-center gap-2 mb-1.5">
-            <span className="text-xs font-medium text-foreground-secondary uppercase tracking-wide">
-              SSE Transport
-            </span>
-            <span className="text-xs text-foreground-tertiary">(streaming)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg font-mono text-sm text-foreground-secondary overflow-x-auto">
-              {sseUrl}
-            </div>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => copyToClipboard(sseUrl, 'sse')}
-              className="shrink-0"
-            >
-              <Icon icon={copiedUrl === 'sse' ? 'check' : 'copy'} size="xs" className="mr-1" />
-              {copiedUrl === 'sse' ? 'Copied!' : 'Copy'}
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      {/* Config snippet toggle */}
-      <div className="mt-4 pt-4 border-t border-border/50">
-        <button
-          type="button"
-          onClick={() => setShowConfig(!showConfig)}
-          className="flex items-center gap-2 text-sm text-primary hover:text-primary/80 transition-colors"
-        >
-          <Icon icon={showConfig ? 'chevronDown' : 'chevronRight'} size="xs" />
-          <span>Show Claude Desktop config</span>
-        </button>
-
-        {showConfig && (
-          <div className="mt-3 relative">
-            <pre className="p-4 bg-surface border border-border rounded-lg text-xs font-mono text-foreground-secondary overflow-x-auto">
-              {configSnippet}
-            </pre>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={async () => {
-                await navigator.clipboard.writeText(configSnippet);
-                trackCollectionMcpCopy(collectionId, 'claude_config');
-                setCopiedUrl('http');
-                setTimeout(() => setCopiedUrl(null), 2000);
-              }}
-              className="absolute top-2 right-2"
-            >
-              <Icon icon="copy" size="xs" />
-            </Button>
-          </div>
-        )}
-      </div>
-
-      <p className="mt-3 text-xs text-foreground-tertiary">
-        Use these URLs with{' '}
-        <Link href="/docs/tutorials/mcp" className="text-primary hover:underline">
-          Claude Desktop, Cursor, or any MCP client
-        </Link>
-      </p>
-    </div>
-  );
 }
 
 export default function PublicCollectionDetailPage(): React.ReactElement {
@@ -321,12 +182,14 @@ export default function PublicCollectionDetailPage(): React.ReactElement {
           </span>
         </div>
 
-        {/* MCP URLs */}
+        {/* Legacy ID URLs redirect here when a stable public identity is available. */}
         {collection.createdBy?.username && collection.slug && (
-          <McpUrlSection
+          <CollectionActivationPanel
             collectionId={collection.id}
+            name={collection.name}
             username={collection.createdBy.username}
             slug={collection.slug}
+            toolCount={collection.toolCount}
           />
         )}
 

--- a/apps/web/src/app/dashboard/collections/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/collections/[id]/page.tsx
@@ -23,6 +23,11 @@ import { CustomServerPanel } from '~/components/collections/CustomServerPanel';
 import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
 import { EnvVarsEditor } from '~/components/EnvVarsEditor';
 import { ExecutorConfigPanel } from '~/components/ExecutorConfigPanel';
+import {
+  buildClaudeCodeCollectionCommand,
+  buildClaudeDesktopCollectionConfig,
+  buildCollectionMcpUrl,
+} from '~/lib/collection-mcp';
 
 // MCP URL display component
 function McpUrlDisplay({ url, label, sublabel }: { url: string; label: string; sublabel: string }) {
@@ -366,25 +371,11 @@ export default function CollectionDetailPage(): React.ReactElement {
   }
 
   const existingToolIds = collection.tools.map((t) => t.toolId);
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://tpmjs.com';
-  const httpUrl = `${baseUrl}/api/mcp/${collection.user.username}/${collection.slug}/http`;
-  const sseUrl = `${baseUrl}/api/mcp/${collection.user.username}/${collection.slug}/sse`;
-
-  // Claude Code CLI command (correct arg order: options before name and url)
-  const claudeCodeCommand = `claude mcp add ${collection.slug} ${httpUrl} -t http -H "Authorization: Bearer YOUR_TPMJS_API_KEY"`;
-
-  // Claude Desktop native HTTP config
-  const configSnippet = `{
-  "mcpServers": {
-    "${collection.slug}": {
-      "type": "http",
-      "url": "${httpUrl}",
-      "headers": {
-        "Authorization": "Bearer YOUR_TPMJS_API_KEY"
-      }
-    }
-  }
-}`;
+  const mcpTarget = { username: collection.user.username, slug: collection.slug };
+  const httpUrl = buildCollectionMcpUrl(mcpTarget);
+  const ownerAuth = { bearerToken: 'YOUR_TPMJS_API_KEY' };
+  const claudeCodeCommand = buildClaudeCodeCollectionCommand(mcpTarget, ownerAuth);
+  const configSnippet = buildClaudeDesktopCollectionConfig(mcpTarget, ownerAuth);
 
   const envVarsCount = envVars ? Object.keys(envVars).length : 0;
 
@@ -584,12 +575,11 @@ export default function CollectionDetailPage(): React.ReactElement {
                 <div className="p-1.5 bg-primary/10 rounded-lg">
                   <Icon icon="link" size="sm" className="text-primary" />
                 </div>
-                <h3 className="font-semibold text-foreground">MCP Server URLs</h3>
+                <h3 className="font-semibold text-foreground">MCP Server</h3>
               </div>
 
               <div className="space-y-4">
                 <McpUrlDisplay url={httpUrl} label="HTTP Transport" sublabel="recommended" />
-                <McpUrlDisplay url={sseUrl} label="SSE Transport" sublabel="streaming" />
               </div>
 
               {/* Claude Code CLI command */}

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -1439,8 +1439,7 @@ export TPMJS_EXECUTOR_URL=https://executor.mycompany.com`}
                 <CodeBlock
                   language="bash"
                   code={`claude mcp add --transport http tpmjs-my-collection \\
-  https://tpmjs.com/api/mcp/<username>/<collection-slug>/http \\
-  --header "Authorization: Bearer $TPMJS_API_KEY"`}
+  https://tpmjs.com/@<username>/collections/<collection-slug>/mcp`}
                 />
                 <p className="text-foreground-secondary mt-4">
                   This automatically adds the server to your Claude Code configuration.

--- a/apps/web/src/app/docs/platform-guide/page.tsx
+++ b/apps/web/src/app/docs/platform-guide/page.tsx
@@ -738,26 +738,18 @@ Invalid usernames:
               </p>
               <DocSubSection title="MCP Server URLs">
                 <p className="text-foreground-secondary mb-4">
-                  Each collection provides two transport options:
+                  Every collection has one recommended, human-readable HTTP endpoint:
                 </p>
-                <div className="space-y-3">
-                  <div className="p-4 border border-border rounded-lg bg-surface">
-                    <div className="flex items-center gap-2 mb-2">
-                      <Badge variant="success" size="sm">
-                        Recommended
-                      </Badge>
-                      <code className="text-primary font-mono text-sm">HTTP Transport</code>
-                    </div>
-                    <code className="text-xs text-foreground-secondary block">
-                      https://tpmjs.com/api/mcp/{'{username}'}/{'{collection-slug}'}/http
-                    </code>
+                <div className="p-4 border border-border rounded-lg bg-surface">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Badge variant="success" size="sm">
+                      Recommended
+                    </Badge>
+                    <code className="text-primary font-mono text-sm">HTTP Transport</code>
                   </div>
-                  <div className="p-4 border border-border rounded-lg bg-surface">
-                    <code className="text-primary font-mono text-sm block mb-2">SSE Transport</code>
-                    <code className="text-xs text-foreground-secondary block">
-                      https://tpmjs.com/api/mcp/{'{username}'}/{'{collection-slug}'}/sse
-                    </code>
-                  </div>
+                  <code className="text-xs text-foreground-secondary block">
+                    https://tpmjs.com/@{'{username}'}/collections/{'{collection-slug}'}/mcp
+                  </code>
                 </div>
               </DocSubSection>
               <DocSubSection title="Claude Desktop Configuration">
@@ -769,13 +761,8 @@ Invalid usernames:
                   code={`{
   "mcpServers": {
     "tpmjs-my-collection": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://tpmjs.com/@YOUR_USERNAME/collections/YOUR_COLLECTION_SLUG/mcp",
-        "--header",
-        "Authorization: Bearer YOUR_TPMJS_API_KEY"
-      ]
+      "type": "http",
+      "url": "https://tpmjs.com/@YOUR_USERNAME/collections/YOUR_COLLECTION_SLUG/mcp"
     }
   }
 }`}
@@ -802,8 +789,7 @@ Invalid usernames:
                 <CodeBlock
                   language="bash"
                   code={`claude mcp add --transport http tpmjs-my-collection \\
-  https://tpmjs.com/api/mcp/YOUR_USERNAME/YOUR_COLLECTION_SLUG/http \\
-  --header "Authorization: Bearer $TPMJS_API_KEY"`}
+  https://tpmjs.com/@YOUR_USERNAME/collections/YOUR_COLLECTION_SLUG/mcp`}
                 />
               </DocSubSection>
             </DocSection>

--- a/apps/web/src/app/docs/sharing/page.tsx
+++ b/apps/web/src/app/docs/sharing/page.tsx
@@ -360,20 +360,15 @@ Invalid usernames:
               </DocSubSection>
               <DocSubSection title="MCP Server URLs">
                 <p className="text-foreground-secondary mb-4">
-                  Each collection provides HTTP and SSE transport URLs:
+                  Each collection provides one recommended HTTP endpoint:
                 </p>
                 <CodeBlock
                   language="json"
                   code={`{
   "mcpServers": {
     "tpmjs-collection": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://tpmjs.com/api/mcp/{username}/{collection-slug}/http",
-        "--header",
-        "Authorization: Bearer YOUR_TPMJS_API_KEY"
-      ]
+      "type": "http",
+      "url": "https://tpmjs.com/@{username}/collections/{collection-slug}/mcp"
     }
   }
 }`}

--- a/apps/web/src/app/how-it-works/page.tsx
+++ b/apps/web/src/app/how-it-works/page.tsx
@@ -595,14 +595,13 @@ const result = await streamText({
                   <CodeBlock
                     language="bash"
                     code={`# Add a collection to Claude Code as one MCP endpoint
-claude mcp add web-scraping \\
-  https://tpmjs.com/@ada/collections/web-scraping/mcp \\
-  -t http
+claude mcp add --transport http tpmjs-web-scraping \\
+  https://tpmjs.com/@ada/collections/web-scraping/mcp
 
 # Private collection? Pass your TPMJS API key
-claude mcp add web-scraping \\
+claude mcp add --transport http tpmjs-web-scraping \\
   https://tpmjs.com/@ada/collections/web-scraping/mcp \\
-  -t http -H "Authorization: Bearer YOUR_TPMJS_API_KEY"`}
+  --header "Authorization: Bearer YOUR_TPMJS_API_KEY"`}
                   />
                   <div className="mt-4 p-4 bg-primary/5 border border-primary/20 rounded">
                     <p className="text-sm text-foreground-secondary">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,6 +13,7 @@ import { HeroSection } from '../components/home/HeroSection';
 import { McpSection } from '../components/home/McpSection';
 import { ProtocolSection } from '../components/home/ProtocolSection';
 import { SocialProofSection } from '../components/home/SocialProofSection';
+import { selectFeaturedCollection } from '../lib/featured-collection';
 import { defaultToolDiscoveryFilter } from '../lib/tool-health-policy';
 
 export const dynamic = 'force-dynamic';
@@ -27,6 +28,7 @@ async function getHomePageData() {
       latestSnapshot,
       liveToolCount,
       livePackageCount,
+      featuredCollectionCandidates,
     ] = await Promise.all([
       // Top 6 featured tools by quality score (never feature an import-broken tool)
       prisma.tool.findMany({
@@ -125,6 +127,28 @@ async function getHomePageData() {
       // never trust the drift-prone counters/snapshot for the headline numbers).
       prisma.tool.count({ where: defaultToolDiscoveryFilter() }),
       prisma.package.count(),
+
+      // Build a bounded live candidate set. The final choice combines proven
+      // usage with collection breadth instead of pinning a hand-maintained ID.
+      prisma.collection.findMany({
+        where: {
+          isPublic: true,
+          slug: { not: null },
+          user: { username: { not: null } },
+          tools: { some: { tool: defaultToolDiscoveryFilter() } },
+        },
+        orderBy: [{ executionCount: 'desc' }, { likeCount: 'desc' }, { createdAt: 'desc' }],
+        take: 50,
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          executionCount: true,
+          likeCount: true,
+          user: { select: { username: true } },
+          _count: { select: { tools: true } },
+        },
+      }),
     ]);
 
     // Always query all-time avg execution time (snapshot only has daily value)
@@ -185,6 +209,7 @@ async function getHomePageData() {
     // reconcile job). Small tables, so a direct count is instant.
     const packageCount = livePackageCount;
     const toolCount = liveToolCount;
+    const featuredCollection = selectFeaturedCollection(featuredCollectionCandidates);
 
     return {
       stats: {
@@ -201,6 +226,16 @@ async function getHomePageData() {
         count: c._count._all,
       })),
       featuredScenarios,
+      featuredCollection:
+        featuredCollection?.slug && featuredCollection.user.username
+          ? {
+              id: featuredCollection.id,
+              name: featuredCollection.name,
+              slug: featuredCollection.slug,
+              username: featuredCollection.user.username,
+              toolCount: featuredCollection._count.tools,
+            }
+          : null,
     };
   } catch (error) {
     console.error('Failed to fetch homepage data:', error);
@@ -222,6 +257,7 @@ async function getHomePageData() {
       featuredTools: [],
       categories: [],
       featuredScenarios: [],
+      featuredCollection: null,
     };
   }
 }
@@ -236,8 +272,8 @@ export default async function HomePage(): Promise<React.ReactElement> {
         {/* Hero Section - Dithered Design */}
         <HeroSection stats={data.stats} />
 
-        {/* Get Started - Install Script Section */}
-        <GetStartedSection />
+        {/* Get Started - live public collection activation */}
+        <GetStartedSection collection={data.featuredCollection} />
 
         {/* Ecosystem Stats */}
         <EcosystemStats stats={data.ecosystemStats} />

--- a/apps/web/src/app/sdk/page.tsx
+++ b/apps/web/src/app/sdk/page.tsx
@@ -636,14 +636,13 @@ Use registrySearch to find tools, then registryExecute to run them.\`,
                 <CodeBlock
                   language="bash"
                   code={`# Add a collection to Claude Code as one MCP endpoint
-claude mcp add web-scraping \\
-  https://tpmjs.com/@ada/collections/web-scraping/mcp \\
-  -t http
+claude mcp add --transport http tpmjs-web-scraping \\
+  https://tpmjs.com/@ada/collections/web-scraping/mcp
 
 # Private collection? Pass your TPMJS API key
-claude mcp add web-scraping \\
+claude mcp add --transport http tpmjs-web-scraping \\
   https://tpmjs.com/@ada/collections/web-scraping/mcp \\
-  -t http -H "Authorization: Bearer YOUR_TPMJS_API_KEY"`}
+  --header "Authorization: Bearer YOUR_TPMJS_API_KEY"`}
                 />
               </div>
 

--- a/apps/web/src/components/CopyButton.tsx
+++ b/apps/web/src/components/CopyButton.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@tpmjs/ui/Button/Button';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 interface CopyButtonProps {
@@ -11,6 +11,7 @@ interface CopyButtonProps {
   successMessage?: string;
   size?: 'xs' | 'sm' | 'md';
   className?: string;
+  onCopy?: () => void;
 }
 
 export function CopyButton({
@@ -19,19 +20,34 @@ export function CopyButton({
   successMessage = 'Copied to clipboard',
   size = 'sm',
   className = '',
+  onCopy,
 }: CopyButtonProps): React.ReactElement {
   const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    []
+  );
 
   const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
       toast.success(successMessage);
-      setTimeout(() => setCopied(false), 2000);
+      try {
+        onCopy?.();
+      } catch {
+        // Follow-up observers must never turn a successful copy into a UI failure.
+      }
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error('Failed to copy');
     }
-  }, [text, successMessage]);
+  }, [text, successMessage, onCopy]);
 
   const iconSize = size === 'xs' ? 'xs' : size === 'sm' ? 'sm' : 'md';
   // Map xs to sm for Button since Button doesn't support xs size
@@ -44,9 +60,10 @@ export function CopyButton({
       onClick={handleCopy}
       className={`inline-flex items-center gap-1.5 text-foreground-secondary hover:text-foreground ${className}`}
       title={label || 'Copy to clipboard'}
+      aria-label={label || 'Copy to clipboard'}
     >
       <Icon icon={copied ? 'check' : 'copy'} size={iconSize} />
-      {label && <span className="text-xs">{label}</span>}
+      {label && <span className={size === 'md' ? 'text-sm' : 'text-xs'}>{label}</span>}
     </Button>
   );
 }

--- a/apps/web/src/components/CopyDropdown.tsx
+++ b/apps/web/src/components/CopyDropdown.tsx
@@ -4,6 +4,11 @@ import { Button } from '@tpmjs/ui/Button/Button';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import {
+  buildClaudeCodeCollectionCommand,
+  buildClaudeDesktopCollectionConfig,
+  buildCollectionMcpUrl,
+} from '~/lib/collection-mcp';
 
 export interface CopyOption {
   /** Stable identifier for consumers such as analytics; never derived from the label. */
@@ -101,35 +106,22 @@ export function CopyDropdown({
 
 // Helper functions to generate copy options for different entity types
 
-export function getCollectionCopyOptions(
-  username: string,
-  slug: string,
-  collectionName: string
-): CopyOption[] {
-  const baseUrl = 'https://tpmjs.com';
-  const mcpUrlHttp = `${baseUrl}/api/mcp/${username}/${slug}/http`;
-  const mcpUrlSse = `${baseUrl}/api/mcp/${username}/${slug}/sse`;
-
-  const claudeConfig = JSON.stringify(
-    {
-      mcpServers: {
-        [collectionName.toLowerCase().replace(/\s+/g, '-')]: {
-          command: 'npx',
-          args: ['-y', '@anthropic-ai/mcp-remote', mcpUrlSse],
-        },
-      },
-    },
-    null,
-    2
-  );
+export function getCollectionCopyOptions(username: string, slug: string): CopyOption[] {
+  const target = { username, slug };
+  const mcpUrl = buildCollectionMcpUrl(target);
 
   return [
-    { id: 'http_url', label: 'MCP URL (HTTP)', value: mcpUrlHttp, description: mcpUrlHttp },
-    { id: 'sse_url', label: 'MCP URL (SSE)', value: mcpUrlSse, description: mcpUrlSse },
+    {
+      id: 'claude_code',
+      label: 'Claude Code command',
+      value: buildClaudeCodeCollectionCommand(target),
+      description: 'Connect this public collection over HTTP',
+    },
+    { id: 'http_url', label: 'MCP URL (HTTP)', value: mcpUrl, description: mcpUrl },
     {
       id: 'claude_config',
-      label: 'Claude Config',
-      value: claudeConfig,
+      label: 'Claude Desktop config',
+      value: buildClaudeDesktopCollectionConfig(target),
       description: 'JSON for claude_desktop_config.json',
     },
   ];

--- a/apps/web/src/components/collections/CollectionActivationPanel.tsx
+++ b/apps/web/src/components/collections/CollectionActivationPanel.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { Badge } from '@tpmjs/ui/Badge/Badge';
+import { CodeBlock } from '@tpmjs/ui/CodeBlock/CodeBlock';
+import { Icon } from '@tpmjs/ui/Icon/Icon';
+import Link from 'next/link';
+import { useId } from 'react';
+import { CopyButton } from '~/components/CopyButton';
+import { trackCollectionMcpCopy } from '~/lib/analytics';
+import {
+  buildClaudeCodeCollectionCommand,
+  buildClaudeDesktopCollectionConfig,
+  buildCollectionMcpUrl,
+} from '~/lib/collection-mcp';
+
+interface CollectionActivationPanelProps {
+  collectionId: string;
+  name: string;
+  username: string;
+  slug: string;
+  toolCount: number;
+  showCollectionLink?: boolean;
+}
+
+const ACTIVATION_STEPS = [
+  ['1', 'Copy the command'],
+  ['2', 'Paste it in your terminal'],
+  ['3', 'Run /mcp in Claude Code'],
+] as const;
+
+export function CollectionActivationPanel({
+  collectionId,
+  name,
+  username,
+  slug,
+  toolCount,
+  showCollectionLink = false,
+}: CollectionActivationPanelProps): React.ReactElement {
+  const titleId = useId();
+  const target = { username, slug };
+  const endpoint = buildCollectionMcpUrl(target);
+  const command = buildClaudeCodeCollectionCommand(target);
+  const desktopConfig = buildClaudeDesktopCollectionConfig(target);
+
+  return (
+    <section aria-labelledby={titleId} className="border-2 border-foreground bg-background">
+      <div className="flex flex-col gap-5 border-b border-border p-5 sm:flex-row sm:items-start sm:justify-between sm:p-7">
+        <div className="max-w-2xl">
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <Badge variant="success" size="sm">
+              Public MCP
+            </Badge>
+            <span className="font-mono text-xs text-foreground-secondary">
+              {toolCount} {toolCount === 1 ? 'tool' : 'tools'}
+            </span>
+          </div>
+          <h3 id={titleId} className="text-xl font-semibold text-foreground sm:text-2xl">
+            Connect {name}
+          </h3>
+          <p className="mt-2 max-w-[68ch] text-sm leading-relaxed text-foreground-secondary sm:text-base">
+            No TPMJS account or token is needed to connect this public collection. Paste one
+            command, then confirm the server in Claude Code.
+          </p>
+        </div>
+
+        {showCollectionLink && (
+          <Link
+            href={`/${encodeURIComponent(username.replace(/^@+/, ''))}/collections/${encodeURIComponent(slug)}`}
+            className="shrink-0 text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            View collection
+          </Link>
+        )}
+      </div>
+
+      <div className="p-5 sm:p-7">
+        <ol className="mb-6 flex flex-col gap-3 text-sm text-foreground-secondary sm:flex-row sm:gap-6">
+          {ACTIVATION_STEPS.map(([number, label]) => (
+            <li key={number} className="flex items-center gap-2.5">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center border border-foreground font-mono text-xs font-semibold text-foreground">
+                {number}
+              </span>
+              <span>{label}</span>
+            </li>
+          ))}
+        </ol>
+
+        <div className="border border-foreground bg-foreground p-3 sm:p-4">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <span className="font-mono text-xs text-background/75 sm:hidden">HTTP MCP</span>
+            <span className="hidden font-mono text-xs text-background/75 sm:inline">
+              Claude Code · HTTP
+            </span>
+            <CopyButton
+              text={command}
+              label="Copy command"
+              size="md"
+              successMessage="Claude Code command copied"
+              className="text-background hover:bg-background/10 hover:text-background"
+              onCopy={() => trackCollectionMcpCopy(collectionId, 'claude_code')}
+            />
+          </div>
+          <pre className="overflow-x-auto whitespace-pre font-mono text-xs leading-relaxed text-background sm:text-sm">
+            <span aria-hidden="true" className="select-none text-primary">
+              ${' '}
+            </span>
+            {command}
+          </pre>
+        </div>
+
+        <div className="mt-4 flex items-start gap-2.5 text-sm text-foreground-secondary">
+          <Icon icon="check" size="sm" className="mt-0.5 shrink-0 text-success" />
+          <p>
+            The connection and tool list are public. A tool that calls a third-party service may
+            still ask for credentials from that provider.
+          </p>
+        </div>
+
+        <details className="group mt-5 border-t border-border pt-4">
+          <summary className="cursor-pointer list-none text-sm font-medium text-foreground marker:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <span className="inline-flex items-center gap-2">
+              <Icon
+                icon="chevronRight"
+                size="xs"
+                className="transition-transform duration-200 group-open:rotate-90 motion-reduce:transition-none"
+              />
+              Other MCP clients and raw endpoint
+            </span>
+          </summary>
+
+          <div className="mt-4 space-y-5">
+            <div>
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <p className="text-xs font-medium text-foreground-secondary">HTTP endpoint</p>
+                <CopyButton
+                  text={endpoint}
+                  label="Copy URL"
+                  size="xs"
+                  onCopy={() => trackCollectionMcpCopy(collectionId, 'http_url')}
+                />
+              </div>
+              <pre className="overflow-x-auto border border-border bg-surface-2 p-3 font-mono text-xs text-foreground-secondary">
+                {endpoint}
+              </pre>
+            </div>
+
+            <CodeBlock
+              language="json"
+              code={desktopConfig}
+              onCopy={() => trackCollectionMcpCopy(collectionId, 'claude_config')}
+            />
+
+            <p className="text-xs text-foreground-tertiary">
+              Need another client? The same HTTP endpoint works with any current MCP client.{' '}
+              <Link href="/docs/sharing" className="text-primary hover:underline">
+                Read the connection guide
+              </Link>
+              .
+            </p>
+          </div>
+        </details>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/home/GetStartedSection.tsx
+++ b/apps/web/src/components/home/GetStartedSection.tsx
@@ -1,169 +1,77 @@
-'use client';
-
-import { Button } from '@tpmjs/ui/Button/Button';
 import { Container } from '@tpmjs/ui/Container/Container';
-import { Icon } from '@tpmjs/ui/Icon/Icon';
 import Link from 'next/link';
-import { useState } from 'react';
+import { CollectionActivationPanel } from '~/components/collections/CollectionActivationPanel';
 
-const INSTALL_CMD = 'curl -fsSL https://tpmjs.com/install.sh | bash';
-
-function CopyButton({ text, className }: { text: string; className?: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const copy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      onClick={copy}
-      className={`p-1.5 text-foreground-tertiary hover:text-foreground transition-colors ${className || ''}`}
-      aria-label="Copy to clipboard"
-    >
-      <Icon icon={copied ? 'check' : 'copy'} size="xs" />
-    </Button>
-  );
+export interface FeaturedCollectionActivation {
+  id: string;
+  name: string;
+  slug: string;
+  username: string;
+  toolCount: number;
 }
 
-export function GetStartedSection(): React.ReactElement {
+interface GetStartedSectionProps {
+  collection: FeaturedCollectionActivation | null;
+}
+
+export function GetStartedSection({ collection }: GetStartedSectionProps): React.ReactElement {
   return (
-    <section className="py-20 bg-surface border-t border-border relative overflow-hidden">
-      {/* Subtle diagonal lines background */}
-      <div className="absolute inset-0 opacity-[0.02]">
-        <div
-          className="absolute inset-0"
-          style={{
-            backgroundImage: `repeating-linear-gradient(
-              -45deg,
-              currentColor,
-              currentColor 1px,
-              transparent 1px,
-              transparent 20px
-            )`,
-          }}
-        />
-      </div>
-
-      <Container size="xl" padding="lg" className="relative z-10">
-        {/* Section Header */}
-        <div className="text-center mb-16">
-          <p className="font-mono text-xs text-primary uppercase tracking-widest mb-3">
-            get started
+    <section className="border-t border-border bg-surface py-16 sm:py-20">
+      <Container size="xl" padding="lg">
+        <div className="mb-9 max-w-3xl sm:mb-12">
+          <p className="mb-3 font-mono text-sm font-medium text-primary">
+            Start with the real thing
           </p>
-          <h2 className="font-mono text-3xl md:text-4xl font-semibold mb-4 text-foreground lowercase">
-            one command. all your editors.
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Give Claude Code a tool collection in 60 seconds.
           </h2>
-          <p className="text-base text-foreground-secondary max-w-xl mx-auto font-sans">
-            Pick tool collections, choose your editors, run the install script. MCP servers
-            configured across Claude Code, Cursor, Windsurf, and Claude Desktop in one shot.
+          <p className="mt-4 max-w-[68ch] text-base leading-relaxed text-foreground-secondary sm:text-lg">
+            Skip the account setup and configuration wizard. Public collections are already live MCP
+            servers, so your first useful action is one terminal command.
           </p>
         </div>
 
-        {/* 3-Step Flow */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-4 mb-16">
-          {/* Step 1 */}
-          <div className="group p-6 border border-dashed border-border bg-background hover:border-primary hover:bg-primary/5 transition-all duration-200">
-            <div className="w-12 h-12 flex items-center justify-center mb-4 border border-dashed border-border bg-surface group-hover:border-primary group-hover:bg-primary/10 transition-all duration-200">
-              <span className="font-mono text-lg text-primary">1</span>
-            </div>
-            <h3 className="font-mono text-sm font-medium text-foreground mb-2 lowercase">
-              pick your collections
-            </h3>
-            <p className="font-sans text-xs text-foreground-secondary leading-relaxed">
-              Browse tool collections — yours, or any public one.
+        {collection ? (
+          <CollectionActivationPanel
+            collectionId={collection.id}
+            name={collection.name}
+            username={collection.username}
+            slug={collection.slug}
+            toolCount={collection.toolCount}
+            showCollectionLink
+          />
+        ) : (
+          <div className="border-2 border-foreground p-6 sm:p-8">
+            <h3 className="text-xl font-semibold text-foreground">Choose a public collection</h3>
+            <p className="mt-2 max-w-[65ch] text-foreground-secondary">
+              Every public collection has a ready-to-copy MCP command on its detail page.
             </p>
-          </div>
-
-          {/* Step 2 */}
-          <div className="group p-6 border border-dashed border-border bg-background hover:border-primary hover:bg-primary/5 transition-all duration-200">
-            <div className="w-12 h-12 flex items-center justify-center mb-4 border border-dashed border-border bg-surface group-hover:border-primary group-hover:bg-primary/10 transition-all duration-200">
-              <span className="font-mono text-lg text-primary">2</span>
-            </div>
-            <h3 className="font-mono text-sm font-medium text-foreground mb-2 lowercase">
-              choose your editors
-            </h3>
-            <p className="font-sans text-xs text-foreground-secondary leading-relaxed">
-              Map collections to Claude Code, Cursor, Windsurf, or Claude Desktop.
-            </p>
-          </div>
-
-          {/* Step 3 */}
-          <div className="group p-6 border border-dashed border-border bg-background hover:border-primary hover:bg-primary/5 transition-all duration-200">
-            <div className="w-12 h-12 flex items-center justify-center mb-4 border border-dashed border-border bg-surface group-hover:border-primary group-hover:bg-primary/10 transition-all duration-200">
-              <span className="font-mono text-lg text-primary">3</span>
-            </div>
-            <h3 className="font-mono text-sm font-medium text-foreground mb-2 lowercase">
-              run one command
-            </h3>
-            <p className="font-sans text-xs text-foreground-secondary leading-relaxed">
-              Paste in your terminal. MCP servers configured across all selected editors.
-            </p>
-          </div>
-        </div>
-
-        {/* Command Box */}
-        <fieldset className="border border-dashed border-border p-6 md:p-8 max-w-2xl mx-auto mb-12">
-          <legend className="font-mono text-sm text-foreground-secondary px-3 lowercase">
-            install script
-          </legend>
-
-          <div className="relative">
-            <div className="p-4 bg-background border border-border font-mono text-sm overflow-x-auto">
-              <div className="flex items-center gap-3">
-                <span className="text-primary font-bold select-none">$</span>
-                <pre className="text-foreground whitespace-pre">{INSTALL_CMD}</pre>
-              </div>
-            </div>
-            <CopyButton text={INSTALL_CMD} className="absolute top-3 right-3" />
-          </div>
-
-          <div className="mt-4 flex items-start gap-3 p-3 bg-background border border-dashed border-border">
-            <span className="font-mono text-xs text-primary mt-0.5">tip</span>
-            <p className="font-mono text-xs text-foreground-secondary">
-              go to{' '}
-              <Link href="/setup" className="text-primary hover:underline">
-                tpmjs.com/setup
-              </Link>{' '}
-              first to select collections and get a personalized command with your token baked in.
-            </p>
-          </div>
-        </fieldset>
-
-        {/* Supported Editors */}
-        <div className="flex flex-wrap justify-center gap-4 mb-12">
-          {[
-            { icon: '>_', name: 'Claude Code' },
-            { icon: 'C', name: 'Claude Desktop' },
-            { icon: '{;}', name: 'Cursor' },
-            { icon: 'W', name: 'Windsurf' },
-          ].map((editor) => (
-            <div
-              key={editor.name}
-              className="flex items-center gap-2 px-4 py-2 border border-border bg-background font-mono text-sm"
+            <Link
+              href="/collections"
+              className="mt-5 inline-flex h-11 items-center justify-center bg-primary px-8 font-mono text-lg font-medium lowercase text-primary-foreground transition-colors duration-150 hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
-              <span className="text-primary font-bold">{editor.icon}</span>
-              <span className="text-foreground-secondary">{editor.name}</span>
-            </div>
-          ))}
-        </div>
-
-        {/* CTA */}
-        <div className="text-center">
-          <div className="inline-flex flex-col sm:flex-row gap-4">
-            <Link href="/setup">
-              <Button size="lg" variant="default">
-                Configure Your Setup
-              </Button>
+              Browse public collections
             </Link>
-            <Link href="/collections">
-              <Button size="lg" variant="outline">
-                Browse Collections
-              </Button>
+          </div>
+        )}
+
+        <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-foreground-secondary">
+            Want your own mix? Create a collection once, then expose it through MCP, CLI, REST, SDK,
+            and Skill surfaces.
+          </p>
+          <div className="flex shrink-0 gap-3">
+            <Link
+              href="/collections"
+              className="inline-flex h-10 items-center justify-center border border-border bg-transparent px-4 font-mono text-base font-medium lowercase transition-colors duration-150 hover:border-border-strong hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            >
+              Browse collections
+            </Link>
+            <Link
+              href="/setup"
+              className="inline-flex h-10 items-center justify-center px-4 font-mono text-base font-medium lowercase text-foreground transition-colors duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            >
+              Build your setup
             </Link>
           </div>
         </div>

--- a/apps/web/src/components/home/McpSection.tsx
+++ b/apps/web/src/components/home/McpSection.tsx
@@ -5,12 +5,15 @@ import { Container } from '@tpmjs/ui/Container/Container';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
 import Link from 'next/link';
 import { useState } from 'react';
+import { buildClaudeCodeCollectionCommand, buildCollectionMcpUrl } from '~/lib/collection-mcp';
 
 interface McpSectionProps {
   toolCount: number;
 }
 
-const EXAMPLE_URL = 'https://tpmjs.com/@username/collections/my-tools/mcp';
+const EXAMPLE_TARGET = { username: 'username', slug: 'my-tools' };
+const EXAMPLE_URL = buildCollectionMcpUrl(EXAMPLE_TARGET);
+const EXAMPLE_COMMAND = buildClaudeCodeCollectionCommand(EXAMPLE_TARGET);
 
 type Provider = 'claude-code' | 'claude-desktop' | 'cursor' | 'windsurf' | 'any';
 
@@ -109,7 +112,7 @@ function ProviderConfig({ provider }: { provider: Provider }) {
                 one command — that&apos;s it
               </p>
             </div>
-            <CodeBlock code={`claude mcp add my-tools \\\n  ${EXAMPLE_URL} \\\n  -t http`} />
+            <CodeBlock code={EXAMPLE_COMMAND} />
           </div>
           <div className="flex items-start gap-3 p-3 bg-surface border border-dashed border-border">
             <span className="font-mono text-xs text-primary mt-0.5">tip</span>
@@ -260,10 +263,7 @@ Content-Type: application/json
               >
                 Model Context Protocol
               </a>{' '}
-              can connect. SSE transport is also available at{' '}
-              <code className="px-1 py-0.5 bg-background border border-border text-foreground">
-                /api/mcp/username/slug/sse
-              </code>
+              can connect to the same recommended HTTP endpoint.
             </p>
           </div>
         </div>

--- a/apps/web/src/components/home/ProtocolSection.tsx
+++ b/apps/web/src/components/home/ProtocolSection.tsx
@@ -4,6 +4,7 @@ import { Button } from '@tpmjs/ui/Button/Button';
 import { Container } from '@tpmjs/ui/Container/Container';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
 import { useState } from 'react';
+import { buildClaudeCodeCollectionCommand } from '~/lib/collection-mcp';
 
 function CopyBtn({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
@@ -75,9 +76,7 @@ const protocols: ProtocolInfo[] = [
     label: 'MCP',
     bestFor: 'Claude Desktop, Cursor, Windsurf, ChatGPT, VS Code',
     why: 'Structured tool interface for clients without a shell. One URL, instant access. Open protocol, now stewarded under the Linux Foundation.',
-    example: `claude mcp add my-tools \\
-  https://tpmjs.com/@you/collections/my-tools/mcp \\
-  -t http`,
+    example: buildClaudeCodeCollectionCommand({ username: 'you', slug: 'my-tools' }),
     tokens: '~200 tokens',
   },
   {

--- a/apps/web/src/data/blog/posts.ts
+++ b/apps/web/src/data/blog/posts.ts
@@ -87,9 +87,8 @@ Why CLI wins here:
 **Best for:** Claude Desktop, Cursor, Windsurf, any editor without a shell. And anywhere you need structured tool boundaries.
 
 \`\`\`bash
-claude mcp add my-tools \\
-  https://tpmjs.com/@you/collections/my-tools/mcp \\
-  -t http
+claude mcp add --transport http tpmjs-my-tools \\
+  https://tpmjs.com/@you/collections/my-tools/mcp
 \`\`\`
 
 Why MCP wins here:

--- a/apps/web/src/lib/collection-mcp.test.ts
+++ b/apps/web/src/lib/collection-mcp.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildClaudeCodeCollectionCommand,
+  buildClaudeDesktopCollectionConfig,
+  buildCollectionMcpServerName,
+  buildCollectionMcpUrl,
+} from './collection-mcp';
+
+const target = { username: '@Ajax', slug: 'Research Tools' };
+
+describe('collection MCP activation contract', () => {
+  it('builds the canonical pretty HTTP endpoint and safely encodes dynamic segments', () => {
+    expect(buildCollectionMcpUrl(target)).toBe(
+      'https://tpmjs.com/@Ajax/collections/Research%20Tools/mcp'
+    );
+    expect(buildCollectionMcpUrl(target, 'http://localhost:3000/ignored')).toBe(
+      'http://localhost:3000/@Ajax/collections/Research%20Tools/mcp'
+    );
+  });
+
+  it('derives a bounded Claude-compatible server name without semantic mappings', () => {
+    expect(buildCollectionMcpServerName('  Crème & Research / Tools  ')).toBe(
+      'tpmjs-creme-research-tools'
+    );
+  });
+
+  it('puts the HTTP transport before positional arguments and keeps public setup token-free', () => {
+    const command = buildClaudeCodeCollectionCommand(target);
+
+    expect(command).toBe(
+      'claude mcp add --transport http tpmjs-research-tools https://tpmjs.com/@Ajax/collections/Research%20Tools/mcp'
+    );
+    expect(command).not.toContain('Authorization');
+    expect(command).not.toContain('/sse');
+  });
+
+  it('adds owner authentication only when explicitly requested', () => {
+    expect(buildClaudeCodeCollectionCommand(target, { bearerToken: '$TPMJS_API_KEY' })).toContain(
+      '--header "Authorization: Bearer $TPMJS_API_KEY"'
+    );
+
+    expect(JSON.parse(buildClaudeDesktopCollectionConfig(target))).toEqual({
+      mcpServers: {
+        'tpmjs-research-tools': {
+          type: 'http',
+          url: 'https://tpmjs.com/@Ajax/collections/Research%20Tools/mcp',
+        },
+      },
+    });
+    expect(
+      JSON.parse(buildClaudeDesktopCollectionConfig(target, { bearerToken: 'YOUR_TPMJS_API_KEY' }))
+        .mcpServers['tpmjs-research-tools'].headers
+    ).toEqual({ Authorization: 'Bearer YOUR_TPMJS_API_KEY' });
+  });
+
+  it('rejects missing collection identity instead of generating a broken command', () => {
+    expect(() => buildCollectionMcpUrl({ username: '@', slug: 'tools' })).toThrow(
+      'Collection username is required'
+    );
+    expect(() => buildCollectionMcpServerName('   ')).toThrow('Collection slug is required');
+  });
+});

--- a/apps/web/src/lib/collection-mcp.ts
+++ b/apps/web/src/lib/collection-mcp.ts
@@ -1,0 +1,72 @@
+export const TPMJS_ORIGIN = 'https://tpmjs.com';
+
+export interface CollectionMcpTarget {
+  username: string;
+  slug: string;
+}
+
+export interface CollectionMcpAuth {
+  /** Literal token or shell expression inserted into generated client configuration. */
+  bearerToken?: string;
+}
+
+function requiredSegment(value: string, label: 'username' | 'slug'): string {
+  const normalized = label === 'username' ? value.trim().replace(/^@+/, '') : value.trim();
+  if (!normalized) throw new Error(`Collection ${label} is required`);
+  return normalized;
+}
+
+/** Build the one canonical, human-readable HTTP MCP endpoint for a collection. */
+export function buildCollectionMcpUrl(target: CollectionMcpTarget, origin = TPMJS_ORIGIN): string {
+  const username = requiredSegment(target.username, 'username');
+  const slug = requiredSegment(target.slug, 'slug');
+  const base = new URL(origin).origin;
+
+  return `${base}/@${encodeURIComponent(username)}/collections/${encodeURIComponent(slug)}/mcp`;
+}
+
+/** Produce a stable Claude-compatible server name from an arbitrary collection slug. */
+export function buildCollectionMcpServerName(slug: string): string {
+  const normalized = requiredSegment(slug, 'slug')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 54)
+    .replace(/-+$/g, '');
+
+  return `tpmjs-${normalized || 'collection'}`;
+}
+
+/** Build the supported Claude Code command for the collection's HTTP transport. */
+export function buildClaudeCodeCollectionCommand(
+  target: CollectionMcpTarget,
+  auth: CollectionMcpAuth = {}
+): string {
+  const command = `claude mcp add --transport http ${buildCollectionMcpServerName(target.slug)} ${buildCollectionMcpUrl(target)}`;
+  const authorizationHeader = auth.bearerToken
+    ? JSON.stringify(`Authorization: Bearer ${auth.bearerToken}`)
+    : null;
+  return authorizationHeader ? `${command} --header ${authorizationHeader}` : command;
+}
+
+/** Build native HTTP configuration for clients that consume Claude Desktop-style JSON. */
+export function buildClaudeDesktopCollectionConfig(
+  target: CollectionMcpTarget,
+  auth: CollectionMcpAuth = {}
+): string {
+  const server = {
+    type: 'http',
+    url: buildCollectionMcpUrl(target),
+    ...(auth.bearerToken && {
+      headers: { Authorization: `Bearer ${auth.bearerToken}` },
+    }),
+  };
+
+  return JSON.stringify(
+    { mcpServers: { [buildCollectionMcpServerName(target.slug)]: server } },
+    null,
+    2
+  );
+}

--- a/apps/web/src/lib/featured-collection.test.ts
+++ b/apps/web/src/lib/featured-collection.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { collectionActivationValue, selectFeaturedCollection } from './featured-collection';
+
+describe('featured collection selection', () => {
+  it('balances proven usage with collection breadth', () => {
+    const candidates = [
+      { id: 'single-hot-tool', executionCount: 272, likeCount: 1, _count: { tools: 1 } },
+      { id: 'proven-collection', executionCount: 126, likeCount: 1, _count: { tools: 60 } },
+      { id: 'large-unused-bundle', executionCount: 0, likeCount: 2, _count: { tools: 74 } },
+    ] as const;
+
+    expect(selectFeaturedCollection(candidates)?.id).toBe('proven-collection');
+  });
+
+  it('returns no selection for an empty candidate set', () => {
+    expect(selectFeaturedCollection([])).toBeUndefined();
+  });
+
+  it('uses logarithmic breadth so size alone cannot dominate demonstrated use', () => {
+    expect(
+      collectionActivationValue({ executionCount: 10, likeCount: 0, _count: { tools: 10 } })
+    ).toBeGreaterThan(
+      collectionActivationValue({ executionCount: 0, likeCount: 0, _count: { tools: 100 } })
+    );
+  });
+});

--- a/apps/web/src/lib/featured-collection.ts
+++ b/apps/web/src/lib/featured-collection.ts
@@ -1,0 +1,28 @@
+export interface CollectionActivationCandidate {
+  executionCount: number;
+  likeCount: number;
+  _count: { tools: number };
+}
+
+/**
+ * Balance demonstrated use with the breadth that makes a collection useful.
+ * Logarithmic breadth prevents a giant uncurated bundle from winning on size alone.
+ */
+export function collectionActivationValue(candidate: CollectionActivationCandidate): number {
+  return (
+    (candidate.executionCount + 1) *
+    (candidate.likeCount + 1) *
+    Math.log2(candidate._count.tools + 1)
+  );
+}
+
+export function selectFeaturedCollection<T extends CollectionActivationCandidate>(
+  candidates: readonly T[]
+): T | undefined {
+  return candidates.reduce<T | undefined>((best, candidate) => {
+    if (!best) return candidate;
+    return collectionActivationValue(candidate) > collectionActivationValue(best)
+      ? candidate
+      : best;
+  }, undefined);
+}

--- a/docs/marketing/launch-kit/demo-script.md
+++ b/docs/marketing/launch-kit/demo-script.md
@@ -16,8 +16,8 @@ _Browser: tpmjs.com homepage — 781 tools, 237 packages. Click into a collectio
 
 _On the collection page, click "copy" on the MCP install command. Switch to terminal, paste:_
 ```
-claude mcp add claude-code-tools \
-  https://tpmjs.com/@ajax/collections/claude-code-tools/mcp -t http
+claude mcp add --transport http tpmjs-claude-code-tools \
+  https://tpmjs.com/@ajax/collections/claude-code-tools/mcp
 ```
 _Show `claude mcp list` — the server is connected._
 

--- a/docs/marketing/launch-kit/launch-post.md
+++ b/docs/marketing/launch-kit/launch-post.md
@@ -28,9 +28,8 @@ On top of that: every tool is import- and execution-**health-checked** (broken t
 Add a real public collection to Claude Code as one MCP endpoint — no signup:
 
 ```bash
-claude mcp add claude-code-tools \
-  https://tpmjs.com/@ajax/collections/claude-code-tools/mcp \
-  -t http
+claude mcp add --transport http tpmjs-claude-code-tools \
+  https://tpmjs.com/@ajax/collections/claude-code-tools/mcp
 ```
 
 Or hit a tool over plain REST (public, key-free):

--- a/docs/marketing/launch-kit/social.md
+++ b/docs/marketing/launch-kit/social.md
@@ -26,8 +26,8 @@ Write the tool once. We serve all five.
 Add a real collection to Claude Code with one command — no signup:
 
 ```
-claude mcp add claude-code-tools \
-  https://tpmjs.com/@ajax/collections/claude-code-tools/mcp -t http
+claude mcp add --transport http tpmjs-claude-code-tools \
+  https://tpmjs.com/@ajax/collections/claude-code-tools/mcp
 ```
 
 Same collection is also a REST endpoint, a `tpm` CLI, an SDK import, and a Skill.
@@ -52,7 +52,7 @@ Tools are import/execution health-checked (~96.5% of 781 healthy) and run in a s
 
 Try it with no signup — add a real collection to Claude Code:
 ```
-claude mcp add claude-code-tools https://tpmjs.com/@ajax/collections/claude-code-tools/mcp -t http
+claude mcp add --transport http tpmjs-claude-code-tools https://tpmjs.com/@ajax/collections/claude-code-tools/mcp
 ```
 It's early and I'd love blunt feedback. Code: github.com/tpmjs/tpmjs · Site: tpmjs.com
 

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -10,14 +10,14 @@ wiring. This example is config only; there is nothing to install or run.
 https://tpmjs.com/@{user}/collections/{slug}/mcp
 ```
 
-(Source of truth: [`InstallationSection.tsx`](../../apps/web/src/components/collections/InstallationSection.tsx).)
+(Source of truth: [`collection-mcp.ts`](../../apps/web/src/lib/collection-mcp.ts).)
 
 ## Add a public collection to Claude Code
 
-Positional args (name, url) come **before** flags so `-H` doesn't swallow them:
+Use the current Claude Code HTTP transport syntax:
 
 ```bash
-claude mcp add {slug} https://tpmjs.com/@{user}/collections/{slug}/mcp -t http
+claude mcp add --transport http tpmjs-{slug} https://tpmjs.com/@{user}/collections/{slug}/mcp
 ```
 
 Then verify the connection inside Claude Code:
@@ -34,8 +34,8 @@ Add your API key as a bearer header (get one at
 `https://tpmjs.com/dashboard/settings/tpmjs-api-keys`):
 
 ```bash
-claude mcp add {slug} https://tpmjs.com/@{user}/collections/{slug}/mcp -t http \
-  -H "Authorization: Bearer YOUR_TPMJS_API_KEY"
+claude mcp add --transport http tpmjs-{slug} https://tpmjs.com/@{user}/collections/{slug}/mcp \
+  --header "Authorization: Bearer YOUR_TPMJS_API_KEY"
 ```
 
 ## Add to Claude Desktop instead
@@ -68,7 +68,7 @@ Prefer *search‑then‑execute* over a curated collection? Point the client at 
 endpoint, which exposes `search_tools` and `execute_tool` across every tool:
 
 ```bash
-claude mcp add tpmjs-registry https://tpmjs.com/api/mcp/registry/http -t http
+claude mcp add --transport http tpmjs-registry https://tpmjs.com/api/mcp/registry/http
 ```
 
 (Streamable HTTP transport; source:
@@ -83,6 +83,6 @@ claude mcp add tpmjs-registry https://tpmjs.com/api/mcp/registry/http -t http
 ## Notes
 
 - Replace `{user}` and `{slug}` with a real username and collection slug. Everything else — the URL
-  shape, the `claude mcp add … -t http` command, the Claude Desktop JSON, the `/mcp` verify step — is
-  taken verbatim from the app's Installation UI and CLI.
+  shape, the `claude mcp add --transport http …` command, the Claude Desktop JSON, and the `/mcp`
+  verification step — is taken verbatim from the app's activation UI and CLI.
 - Docs: <https://tpmjs.com/docs>.

--- a/packages/skills.md
+++ b/packages/skills.md
@@ -664,8 +664,8 @@ Per-API-key rate limit overrides are supported.
 {
   "mcpServers": {
     "tpmjs": {
-      "command": "npx",
-      "args": ["-y", "@anthropic/mcp-remote", "https://tpmjs.com/api/mcp/username/collection/sse"]
+      "type": "http",
+      "url": "https://tpmjs.com/@username/collections/collection/mcp"
     }
   }
 }
@@ -673,7 +673,7 @@ Per-API-key rate limit overrides are supported.
 
 ### Claude Code CLI
 ```bash
-claude mcp add tpmjs -- npx -y @anthropic/mcp-remote https://tpmjs.com/api/mcp/username/collection/sse
+claude mcp add --transport http tpmjs https://tpmjs.com/@username/collections/collection/mcp
 ```
 
 ### Cursor
@@ -681,7 +681,7 @@ claude mcp add tpmjs -- npx -y @anthropic/mcp-remote https://tpmjs.com/api/mcp/u
 {
   "mcpServers": {
     "tpmjs": {
-      "url": "https://tpmjs.com/api/mcp/username/collection/sse"
+      "url": "https://tpmjs.com/@username/collections/collection/mcp"
     }
   }
 }
@@ -692,7 +692,7 @@ claude mcp add tpmjs -- npx -y @anthropic/mcp-remote https://tpmjs.com/api/mcp/u
 {
   "mcpServers": {
     "tpmjs": {
-      "serverUrl": "https://tpmjs.com/api/mcp/username/collection/sse"
+      "serverUrl": "https://tpmjs.com/@username/collections/collection/mcp"
     }
   }
 }


### PR DESCRIPTION
## Outcome

Public TPMJS collections are now a real one-command activation path for Claude Code. The homepage and both collection detail surfaces share one canonical HTTP MCP contract, public setup is token-free, and stale SSE/auth-first guidance has been removed from user-facing onboarding.

## What changed

- add a single tested generator for canonical collection MCP URLs, Claude Code commands, server names, and native HTTP client config
- add a reusable activation panel with copy analytics and precise credential guidance
- select a useful live homepage collection dynamically from usage, likes, and logarithmic tool breadth
- replace duplicated collection-page MCP panels and align the owner dashboard
- update docs, examples, blog copy, launch material, and collection copy menus to the current HTTP syntax
- make copy follow-up observers fail-open and clean up their timers

## Verification

- focused Vitest: 17/17 passed
- dependency-aware type-check: 20/20 tasks passed
- architecture gates: no Vercel hosting, Sentry ownership, build-performance contract, dependency rules
- repository format: passed
- repository lint: 16/16 tasks passed (no errors)
- repository tests: 24/24 tasks passed; web 176 passed, UI 863 passed
- production build: 226/226 tasks passed
- warm production rebuild: 226/226 cache hits in 12.7s
- browser proof at desktop and mobile widths against live-shaped database data; no page or console errors
- installed `claude mcp add --help` syntax matches the generated command

Closes #170
Parent: #125
