### PR TITLE
fix(executor): scope the module cache key by package version

### DIFF
--- a/apps/railway-executor/server.ts
+++ b/apps/railway-executor/server.ts
@@ -370,7 +370,8 @@ async function loadAndDescribe(req: Request): Promise<Response> {
       );
     }
 
-    const cacheKey = `${packageName}::${name}`;
+    // Version-scoped: a re-synced package must never be served from the previous version's module.
+    const cacheKey = `${packageName}@${version}::${name}`;
 
     // biome-ignore lint/suspicious/noImplicitAnyLet: Tool type is determined dynamically after import
     let toolModule;
@@ -704,7 +705,8 @@ async function executeTool(req: Request): Promise<Response> {
       );
     }
 
-    const cacheKey = `${packageName}::${toolName}`;
+    // Version-scoped: a re-synced package must never be served from the previous version's module.
+    const cacheKey = `${packageName}@${version}::${toolName}`;
 
     // Inject environment variables FIRST - before cache check and factory calls
     // This ensures process.env is set when factory functions read from it.


### PR DESCRIPTION
## Summary
The executor's tool-module cache was keyed on `package::tool` only, so after a package was re-synced to a new version it kept serving the previous version's module for up to `CACHE_TTL_MS` (120 s) even though tpmjs-web requested the new version (observed: `@tpmjs/tools-ham` 0.1.0 → 0.1.1, calls returned 0.1.0 behaviour until the TTL expired). The key is now `package@version::tool` at both execute paths.

## Test plan
- [x] biome clean; log-only + cache-key change
- [ ] After merge: `scripts/deploy-on-box.sh executor`, then confirm a re-synced version is imported immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)