### PR TITLE
perf(ci): reuse exact validation after squash merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   actions: read
+  pull-requests: read
 
 jobs:
   validation_provenance:

--- a/docs/marketing/launch-kit/launch-checklist.md
+++ b/docs/marketing/launch-kit/launch-checklist.md
@@ -4,9 +4,9 @@ Concrete steps to actually launch. **[founder]** = needs Thomas / an owner crede
 
 ## Pre-launch — product must not embarrass us
 - [x] **Homepage tells the truth** — real counts, no fabricated activity ticker (shipped 8a4dd141).
-- [ ] **[team]** 5 surfaces visible on the tool detail page (CLI/MCP/REST/SDK/Skill switcher) — the differentiator must be obvious where a dev decides to use a tool. (tracked in #125)
-- [ ] **[team]** Discovery pages SSR'd + indexable (`/tool/tool-search`, `/collections`) — currently client-only "Loading…", zero SEO. (#125)
-- [ ] **[team]** Onboarding collapsed to the one 60-second flow (collection → `claude mcp add` → works).
+- [x] **[team]** 5 surfaces visible on the tool detail page (CLI/MCP/REST/SDK/Skill switcher) — shipped and live. (#125)
+- [x] **[team]** Discovery pages SSR'd + indexable (`/tool/tool-search`, `/collections`) — shipped and live. (#125)
+- [x] **[team]** Onboarding collapsed to the one 60-second flow (collection → `claude mcp add` → works) — #170 / #171, live at `a7d02c21`.
 - [ ] **[team]** Verify every command in this kit runs live the morning of launch (MCP add, REST execute, SDK).
 
 ## Distribution — where devs will find us
@@ -24,7 +24,7 @@ Concrete steps to actually launch. **[founder]** = needs Thomas / an owner crede
 ## Growth — make it worth returning to
 - [ ] **[team]** Reignite tool discovery — the npm-changes sync runs but adds nothing (0 new tools in 30d); fix or seed high-demand tools (real search demand: resend, discord, email, python). (#124 area)
 - [ ] **[team]** Seed 3–5 flagship public collections beyond the founder's (e.g. "web research", "devops", "data wrangling") so the registry doesn't look single-author.
-- [ ] **[team]** Instrument the activation funnel honestly (land → search → tool view → first call) so we can see what converts. (#125 analytics)
+- [x] **[team]** Instrument the activation funnel honestly (land → search → tool view → first call) so we can see what converts. (#128 / #134)
 
 ## Timing
 Don't launch until the tool page shows all 5 surfaces and the npm packages are refreshed — those are the two things a skeptical dev checks first. Everything else can ship in the days after.

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -270,7 +270,7 @@ for (const [name, dockerfile] of [
 requireText(ci, 'apps/web/.next/cache', 'CI must preserve Next.js incremental compiler state');
 requireText(
   ci,
-  'permissions:\n  contents: read\n  actions: read',
+  'permissions:\n  contents: read\n  actions: read\n  pull-requests: read',
   'CI provenance lookup must retain least-privilege workflow-run read access'
 );
 requireText(
@@ -285,7 +285,7 @@ requireText(
 );
 requireText(
   ci,
-  'run-id: ${{ steps.provenance.outputs.source_run_id }}',
+  `run-id: \${{ steps.provenance.outputs.source_run_id }}`,
   'main cache promotion must import only the exact validated pull-request run'
 );
 for (const artifact of ['pr-compiler-state-typescript', 'pr-compiler-state-build']) {
@@ -326,8 +326,7 @@ for (const [cacheKey, expectedCount] of [
   ['next-build-', 3],
   ['typescript-', 2],
 ]) {
-  const exactKey =
-    'key: ${{ runner.os }}-' + cacheKey + "${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}";
+  const exactKey = `key: \${{ runner.os }}-${cacheKey}\${{ hashFiles('pnpm-lock.yaml') }}-\${{ github.sha }}`;
   if (ci.split(exactKey).length - 1 !== expectedCount) {
     failures.push(`${cacheKey} restore and promotion must use the same exact cache key`);
   }
@@ -345,12 +344,52 @@ requireText(
 requireText(
   reusePrValidation,
   "git(['rev-list', '--parents', '-n', '1', sha])",
-  'validation reuse must be limited to normal merge commits'
+  'validation reuse must inspect the exact pushed commit topology'
 );
 requireText(
   reusePrValidation,
   "git(['show', '-s', '--format=%T', sourceSha])",
-  'validation reuse must compare the pull-request head tree'
+  'normal-merge validation reuse must compare the local pull-request head tree'
+);
+requireText(
+  reusePrValidation,
+  `\`https://api.github.com/repos/\${repository}/commits/\${sha}/pulls\``,
+  'single-parent validation reuse must use GitHub commit-to-pull-request provenance'
+);
+for (const invariant of [
+  "pullRequest?.state === 'closed'",
+  'pullRequest?.merge_commit_sha === sha',
+  'pullRequest?.base?.repo?.full_name === repository',
+  'pullRequest?.base?.ref === refName',
+  "typeof pullRequest?.head?.ref === 'string'",
+  "typeof pullRequest?.head?.repo?.full_name === 'string'",
+  'matchingPullRequests.length !== 1',
+]) {
+  requireText(
+    reusePrValidation,
+    invariant,
+    `single-parent validation reuse must retain provenance invariant: ${invariant}`
+  );
+}
+requireText(
+  reusePrValidation,
+  `\`https://api.github.com/repos/\${repository}/git/commits/\${encodeURIComponent(sourceSha)}\``,
+  'single-parent validation reuse must resolve the associated head tree from GitHub'
+);
+requireText(
+  reusePrValidation,
+  'mergeTree !== sourceTree',
+  'all validation reuse paths must require exact tree equality'
+);
+requireText(
+  reusePrValidation,
+  'run?.head_branch === source.sourceHeadRef',
+  'squash validation reuse must bind the workflow run to the associated head branch'
+);
+requireText(
+  reusePrValidation,
+  'run?.head_repository?.full_name === source.sourceHeadRepository',
+  'squash validation reuse must bind the workflow run to the associated head repository'
 );
 requireText(
   reusePrValidation,

--- a/scripts/reuse-pr-validation.mjs
+++ b/scripts/reuse-pr-validation.mjs
@@ -14,9 +14,186 @@ function rejection(reason) {
   return { reuse: false, reason };
 }
 
+class ProvenanceMiss extends Error {}
+
+function rejectProvenance(reason) {
+  throw new ProvenanceMiss(reason);
+}
+
+function githubHeaders(token) {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'tpmjs-validation-provenance',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+async function fetchGithubJson({ fetchImpl, headers, label, url }) {
+  const response = await fetchImpl(url, { headers });
+  if (!response.ok) {
+    rejectProvenance(`${label} returned HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function requireExactTree({ mergeTree, sourceTree, source }) {
+  if (typeof sourceTree !== 'string' || sourceTree.length === 0) {
+    rejectProvenance('the pull-request head tree is unavailable');
+  }
+  if (mergeTree !== sourceTree) {
+    rejectProvenance('the merge tree differs from the pull-request head tree');
+  }
+  return { ...source, sourceTree };
+}
+
+function isExactPullRequestAssociation(pullRequest, { refName, repository, sha }) {
+  return [
+    pullRequest?.state === 'closed',
+    Boolean(pullRequest?.merged_at),
+    pullRequest?.merge_commit_sha === sha,
+    pullRequest?.base?.repo?.full_name === repository,
+    pullRequest?.base?.ref === refName,
+    Number.isInteger(pullRequest?.number),
+    typeof pullRequest?.head?.sha === 'string' && pullRequest.head.sha.length > 0,
+    typeof pullRequest?.head?.ref === 'string' && pullRequest.head.ref.length > 0,
+    typeof pullRequest?.head?.repo?.full_name === 'string' &&
+      pullRequest.head.repo.full_name.length > 0,
+  ].every(Boolean);
+}
+
+async function resolveSingleParentSource({
+  fetchImpl,
+  headers,
+  mergeTree,
+  refName,
+  repository,
+  sha,
+}) {
+  if (!refName) {
+    rejectProvenance('the pushed ref name is unavailable for single-parent provenance');
+  }
+
+  const pullRequestUrl = new URL(`https://api.github.com/repos/${repository}/commits/${sha}/pulls`);
+  const pullRequests = await fetchGithubJson({
+    fetchImpl,
+    headers,
+    label: 'GitHub commit-to-pull-request lookup',
+    url: pullRequestUrl,
+  });
+  if (!Array.isArray(pullRequests)) {
+    rejectProvenance('GitHub commit-to-pull-request lookup returned an unexpected response');
+  }
+
+  const matchingPullRequests = pullRequests.filter((pullRequest) =>
+    isExactPullRequestAssociation(pullRequest, { refName, repository, sha })
+  );
+  if (matchingPullRequests.length !== 1) {
+    rejectProvenance(
+      'the single-parent revision is not uniquely associated with an exact merged pull request'
+    );
+  }
+
+  const pullRequest = matchingPullRequests[0];
+  const sourceSha = pullRequest.head.sha;
+  const sourceCommitUrl = new URL(
+    `https://api.github.com/repos/${repository}/git/commits/${encodeURIComponent(sourceSha)}`
+  );
+  const sourceCommit = await fetchGithubJson({
+    fetchImpl,
+    headers,
+    label: 'GitHub source-commit lookup',
+    url: sourceCommitUrl,
+  });
+  if (typeof sourceCommit?.tree?.sha !== 'string' || sourceCommit.tree.sha.length === 0) {
+    rejectProvenance('GitHub source-commit lookup returned an unexpected response');
+  }
+
+  return requireExactTree({
+    mergeTree,
+    sourceTree: sourceCommit.tree.sha,
+    source: {
+      integrationMethod: 'squash',
+      sourceHeadRef: pullRequest.head.ref,
+      sourceHeadRepository: pullRequest.head.repo.full_name,
+      sourcePullRequest: String(pullRequest.number),
+      sourceSha,
+    },
+  });
+}
+
+async function resolveSource({ fetchImpl, headers, git, refName, repository, sha }) {
+  const revision = git(['rev-list', '--parents', '-n', '1', sha]).split(/\s+/);
+  if (revision[0] !== sha) {
+    rejectProvenance('the pushed revision could not be resolved exactly');
+  }
+
+  const mergeTree = git(['show', '-s', '--format=%T', sha]);
+  if (!mergeTree) {
+    rejectProvenance('the pushed revision tree is unavailable');
+  }
+
+  if (revision.length === 3) {
+    const sourceSha = revision[2];
+    return requireExactTree({
+      mergeTree,
+      sourceTree: git(['show', '-s', '--format=%T', sourceSha]),
+      source: { integrationMethod: 'merge', sourceSha },
+    });
+  }
+  if (revision.length !== 2) {
+    rejectProvenance('the pushed revision is not a supported one- or two-parent integration');
+  }
+
+  return resolveSingleParentSource({
+    fetchImpl,
+    headers,
+    mergeTree,
+    refName,
+    repository,
+    sha,
+  });
+}
+
+function isExactSuccessfulRun(run, source) {
+  const exactRun = [
+    run?.head_sha === source.sourceSha,
+    run?.event === 'pull_request',
+    run?.status === 'completed',
+    run?.conclusion === 'success',
+    run?.path === CI_WORKFLOW_PATH,
+  ].every(Boolean);
+  if (!exactRun) return false;
+  if (source.integrationMethod !== 'squash') return true;
+  return (
+    run?.head_branch === source.sourceHeadRef &&
+    run?.head_repository?.full_name === source.sourceHeadRepository
+  );
+}
+
+async function findSuccessfulRun({ fetchImpl, headers, repository, source }) {
+  const url = new URL(`https://api.github.com/repos/${repository}/actions/workflows/ci.yml/runs`);
+  url.searchParams.set('head_sha', source.sourceSha);
+  url.searchParams.set('event', 'pull_request');
+  url.searchParams.set('status', 'completed');
+  url.searchParams.set('per_page', '100');
+
+  const payload = await fetchGithubJson({
+    fetchImpl,
+    headers,
+    label: 'GitHub workflow lookup',
+    url,
+  });
+  if (!Array.isArray(payload?.workflow_runs)) {
+    rejectProvenance('GitHub workflow lookup returned an unexpected response');
+  }
+  return payload.workflow_runs.find((run) => isExactSuccessfulRun(run, source));
+}
+
 export async function findReusablePullRequestValidation({
   sha,
   repository,
+  refName,
   token,
   git = defaultGit,
   fetchImpl = globalThis.fetch,
@@ -26,62 +203,34 @@ export async function findReusablePullRequestValidation({
       return rejection('required GitHub provenance input is unavailable');
     }
 
-    const revision = git(['rev-list', '--parents', '-n', '1', sha]).split(/\s+/);
-    if (revision.length !== 3 || revision[0] !== sha) {
-      return rejection('the pushed revision is not a normal two-parent merge commit');
-    }
-
-    const sourceSha = revision[2];
-    const mergeTree = git(['show', '-s', '--format=%T', sha]);
-    const sourceTree = git(['show', '-s', '--format=%T', sourceSha]);
-    if (!mergeTree || mergeTree !== sourceTree) {
-      return rejection('the merge tree differs from the pull-request head tree');
-    }
-
-    const url = new URL(`https://api.github.com/repos/${repository}/actions/workflows/ci.yml/runs`);
-    url.searchParams.set('head_sha', sourceSha);
-    url.searchParams.set('event', 'pull_request');
-    url.searchParams.set('status', 'completed');
-    url.searchParams.set('per_page', '100');
-
-    const response = await fetchImpl(url, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${token}`,
-        'User-Agent': 'tpmjs-validation-provenance',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
+    const headers = githubHeaders(token);
+    const source = await resolveSource({
+      fetchImpl,
+      headers,
+      git,
+      refName,
+      repository,
+      sha,
     });
-    if (!response.ok) {
-      return rejection(`GitHub workflow lookup returned HTTP ${response.status}`);
-    }
-
-    const payload = await response.json();
-    if (!Array.isArray(payload?.workflow_runs)) {
-      return rejection('GitHub workflow lookup returned an unexpected response');
-    }
-
-    const sourceRun = payload.workflow_runs.find(
-      (run) =>
-        run?.head_sha === sourceSha &&
-        run?.event === 'pull_request' &&
-        run?.status === 'completed' &&
-        run?.conclusion === 'success' &&
-        run?.path === CI_WORKFLOW_PATH
-    );
+    const sourceRun = await findSuccessfulRun({ fetchImpl, headers, repository, source });
     if (!sourceRun) {
-      return rejection('no successful completed pull-request CI run exists for the exact head SHA');
+      rejectProvenance('no successful completed pull-request CI run exists for the exact head SHA');
     }
 
     return {
       reuse: true,
       reason: 'the merge tree is identical to an exact successfully validated pull-request head',
-      sourceSha,
-      sourceTree,
+      integrationMethod: source.integrationMethod,
+      sourcePullRequest: source.sourcePullRequest,
+      sourceSha: source.sourceSha,
+      sourceTree: source.sourceTree,
       sourceRunId: String(sourceRun.id),
       sourceRunUrl: sourceRun.html_url ?? '',
     };
   } catch (error) {
+    if (error instanceof ProvenanceMiss) {
+      return rejection(error.message);
+    }
     const detail = error instanceof Error ? error.message : String(error);
     return rejection(`provenance lookup failed safely: ${detail}`);
   }
@@ -91,6 +240,8 @@ function writeOutput(result) {
   const output = [
     `reuse=${String(result.reuse)}`,
     `reason=${result.reason.replaceAll('\n', ' ')}`,
+    `integration_method=${result.integrationMethod ?? ''}`,
+    `source_pull_request=${result.sourcePullRequest ?? ''}`,
     `source_sha=${result.sourceSha ?? ''}`,
     `source_tree=${result.sourceTree ?? ''}`,
     `source_run_id=${result.sourceRunId ?? ''}`,
@@ -110,6 +261,10 @@ function writeSummary(result) {
     : '## Running the complete validation suite';
   const details = result.reuse
     ? [
+        `- Integration method: \`${result.integrationMethod}\``,
+        ...(result.sourcePullRequest
+          ? [`- Source pull request: \`#${result.sourcePullRequest}\``]
+          : []),
         `- Source commit: \`${result.sourceSha}\``,
         `- Source tree: \`${result.sourceTree}\``,
         `- Source run: [${result.sourceRunId}](${result.sourceRunUrl})`,
@@ -128,6 +283,7 @@ async function main() {
   const result = await findReusablePullRequestValidation({
     sha: process.env.GITHUB_SHA,
     repository: process.env.GITHUB_REPOSITORY,
+    refName: process.env.GITHUB_REF_NAME,
     token: process.env.GITHUB_TOKEN,
   });
   writeOutput(result);

--- a/scripts/reuse-pr-validation.test.mjs
+++ b/scripts/reuse-pr-validation.test.mjs
@@ -7,6 +7,8 @@ const mergeSha = 'a'.repeat(40);
 const firstParent = 'b'.repeat(40);
 const sourceSha = 'c'.repeat(40);
 const sharedTree = 'd'.repeat(40);
+const repository = 'tpmjs/tpmjs';
+const refName = 'main';
 
 function gitFixture({
   parents = [mergeSha, firstParent, sourceSha],
@@ -20,11 +22,11 @@ function gitFixture({
   };
 }
 
-function response(workflowRuns, { ok = true, status = 200 } = {}) {
+function jsonResponse(payload, { ok = true, status = 200 } = {}) {
   return {
     ok,
     status,
-    json: async () => ({ workflow_runs: workflowRuns }),
+    json: async () => payload,
   };
 }
 
@@ -36,31 +38,79 @@ function successfulRun(overrides = {}) {
     status: 'completed',
     conclusion: 'success',
     path: '.github/workflows/ci.yml',
+    head_branch: 'perf/squash-validation-reuse',
+    head_repository: { full_name: repository },
     html_url: 'https://github.com/tpmjs/tpmjs/actions/runs/123',
     ...overrides,
   };
 }
 
-function decide({ git = gitFixture(), workflowRuns = [successfulRun()], fetchImpl } = {}) {
+function associatedPullRequest(overrides = {}) {
+  return {
+    number: 171,
+    state: 'closed',
+    merged_at: '2026-07-22T22:24:05Z',
+    merge_commit_sha: mergeSha,
+    base: { ref: refName, repo: { full_name: repository } },
+    head: {
+      sha: sourceSha,
+      ref: 'perf/squash-validation-reuse',
+      repo: { full_name: repository },
+    },
+    ...overrides,
+  };
+}
+
+function fetchFixture({
+  pullRequests = [associatedPullRequest()],
+  sourceTree = sharedTree,
+  workflowRuns = [successfulRun()],
+  onRequest = () => {},
+} = {}) {
+  return async (url) => {
+    onRequest(url);
+    if (url.pathname.endsWith(`/commits/${mergeSha}/pulls`)) {
+      return jsonResponse(pullRequests);
+    }
+    if (url.pathname.endsWith(`/git/commits/${sourceSha}`)) {
+      return jsonResponse({ tree: { sha: sourceTree } });
+    }
+    if (url.pathname.endsWith('/actions/workflows/ci.yml/runs')) {
+      return jsonResponse({ workflow_runs: workflowRuns });
+    }
+    throw new Error(`unexpected GitHub request: ${url}`);
+  };
+}
+
+function decide({
+  git = gitFixture(),
+  workflowRuns = [successfulRun()],
+  fetchImpl,
+  pushedRefName = refName,
+} = {}) {
   return findReusablePullRequestValidation({
     sha: mergeSha,
-    repository: 'tpmjs/tpmjs',
+    repository,
+    refName: pushedRefName,
     token: 'test-token',
     git,
-    fetchImpl: fetchImpl ?? (async () => response(workflowRuns)),
+    fetchImpl: fetchImpl ?? fetchFixture({ workflowRuns }),
   });
 }
 
-test('reuses an exact successful pull-request validation for an identical merge tree', async () => {
+test('reuses exact pull-request validation for an identical two-parent merge tree', async () => {
   let requestedUrl;
   const result = await decide({
-    fetchImpl: async (url) => {
-      requestedUrl = url;
-      return response([successfulRun()]);
-    },
+    fetchImpl: fetchFixture({
+      onRequest: (url) => {
+        requestedUrl = url;
+      },
+    }),
   });
 
   assert.equal(result.reuse, true);
+  assert.equal(result.integrationMethod, 'merge');
+  assert.equal(result.sourcePullRequest, undefined);
   assert.equal(result.sourceSha, sourceSha);
   assert.equal(result.sourceTree, sharedTree);
   assert.equal(result.sourceRunId, '123');
@@ -69,26 +119,92 @@ test('reuses an exact successful pull-request validation for an identical merge 
   assert.equal(requestedUrl.searchParams.get('status'), 'completed');
 });
 
-test('rejects a direct push before consulting GitHub', async () => {
+test('reuses exact pull-request validation for a uniquely associated squash merge', async () => {
+  const requestedPaths = [];
+  const result = await decide({
+    git: gitFixture({ parents: [mergeSha, firstParent] }),
+    fetchImpl: fetchFixture({ onRequest: (url) => requestedPaths.push(url.pathname) }),
+  });
+
+  assert.equal(result.reuse, true);
+  assert.equal(result.integrationMethod, 'squash');
+  assert.equal(result.sourcePullRequest, '171');
+  assert.equal(result.sourceSha, sourceSha);
+  assert.equal(result.sourceTree, sharedTree);
+  assert.deepEqual(requestedPaths, [
+    `/repos/${repository}/commits/${mergeSha}/pulls`,
+    `/repos/${repository}/git/commits/${sourceSha}`,
+    `/repos/${repository}/actions/workflows/ci.yml/runs`,
+  ]);
+});
+
+test('rejects a direct push when GitHub has no exact merged pull-request association', async () => {
+  const result = await decide({
+    git: gitFixture({ parents: [mergeSha, firstParent] }),
+    fetchImpl: fetchFixture({ pullRequests: [] }),
+  });
+
+  assert.equal(result.reuse, false);
+  assert.match(result.reason, /not uniquely associated/);
+});
+
+test('rejects ambiguous or inexact single-parent pull-request associations', async () => {
+  const invalidAssociations = [
+    [associatedPullRequest(), associatedPullRequest({ number: 172 })],
+    [associatedPullRequest({ merge_commit_sha: firstParent })],
+    [
+      associatedPullRequest({
+        base: { ref: 'release', repo: { full_name: repository } },
+      }),
+    ],
+    [
+      associatedPullRequest({
+        base: { ref: refName, repo: { full_name: 'someone/else' } },
+      }),
+    ],
+    [associatedPullRequest({ state: 'open', merged_at: null })],
+    [associatedPullRequest({ number: undefined })],
+    [associatedPullRequest({ head: { sha: sourceSha, ref: '', repo: { full_name: repository } } })],
+    [associatedPullRequest({ head: { sha: sourceSha, ref: 'feature', repo: null } })],
+  ];
+
+  for (const pullRequests of invalidAssociations) {
+    const result = await decide({
+      git: gitFixture({ parents: [mergeSha, firstParent] }),
+      fetchImpl: fetchFixture({ pullRequests }),
+    });
+    assert.equal(result.reuse, false);
+    assert.match(result.reason, /not uniquely associated/);
+  }
+});
+
+test('rejects a single-parent revision when its destination ref is unavailable', async () => {
   let fetched = false;
   const result = await decide({
     git: gitFixture({ parents: [mergeSha, firstParent] }),
+    pushedRefName: '',
     fetchImpl: async () => {
       fetched = true;
-      return response([]);
+      return jsonResponse([]);
     },
   });
 
   assert.equal(result.reuse, false);
-  assert.match(result.reason, /not a normal two-parent merge/);
+  assert.match(result.reason, /ref name is unavailable/);
   assert.equal(fetched, false);
 });
 
 test('rejects a merge whose tree differs from the pull-request head', async () => {
-  const result = await decide({ git: gitFixture({ sourceTree: 'e'.repeat(40) }) });
+  const normalMerge = await decide({ git: gitFixture({ sourceTree: 'e'.repeat(40) }) });
+  const squashMerge = await decide({
+    git: gitFixture({ parents: [mergeSha, firstParent] }),
+    fetchImpl: fetchFixture({ sourceTree: 'e'.repeat(40) }),
+  });
 
-  assert.equal(result.reuse, false);
-  assert.match(result.reason, /tree differs/);
+  assert.equal(normalMerge.reuse, false);
+  assert.match(normalMerge.reason, /tree differs/);
+  assert.equal(squashMerge.reuse, false);
+  assert.match(squashMerge.reason, /tree differs/);
 });
 
 test('requires the exact workflow, commit, event, status, and successful conclusion', async () => {
@@ -104,16 +220,39 @@ test('requires the exact workflow, commit, event, status, and successful conclus
   }
 });
 
+test('binds squash validation to the associated pull-request branch and repository', async () => {
+  for (const run of [
+    successfulRun({ head_branch: 'different-branch' }),
+    successfulRun({ head_repository: { full_name: 'someone/else' } }),
+  ]) {
+    const result = await decide({
+      git: gitFixture({ parents: [mergeSha, firstParent] }),
+      fetchImpl: fetchFixture({ workflowRuns: [run] }),
+    });
+    assert.equal(result.reuse, false);
+    assert.match(result.reason, /no successful completed pull-request CI run/);
+  }
+});
+
 test('fails open to complete validation when GitHub is unavailable or malformed', async () => {
   const unavailable = await decide({
-    fetchImpl: async () => response([], { ok: false, status: 503 }),
+    fetchImpl: async () => jsonResponse({}, { ok: false, status: 503 }),
   });
   const malformed = await decide({
-    fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({}) }),
+    fetchImpl: async () => jsonResponse({}),
   });
   const rejected = await decide({
     fetchImpl: async () => {
       throw new Error('network unavailable');
+    },
+  });
+  const malformedSourceCommit = await decide({
+    git: gitFixture({ parents: [mergeSha, firstParent] }),
+    fetchImpl: async (url) => {
+      if (url.pathname.endsWith('/pulls')) {
+        return jsonResponse([associatedPullRequest()]);
+      }
+      return jsonResponse({});
     },
   });
 
@@ -123,4 +262,9 @@ test('fails open to complete validation when GitHub is unavailable or malformed'
   assert.match(malformed.reason, /unexpected response/);
   assert.equal(rejected.reuse, false);
   assert.match(rejected.reason, /failed safely/);
+  assert.equal(malformedSourceCommit.reuse, false);
+  assert.match(
+    malformedSourceCommit.reason,
+    /source-commit lookup returned an unexpected response/
+  );
 });


### PR DESCRIPTION
## Summary

- resolve one-parent GitHub squash merges through the official commit-to-PR association API
- require exact merged PR, destination repo/ref, head SHA/tree, head branch/repository, and successful authoritative PR CI
- preserve fail-open full validation for direct pushes, ambiguity, drift, malformed responses, or GitHub failure
- grant only the required read-only PR permission and ratchet every provenance invariant
- reconcile already-shipped launch checklist items

## Why

PR #171 was fully green, but its squash merge caused main to rerun all nine authoritative jobs because the existing gate only recognized two-parent merge commits. The validated head and squash commit had the exact same tree, so the rerun was safe but redundant.

## Validation

- 9/9 focused provenance contract tests
- architecture contract green
- full monorepo tests green (24/24 tasks)
- full lint green (16/16 tasks; existing warnings only)
- full type-check green (238/238 tasks)
- modified-file Biome clean
- live replay of PR #171 resolves `reuse=true`, source PR #171, exact tree `5bf947e6`, and run 29962574738
- local dependency install: 16.5s; warm lint: 13.8s; warm type-check: 6.4s

Closes #172