### PR TITLE
fix(executor): never log env values; fix(tools-ham): single structured payload

### DIFF
--- a/apps/railway-executor/server.ts
+++ b/apps/railway-executor/server.ts
@@ -684,12 +684,12 @@ async function executeTool(req: Request): Promise<Response> {
     packageName = typeof pkg === 'string' ? pkg : 'unknown';
     toolName = typeof name === 'string' ? name : 'unknown';
 
+    // Never log env VALUES: they are caller credentials (collection env vars / API keys).
     console.log('📥 Execute request:', {
       packageName,
       name: toolName,
       version,
-      envKeys: env ? Object.keys(env) : [],
-      envValues: env || {},
+      envKeys: env && typeof env === 'object' ? Object.keys(env) : [],
     });
 
     if (typeof pkg !== 'string' || typeof name !== 'string' || typeof version !== 'string') {
@@ -735,7 +735,7 @@ async function executeTool(req: Request): Promise<Response> {
             globalThis.process.env[key] = stringValue;
           }
 
-          console.log(`  ✅ Set ${key} = ${stringValue.substring(0, 10)}...`);
+          console.log(`  ✅ Set ${key} (${stringValue.length} chars)`);
         }
       } else {
         console.log('⚠️  No env vars provided in request');

--- a/packages/tools/official/ham/CHANGELOG.md
+++ b/packages/tools/official/ham/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @tpmjs/tools-ham
+
+## 0.1.1
+
+### Patch Changes
+
+- Return HAM's structured replies once (`{ tool, data }`) instead of duplicating the JSON as `text`; plain-text replies stay `{ tool, text }`.
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: all 38 `ham_*` tools of a HAM instance as Vercel AI SDK tools, generated from HAM's catalog; `HAM_API_KEY` / `HAM_API_URL` from env.

--- a/packages/tools/official/ham/README.md
+++ b/packages/tools/official/ham/README.md
@@ -49,8 +49,8 @@ await remember.execute(
 );
 ```
 
-Every tool resolves to `{ tool, text, data? }` — HAM's textual reply plus the parsed JSON payload
-when HAM returned JSON. HAM-side errors (`isError`, scope denials, version conflicts) are thrown
+Every tool resolves to `{ tool, data }` when HAM replied with JSON, otherwise `{ tool, text }`
+(HAM's formatted text). HAM-side errors (`isError`, scope denials, version conflicts) are thrown
 so the agent sees them.
 
 ## Tools

--- a/packages/tools/official/ham/package.json
+++ b/packages/tools/official/ham/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tpmjs/tools-ham",
-  "version": "0.1.0",
-  "description": "HAM shared agent memory tools for AI agents — remember/recall/context, directed messages, handoffs, task board, typed links, supersede/retract, projects and repository mirroring",
+  "version": "0.1.1",
+  "description": "HAM shared agent memory tools for AI agents \u2014 remember/recall/context, directed messages, handoffs, task board, typed links, supersede/retract, projects and repository mirroring",
   "type": "module",
   "keywords": [
     "tpmjs",

--- a/packages/tools/official/ham/src/client.ts
+++ b/packages/tools/official/ham/src/client.ts
@@ -15,10 +15,10 @@ const REQUEST_TIMEOUT_MS = 30_000;
 export interface HamCallResult {
   /** The HAM tool that was called */
   tool: string;
-  /** Parsed JSON payload when HAM returned JSON text, otherwise undefined */
+  /** Parsed JSON payload when HAM returned JSON (then `text` is omitted to avoid a duplicate copy) */
   data?: unknown;
-  /** HAM's textual response (always present) */
-  text: string;
+  /** HAM's textual response when it was not JSON */
+  text?: string;
 }
 
 interface JsonRpcResponse {
@@ -119,16 +119,16 @@ export async function callHam(
     throw new Error(`HAM ${toolName} failed: ${text || 'unknown error'}`);
   }
 
-  let data: unknown;
   const probe = text.trim();
   if (probe.startsWith('{') || probe.startsWith('[')) {
     try {
-      data = JSON.parse(probe);
+      // Structured reply: return the parsed payload once, not the JSON text as well.
+      return { tool: toolName, data: JSON.parse(probe) };
     } catch {
-      data = undefined;
+      // fall through: not valid JSON after all
     }
   }
-  return { tool: toolName, data, text };
+  return { tool: toolName, text };
 }
 
 function specFor(name: string): HamToolSpec {


### PR DESCRIPTION
## Summary
- **Security (executor):** `POST /execute-tool` logged the whole `env` object (collection env vars = caller credentials, e.g. `HAM_API_KEY`) and a 10-char value prefix on every call — found 29 plaintext copies of a live credential in the executor container log. Now logs key names + value lengths only.
- **@tpmjs/tools-ham 0.1.1:** structured HAM replies are returned once as `{ tool, data }` (previously also duplicated as JSON `text`, doubling what agents read).

## Test plan
- [x] biome / build / type-check clean for the package; executor change is log-only
- [x] Verified against live traffic: 38 tools exercised through the collection MCP → executor → HAM
- [ ] After merge: `scripts/deploy-on-box.sh executor`, publish 0.1.1, `POST /api/sync/package`

🤖 Generated with [Claude Code](https://claude.com/claude-code)