### PR TITLE
perf(ci): promote bounded compiler deltas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,14 @@ jobs:
     outputs:
       reuse: ${{ steps.provenance.outputs.reuse }}
       source_run_id: ${{ steps.provenance.outputs.source_run_id }}
+      build_baseline_available: ${{ steps.build_baseline.outputs.cache-matched-key != '' }}
+      build_refresh_required: ${{ steps.delta_budget.outputs.refresh-required }}
+    env:
+      MAX_PROMOTED_TURBO_DELTA_BYTES: 134217728
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Find exact successful pull-request validation
         id: provenance
@@ -59,8 +63,8 @@ jobs:
             packages/tools/official/*/tsconfig.tsbuildinfo
           key: ${{ runner.os }}-typescript-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
 
-      - name: Restore inherited main build state
-        id: inherited_build_state
+      - name: Locate reusable main build baseline
+        id: build_baseline
         if: steps.provenance.outputs.reuse == 'true'
         continue-on-error: true
         uses: actions/cache/restore@v5
@@ -68,40 +72,53 @@ jobs:
           path: |
             apps/web/.next/cache
             .turbo
-          key: ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          key: ${{ runner.os }}-build-baseline-v2-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-build-baseline-v2-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-
+          lookup-only: true
 
       - name: Import build delta from validated pull request
         id: build_delta
-        if: steps.provenance.outputs.reuse == 'true'
+        if: >-
+          steps.provenance.outputs.reuse == 'true' &&
+          steps.build_baseline.outputs.cache-matched-key != ''
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: pr-compiler-state-build
-          path: .ci/imported-build-state
+          path: .ci/compiler-state-build
           github-token: ${{ github.token }}
           run-id: ${{ steps.provenance.outputs.source_run_id }}
 
-      - name: Apply validated Turbo build delta
-        id: build_state
+      - name: Bound the promoted Turbo delta
+        id: delta_budget
         if: steps.build_delta.outcome == 'success'
-        continue-on-error: true
-        run: >-
-          node scripts/compiler-cache-delta.mjs apply
-          .ci/imported-build-state .turbo/cache
+        run: |
+          if ! stats="$(node scripts/compiler-cache-delta.mjs inspect .ci/compiler-state-build)"; then
+            echo 'Validated Turbo delta is invalid; refreshing the complete baseline'
+            echo 'promotable=false' >> "$GITHUB_OUTPUT"
+            echo 'refresh-required=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bytes="$(jq -r '.bytes' <<< "$stats")"
+          echo "Validated Turbo delta: $bytes bytes"
+          echo "bytes=$bytes" >> "$GITHUB_OUTPUT"
+          if [ "$bytes" -le "$MAX_PROMOTED_TURBO_DELTA_BYTES" ]; then
+            echo 'promotable=true' >> "$GITHUB_OUTPUT"
+            echo 'refresh-required=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'promotable=false' >> "$GITHUB_OUTPUT"
+            echo 'refresh-required=true' >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Promote validated build state to main cache scope
-        if: >-
-          steps.inherited_build_state.outcome == 'success' &&
-          steps.build_state.outcome == 'success'
+      - name: Promote validated Turbo delta to main cache scope
+        if: steps.delta_budget.outputs.promotable == 'true'
         continue-on-error: true
         uses: actions/cache/save@v5
         with:
-          path: |
-            apps/web/.next/cache
-            .turbo
-          key: ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          path: .ci/compiler-state-build
+          key: ${{ runner.os }}-turbo-build-delta-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
 
   lint:
     needs: validation_provenance
@@ -321,11 +338,22 @@ jobs:
 
   build:
     needs: validation_provenance
-    if: ${{ always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true') }}
+    if: >-
+      ${{
+        always() &&
+        (
+          github.event_name != 'push' ||
+          needs.validation_provenance.outputs.reuse != 'true' ||
+          needs.validation_provenance.outputs.build_baseline_available != 'true' ||
+          needs.validation_provenance.outputs.build_refresh_required == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     env:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
       TURBO_SCM_HEAD: ${{ github.sha }}
+      BUILD_REFRESH_REQUIRED: ${{ needs.validation_provenance.outputs.build_refresh_required }}
+      MAX_PROMOTED_TURBO_DELTA_BYTES: 134217728
     steps:
       - uses: actions/checkout@v7
         with:
@@ -340,14 +368,16 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Restore incremental Next.js compiler state
-        uses: actions/cache@v5
+      - name: Restore reusable main build baseline
+        id: build_baseline
+        uses: actions/cache/restore@v5
         with:
           path: |
             apps/web/.next/cache
             .turbo
-          key: ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          key: ${{ runner.os }}-build-baseline-v2-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-build-baseline-v2-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-next-build-${{ hashFiles('pnpm-lock.yaml') }}-
 
       - name: Snapshot inherited Turbo build state
@@ -355,11 +385,35 @@ jobs:
           node scripts/compiler-cache-delta.mjs snapshot
           .turbo/cache .ci/build-cache-before.json
 
+      - name: Restore latest promoted Turbo build delta
+        id: inherited_build_delta
+        continue-on-error: true
+        uses: actions/cache/restore@v5
+        with:
+          path: .ci/compiler-state-build
+          key: ${{ runner.os }}-turbo-build-delta-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-delta-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      - name: Apply promoted Turbo build delta
+        if: steps.inherited_build_delta.outputs.cache-matched-key != ''
+        continue-on-error: true
+        run: >-
+          node scripts/compiler-cache-delta.mjs apply
+          .ci/compiler-state-build .turbo/cache
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        env:
+          BUILD_BASELINE_MATCHED_KEY: ${{ steps.build_baseline.outputs.cache-matched-key }}
         run: |
+          if [ "$GITHUB_EVENT_NAME" = 'push' ] && { [ -z "$BUILD_BASELINE_MATCHED_KEY" ] || [ "$BUILD_REFRESH_REQUIRED" = 'true' ]; }; then
+            echo 'Seeding or refreshing the complete main build baseline'
+            pnpm exec turbo run build
+            exit 0
+          fi
           affected_count="$(pnpm exec turbo ls --affected --output=json | jq '.packages.count')"
           if [ "$affected_count" -eq 0 ]; then
             echo 'No workspaces require building'
@@ -368,9 +422,70 @@ jobs:
           pnpm exec turbo run build --affected
 
       - name: Prepare validated Turbo build delta
+        id: prepared_build_delta
+        if: >-
+          github.event_name == 'pull_request' ||
+          (
+            github.event_name == 'push' &&
+            steps.build_baseline.outputs.cache-matched-key != '' &&
+            env.BUILD_REFRESH_REQUIRED != 'true'
+          )
         run: >-
           node scripts/compiler-cache-delta.mjs collect
           .turbo/cache .ci/build-cache-before.json .ci/compiler-state-build
+
+      - name: Measure prepared Turbo build delta
+        id: prepared_delta_budget
+        if: steps.prepared_build_delta.outcome == 'success'
+        run: |
+          if ! stats="$(node scripts/compiler-cache-delta.mjs inspect .ci/compiler-state-build)"; then
+            echo 'Prepared Turbo delta is invalid; refreshing the complete baseline when on main'
+            echo 'promotable=false' >> "$GITHUB_OUTPUT"
+            echo 'refresh-required=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bytes="$(jq -r '.bytes' <<< "$stats")"
+          echo "Prepared Turbo delta: $bytes bytes"
+          echo "bytes=$bytes" >> "$GITHUB_OUTPUT"
+          if [ "$bytes" -le "$MAX_PROMOTED_TURBO_DELTA_BYTES" ]; then
+            echo 'promotable=true' >> "$GITHUB_OUTPUT"
+            echo 'refresh-required=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'promotable=false' >> "$GITHUB_OUTPUT"
+            echo 'refresh-required=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Refresh complete build state after an oversized direct-push delta
+        if: >-
+          github.event_name == 'push' &&
+          steps.prepared_delta_budget.outputs.refresh-required == 'true'
+        run: pnpm exec turbo run build
+
+      - name: Seed reusable main build baseline
+        if: >-
+          github.event_name == 'push' &&
+          (
+            steps.build_baseline.outputs.cache-matched-key == '' ||
+            env.BUILD_REFRESH_REQUIRED == 'true' ||
+            steps.prepared_delta_budget.outputs.refresh-required == 'true'
+          )
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            apps/web/.next/cache
+            .turbo
+          key: ${{ runner.os }}-build-baseline-v2-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+
+      - name: Promote direct-push Turbo delta
+        if: >-
+          github.event_name == 'push' &&
+          steps.prepared_delta_budget.outputs.promotable == 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: .ci/compiler-state-build
+          key: ${{ runner.os }}-turbo-build-delta-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
 
       - name: Export validated build state
         if: github.event_name == 'pull_request'

--- a/scripts/check-build-performance.mjs
+++ b/scripts/check-build-performance.mjs
@@ -283,6 +283,18 @@ requireText(
   'run: node scripts/reuse-pr-validation.mjs',
   'CI must run the validation provenance decision before expensive jobs'
 );
+const validationProvenanceJob = ci.slice(
+  ci.indexOf('  validation_provenance:'),
+  ci.indexOf('  lint:')
+);
+requireText(
+  validationProvenanceJob,
+  'fetch-depth: 2',
+  'validation provenance must fetch both merge parents without cloning complete history'
+);
+if (validationProvenanceJob.includes('fetch-depth: 0')) {
+  failures.push('validation provenance must not refetch the complete repository history');
+}
 requireText(
   ci,
   `run-id: \${{ steps.provenance.outputs.source_run_id }}`,
@@ -298,17 +310,40 @@ requireText(
 );
 requireText(
   ci,
-  "steps.inherited_build_state.outcome == 'success' &&",
-  'build cache promotion must require a successfully restored main baseline'
+  `build_baseline_available: \${{ steps.build_baseline.outputs.cache-matched-key != '' }}`,
+  'main must expose whether a reusable default-branch build baseline exists'
 );
 requireText(
   ci,
-  "steps.build_state.outcome == 'success'",
-  'build cache promotion must require a successfully applied validated delta'
+  `build_refresh_required: \${{ steps.delta_budget.outputs.refresh-required }}`,
+  'an oversized validated delta must force a complete baseline refresh'
 );
+requireText(
+  ci,
+  'lookup-only: true',
+  'validated main merges must inspect baseline availability without downloading it'
+);
+requireText(
+  ci,
+  'MAX_PROMOTED_TURBO_DELTA_BYTES: 134217728',
+  'promoted Turbo deltas must retain an explicit 128 MiB compaction boundary'
+);
+requireText(
+  ci,
+  'node scripts/compiler-cache-delta.mjs inspect .ci/compiler-state-build',
+  'cache promotion must validate and measure the exact delta before saving it'
+);
+requireText(
+  ci,
+  "if: steps.delta_budget.outputs.promotable == 'true'",
+  'main must promote only a validated in-budget Turbo delta'
+);
+
 for (const promotion of [
   'Promote validated TypeScript state to main cache scope',
-  'Promote validated build state to main cache scope',
+  'Promote validated Turbo delta to main cache scope',
+  'Seed reusable main build baseline',
+  'Promote direct-push Turbo delta',
 ]) {
   const start = ci.indexOf(`- name: ${promotion}`);
   const end = ci.indexOf('\n      - name:', start + 1);
@@ -316,21 +351,69 @@ for (const promotion of [
   requireText(section, 'continue-on-error: true', `${promotion} must remain best-effort`);
   requireText(section, 'uses: actions/cache/save@v5', `${promotion} must use an explicit save`);
 }
+const validatedDeltaPromotion = ci.slice(
+  ci.indexOf('- name: Promote validated Turbo delta to main cache scope'),
+  ci.indexOf('\n  lint:')
+);
+requireText(
+  validatedDeltaPromotion,
+  'path: .ci/compiler-state-build',
+  'validated main merges must save only the bounded Turbo delta'
+);
+if (
+  validatedDeltaPromotion.includes('apps/web/.next/cache') ||
+  validatedDeltaPromotion.includes('\n            .turbo')
+) {
+  failures.push('validated main merges must never copy the broad Next/Turbo baseline');
+}
 const bestEffortExportSteps = ci.match(
   /name: Export validated [^\n]+\n\s+if: github\.event_name == 'pull_request'\n\s+continue-on-error: true/g
 );
 if (bestEffortExportSteps?.length !== 2) {
   failures.push('both pull-request compiler-state exports must remain best-effort optimizations');
 }
-for (const [cacheKey, expectedCount] of [
-  ['next-build-', 3],
-  ['typescript-', 2],
+for (const [exactKey, expectedCount, purpose] of [
+  [
+    `key: \${{ runner.os }}-build-baseline-v2-\${{ hashFiles('pnpm-lock.yaml') }}-\${{ github.sha }}`,
+    3,
+    'versioned baseline lookup, restore, and seed',
+  ],
+  [
+    `key: \${{ runner.os }}-turbo-build-delta-\${{ hashFiles('pnpm-lock.yaml') }}-\${{ github.sha }}`,
+    3,
+    'validated, restored, and direct-push Turbo deltas',
+  ],
+  [
+    `key: \${{ runner.os }}-typescript-\${{ hashFiles('pnpm-lock.yaml') }}-\${{ github.sha }}`,
+    2,
+    'TypeScript restore and promotion',
+  ],
 ]) {
-  const exactKey = `key: \${{ runner.os }}-${cacheKey}\${{ hashFiles('pnpm-lock.yaml') }}-\${{ github.sha }}`;
   if (ci.split(exactKey).length - 1 !== expectedCount) {
-    failures.push(`${cacheKey} restore and promotion must use the same exact cache key`);
+    failures.push(`${purpose} must use the expected exact cache key`);
   }
 }
+const cacheAwareBuildJob = ci.slice(ci.indexOf('  build:'), ci.indexOf('  executor:'));
+if (cacheAwareBuildJob.includes('uses: actions/cache@v5')) {
+  failures.push(
+    'pull-request builds must restore caches explicitly without saving broad branch copies'
+  );
+}
+requireText(
+  cacheAwareBuildJob,
+  'Restore latest promoted Turbo build delta',
+  'pull-request builds must layer the latest default-branch Turbo delta over the stable baseline'
+);
+requireText(
+  cacheAwareBuildJob,
+  "steps.build_baseline.outputs.cache-matched-key == '' ||",
+  'a baseline miss must seed a complete default-branch build cache'
+);
+requireText(
+  cacheAwareBuildJob,
+  "steps.prepared_delta_budget.outputs.refresh-required == 'true'",
+  'an oversized direct-push delta must compact into a new complete baseline'
+);
 requireText(
   ci,
   'node --test scripts/reuse-pr-validation.test.mjs',
@@ -406,6 +489,16 @@ requireText(
   'copyFileSync(source, join(cacheDir, name), constants.COPYFILE_EXCL)',
   'compiler-state promotion must never overwrite an inherited cache entry'
 );
+requireText(
+  compilerCacheDelta,
+  "throw new Error('delta directory contains undeclared entries')",
+  'compiler-state promotion must reject files absent from its validated manifest'
+);
+requireText(
+  compilerCacheDelta,
+  'export function inspectCompilerCacheDelta',
+  'compiler-state deltas must expose validated byte accounting for the compaction boundary'
+);
 
 const fullyValidatedJobs = [
   'lint',
@@ -435,11 +528,22 @@ for (const [index, job] of fullyValidatedJobs.entries()) {
     'needs: validation_provenance',
     `${job} must wait for the validation provenance decision`
   );
-  requireText(
-    section,
-    "always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true')",
-    `${job} must run for pull requests and whenever exact validation reuse is unproven`
-  );
+  if (job === 'build') {
+    for (const condition of [
+      "github.event_name != 'push' ||",
+      "needs.validation_provenance.outputs.reuse != 'true' ||",
+      "needs.validation_provenance.outputs.build_baseline_available != 'true' ||",
+      "needs.validation_provenance.outputs.build_refresh_required == 'true'",
+    ]) {
+      requireText(section, condition, `build must retain its fail-open condition: ${condition}`);
+    }
+  } else {
+    requireText(
+      section,
+      "always() && (github.event_name != 'push' || needs.validation_provenance.outputs.reuse != 'true')",
+      `${job} must run for pull requests and whenever exact validation reuse is unproven`
+    );
+  }
 }
 requireText(
   ci,

--- a/scripts/compiler-cache-delta.mjs
+++ b/scripts/compiler-cache-delta.mjs
@@ -5,8 +5,8 @@ import {
   copyFileSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -39,6 +39,25 @@ function readManifest(path, purpose) {
   return manifest;
 }
 
+function validatedDelta(inputDir) {
+  const manifestPath = join(inputDir, 'manifest.json');
+  const manifest = readManifest(manifestPath, 'delta');
+  const expected = ['manifest.json', ...manifest.files].sort();
+  const actual = readdirSync(inputDir).sort();
+  if (actual.length !== expected.length || actual.some((name, index) => name !== expected[index])) {
+    throw new Error('delta directory contains undeclared entries');
+  }
+
+  let bytes = 0;
+  for (const name of manifest.files) {
+    const entry = lstatSync(join(inputDir, name));
+    if (!entry.isFile()) throw new Error(`delta entry is not a file: ${name}`);
+    bytes += entry.size;
+  }
+
+  return { manifest, bytes };
+}
+
 export function snapshotCompilerCache({ cacheDir, manifestPath }) {
   const files = cacheEntries(cacheDir);
   mkdirSync(dirname(manifestPath), { recursive: true });
@@ -60,16 +79,19 @@ export function collectCompilerCacheDelta({ cacheDir, baselinePath, outputDir })
   return { files: files.length };
 }
 
+export function inspectCompilerCacheDelta({ inputDir }) {
+  const { manifest, bytes } = validatedDelta(inputDir);
+  return { files: manifest.files.length, bytes };
+}
+
 export function applyCompilerCacheDelta({ inputDir, cacheDir }) {
-  const manifest = readManifest(join(inputDir, 'manifest.json'), 'delta');
+  const { manifest } = validatedDelta(inputDir);
   mkdirSync(cacheDir, { recursive: true });
 
   let added = 0;
   let alreadyPresent = 0;
   for (const name of manifest.files) {
     const source = join(inputDir, name);
-    if (!lstatSync(source).isFile()) throw new Error(`delta entry is not a file: ${name}`);
-
     try {
       copyFileSync(source, join(cacheDir, name), constants.COPYFILE_EXCL);
       added += 1;
@@ -87,6 +109,7 @@ function usage() {
     'Usage:',
     '  compiler-cache-delta.mjs snapshot <cache-dir> <manifest>',
     '  compiler-cache-delta.mjs collect <cache-dir> <baseline> <output-dir>',
+    '  compiler-cache-delta.mjs inspect <input-dir>',
     '  compiler-cache-delta.mjs apply <input-dir> <cache-dir>',
   ].join('\n');
 }
@@ -101,6 +124,8 @@ function main([command, ...args]) {
       baselinePath: args[1],
       outputDir: args[2],
     });
+  } else if (command === 'inspect' && args.length === 1) {
+    result = inspectCompilerCacheDelta({ inputDir: args[0] });
   } else if (command === 'apply' && args.length === 2) {
     result = applyCompilerCacheDelta({ inputDir: args[0], cacheDir: args[1] });
   } else {

--- a/scripts/compiler-cache-delta.test.mjs
+++ b/scripts/compiler-cache-delta.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -7,6 +7,7 @@ import test from 'node:test';
 import {
   applyCompilerCacheDelta,
   collectCompilerCacheDelta,
+  inspectCompilerCacheDelta,
   snapshotCompilerCache,
 } from './compiler-cache-delta.mjs';
 
@@ -71,6 +72,48 @@ test('emits a valid empty delta when a job produces no new cache state', () => {
   }
 });
 
+test('carries the promoted delta forward while collecting new entries against the stable baseline', () => {
+  const state = fixture();
+  try {
+    const baselinePath = join(state.root, 'baseline.json');
+    const inheritedDelta = join(state.root, 'inherited-delta');
+    const cumulativeDelta = join(state.root, 'cumulative-delta');
+    const inherited = '5555555555555555.tar.zst';
+    const added = '6666666666666666.tar.zst';
+
+    writeFileSync(join(state.cacheDir, '1111111111111111.tar.zst'), 'baseline');
+    snapshotCompilerCache({ cacheDir: state.cacheDir, manifestPath: baselinePath });
+
+    mkdirSync(inheritedDelta);
+    writeFileSync(join(inheritedDelta, inherited), 'inherited');
+    writeFileSync(
+      join(inheritedDelta, 'manifest.json'),
+      JSON.stringify({ version: 1, files: [inherited] })
+    );
+    applyCompilerCacheDelta({ inputDir: inheritedDelta, cacheDir: state.cacheDir });
+    writeFileSync(join(state.cacheDir, added), 'added');
+
+    assert.deepEqual(
+      collectCompilerCacheDelta({
+        cacheDir: state.cacheDir,
+        baselinePath,
+        outputDir: cumulativeDelta,
+      }),
+      { files: 2 }
+    );
+    assert.deepEqual(inspectCompilerCacheDelta({ inputDir: cumulativeDelta }), {
+      files: 2,
+      bytes: 14,
+    });
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(cumulativeDelta, 'manifest.json'), 'utf8')).files,
+      [inherited, added]
+    );
+  } finally {
+    state.cleanup();
+  }
+});
+
 test('applies only declared safe cache entries and never overwrites an existing entry', () => {
   const state = fixture();
   try {
@@ -111,6 +154,27 @@ test('rejects traversal names before applying an untrusted artifact manifest', (
     assert.throws(
       () => applyCompilerCacheDelta({ inputDir, cacheDir: state.cacheDir }),
       /manifest is invalid/
+    );
+  } finally {
+    state.cleanup();
+  }
+});
+
+test('rejects undeclared files before measuring or applying a promoted delta', () => {
+  const state = fixture();
+  try {
+    const inputDir = join(state.root, 'delta');
+    mkdirSync(inputDir);
+    writeFileSync(join(inputDir, 'manifest.json'), JSON.stringify({ version: 1, files: [] }));
+    writeFileSync(join(inputDir, 'undeclared'), 'must not enter the promoted cache');
+
+    assert.throws(
+      () => inspectCompilerCacheDelta({ inputDir }),
+      /delta directory contains undeclared entries/
+    );
+    assert.throws(
+      () => applyCompilerCacheDelta({ inputDir, cacheDir: state.cacheDir }),
+      /delta directory contains undeclared entries/
     );
   } finally {
     state.cleanup();


### PR DESCRIPTION
## Outcome

Replaces per-commit gigabyte compiler-cache copies with one reusable default-branch baseline plus a validated cumulative Turbo delta.

## What changed

- PR builds restore the main baseline explicitly and never auto-save a broad PR-scoped cache.
- Validated main merges locate the baseline with metadata-only lookup, then promote only the exact PR Turbo delta.
- Deltas are manifest-validated, non-overwriting, cumulative, and capped at 128 MiB.
- Baseline misses and oversized deltas trigger a complete main build and a new compacted baseline.
- Direct pushes retain the same fail-open behavior and can promote bounded deltas.
- The provenance checkout now fetches two commits instead of complete history; this was proven against a real two-parent merge.
- Architecture ratchets prevent broad promotion and automatic PR cache saves from returning.

## Verification

- focused cache and provenance tests: 15/15 green
- full type-check: 238/238 tasks green
- full tests: 24/24 tasks green
- full lint: green, existing warnings only
- architecture and format checks: green
- workflow YAML parse: green

Closes #174