### PR TITLE
feat(admin): full monitoring dashboard, role management, health-check backoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,3 +302,7 @@ pnpm changeset:version      # Version packages
 pnpm changeset:publish      # Publish to npm
 git push --follow-tags       # Push with tags
 ```
+
+## Admin monitoring (2026-08-22)
+
+`/dashboard/admin/*` (ADMIN role; `users.role`) is the operator console: Overview (live 1h/24h/7d windows, executor health, job runs), Live activity (unified feed), Executions, API usage (per-key rolling-hour rate-limit consumption), Health & jobs (tool health, broken tools, sync/cron runs, endpoint reports), Collections (+ custom MCP servers; env var *names* only), Agents, Search, Users (promote/demote ADMIN, change tier). Backed by `apps/web/src/lib/admin/{types,metrics}.ts` (bounded raw SQL, `::int`/`::float8` casts — Prisma binds numbers as `bigint`, so interval/limit params need explicit casts) and `app/api/admin/*` (all `requireAdmin()`). Pages share `components/admin/{AdminUi,useAdminResource}`. Smoke-test the queries against the real DB before shipping SQL changes (`scripts`-free one-liner: `npx tsx --tsconfig apps/web/tsconfig.json` importing `lib/admin/metrics`).

--- a/apps/web/src/app/api/admin/activity/route.ts
+++ b/apps/web/src/app/api/admin/activity/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { clampInt, getActivityFeed, parseActivityKind } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/activity
+ * Unified activity feed across executions, API calls, searches, sync runs, definitive health checks, and created collections/agents/users/keys. Cursor = ISO timestamp (`before`).
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const data = await getActivityFeed({
+      limit: clampInt(searchParams.get('limit'), 80, 300) || 80,
+      before: searchParams.get('before'),
+      kind: parseActivityKind(searchParams.get('kind')),
+    });
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin activity]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/agents/route.ts
+++ b/apps/web/src/app/api/admin/agents/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { getAgentsAdmin } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/agents
+ * All agents with owners and activity counts, plus recent conversations.
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    void searchParams;
+    const data = await getAgentsAdmin();
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin agents]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/api-usage/route.ts
+++ b/apps/web/src/app/api/admin/api-usage/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { clampHours, getApiUsageStats } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/api-usage
+ * Platform API-key usage: per-endpoint and per-key aggregates, status codes, rate-limit consumption, hourly series, recent errors.
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const data = await getApiUsageStats(clampHours(searchParams.get('hours'), 24));
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin api-usage]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/collections/route.ts
+++ b/apps/web/src/app/api/admin/collections/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { getCollectionsAdmin } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/collections
+ * All collections (owner, visibility, tool counts, env var names only) and custom MCP servers (no tokens).
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    void searchParams;
+    const data = await getCollectionsAdmin();
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin collections]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/executions/route.ts
+++ b/apps/web/src/app/api/admin/executions/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { clampHours, clampInt, getExecutionStats } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/executions
+ * Tool execution telemetry: windows, status/category/source breakdowns, top tools, hourly series, filtered rows.
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const data = await getExecutionStats({
+      hours: clampHours(searchParams.get('hours'), 24),
+      status: searchParams.get('status'),
+      packageName: searchParams.get('package'),
+      source: searchParams.get('source'),
+      tool: searchParams.get('tool'),
+      limit: clampInt(searchParams.get('limit'), 50, 200) || 50,
+      offset: clampInt(searchParams.get('offset'), 0, 100_000),
+    });
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin executions]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/health/route.ts
+++ b/apps/web/src/app/api/admin/health/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { getHealthOverview } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/health
+ * Registry health: tool health distribution, 24h check outcomes, broken tools, top import errors, sync/cron runs, endpoint reports, executor status.
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    void searchParams;
+    const data = await getHealthOverview();
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin health]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/overview/route.ts
+++ b/apps/web/src/app/api/admin/overview/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { getAdminOverview } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/overview
+ * Live platform overview: execution/API windows, registry + health counts, users, keys, collections, agents, sync runs, executor health.
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    void searchParams;
+    const data = await getAdminOverview();
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin overview]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/search/route.ts
+++ b/apps/web/src/app/api/admin/search/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '~/lib/admin';
+import { clampHours, getSearchAdmin } from '~/lib/admin/metrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/search
+ * Search analytics: volume, zero-result rate, latency, top and failing queries, recent searches.
+ * Requires ADMIN role.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const data = await getSearchAdmin(clampHours(searchParams.get('hours'), 24 * 7));
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[Admin search]', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/users/[id]/route.ts
+++ b/apps/web/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,84 @@
+import { prisma } from '@tpmjs/db';
+import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAdmin } from '~/lib/admin';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const UpdateUserSchema = z
+  .object({
+    role: z.enum(['USER', 'ADMIN']).optional(),
+    tier: z.enum(['FREE', 'PRO', 'ENTERPRISE']).optional(),
+  })
+  .strict()
+  .refine((value) => value.role !== undefined || value.tier !== undefined, {
+    message: 'Provide role and/or tier',
+  });
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PATCH /api/admin/users/[id]
+ * Change a user's role (make/revoke admin) or tier. Requires ADMIN role.
+ * An admin cannot revoke their own admin role, and the last admin cannot be demoted.
+ */
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  let session: Awaited<ReturnType<typeof requireAdmin>>;
+  try {
+    session = await requireAdmin();
+  } catch (response) {
+    if (response instanceof Response) return response;
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const parsed = UpdateUserSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') },
+      { status: 400 }
+    );
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true, email: true, role: true, tier: true },
+  });
+  if (!target) {
+    return NextResponse.json({ success: false, error: 'User not found' }, { status: 404 });
+  }
+
+  if (parsed.data.role === 'USER' && target.role === 'ADMIN') {
+    if (target.id === session.user.id) {
+      return NextResponse.json(
+        { success: false, error: 'You cannot revoke your own admin role' },
+        { status: 400 }
+      );
+    }
+    const admins = await prisma.user.count({ where: { role: 'ADMIN' } });
+    if (admins <= 1) {
+      return NextResponse.json(
+        { success: false, error: 'Cannot demote the last remaining admin' },
+        { status: 400 }
+      );
+    }
+  }
+
+  const updated = await prisma.user.update({
+    where: { id },
+    data: {
+      ...(parsed.data.role !== undefined && { role: parsed.data.role }),
+      ...(parsed.data.tier !== undefined && { tier: parsed.data.tier }),
+    },
+    select: { id: true, email: true, username: true, role: true, tier: true },
+  });
+
+  console.log(
+    `[admin] ${session.user.email} set ${updated.email} role=${updated.role} tier=${updated.tier}`
+  );
+
+  return NextResponse.json({ success: true, data: updated });
+}

--- a/apps/web/src/app/dashboard/admin/activity/page.tsx
+++ b/apps/web/src/app/dashboard/admin/activity/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { Badge } from '@tpmjs/ui/Badge/Badge';
+import { Button } from '@tpmjs/ui/Button/Button';
+import { Tabs } from '@tpmjs/ui/Tabs/Tabs';
+import { useCallback, useMemo, useState } from 'react';
+import { PageState, RefreshBar, StatusBadge } from '~/components/admin/AdminUi';
+import { fetchEnvelope, useAdminResource } from '~/components/admin/useAdminResource';
+import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { ActivityFeed, ActivityItem } from '~/lib/admin/types';
+
+const KINDS: Array<{ id: string; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'execution', label: 'Executions' },
+  { id: 'api', label: 'API calls' },
+  { id: 'search', label: 'Searches' },
+  { id: 'sync', label: 'Jobs' },
+  { id: 'health', label: 'Health' },
+  { id: 'collection', label: 'Collections' },
+  { id: 'agent', label: 'Agents' },
+  { id: 'user', label: 'Users' },
+  { id: 'key', label: 'API keys' },
+];
+
+const KIND_TONE: Record<ActivityItem['kind'], 'default' | 'secondary' | 'outline' | 'warning'> = {
+  execution: 'default',
+  api: 'secondary',
+  search: 'outline',
+  sync: 'warning',
+  health: 'outline',
+  collection: 'secondary',
+  agent: 'secondary',
+  user: 'default',
+  key: 'outline',
+};
+
+function dayLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function EventRow({ item }: { item: ActivityItem }) {
+  return (
+    <li className="grid grid-cols-[5.5rem_minmax(0,1fr)] sm:grid-cols-[5.5rem_7rem_minmax(0,1fr)] gap-x-3 gap-y-1 px-4 py-2.5 border-b border-border last:border-b-0 hover:bg-surface-hover">
+      <span
+        className="font-mono text-xs text-foreground-tertiary tabular-nums pt-0.5"
+        title={new Date(item.at).toLocaleString()}
+      >
+        {new Date(item.at).toLocaleTimeString(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        })}
+      </span>
+      <span
+        className="hidden sm:block text-xs font-medium text-foreground-secondary truncate pt-0.5"
+        title={item.actor ?? ''}
+      >
+        {item.actor ?? '—'}
+      </span>
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Badge variant={KIND_TONE[item.kind]} size="sm">
+            {item.kind}
+          </Badge>
+          <span className="font-medium text-foreground truncate">{item.title}</span>
+          {item.status && <StatusBadge status={item.status} />}
+          <span className="sm:hidden text-xs text-foreground-tertiary">{item.actor}</span>
+        </div>
+        {item.detail && (
+          <p className="text-xs text-foreground-tertiary mt-0.5 line-clamp-2 break-all">
+            {item.detail}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export default function AdminActivityPage() {
+  const [kind, setKind] = useState('all');
+  const [older, setOlder] = useState<ActivityItem[]>([]);
+  const [olderCursor, setOlderCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const url = `/api/admin/activity?limit=100${kind !== 'all' ? `&kind=${kind}` : ''}`;
+  const feed = useAdminResource<ActivityFeed>(url, { refreshMs: 10_000 });
+
+  const items = useMemo(() => {
+    const seen = new Set<string>();
+    const merged: ActivityItem[] = [];
+    for (const item of [...(feed.data?.items ?? []), ...older]) {
+      const key = `${item.kind}|${item.ref ?? item.at}|${item.at}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(item);
+    }
+    return merged;
+  }, [feed.data, older]);
+
+  const cursor = olderCursor ?? feed.data?.nextCursor ?? null;
+
+  const loadMore = useCallback(async () => {
+    if (!cursor) return;
+    setLoadingMore(true);
+    try {
+      const page = await fetchEnvelope<ActivityFeed>(
+        `/api/admin/activity?limit=100&before=${encodeURIComponent(cursor)}${kind !== 'all' ? `&kind=${kind}` : ''}`
+      );
+      setOlder((prev) => [...prev, ...page.items]);
+      setOlderCursor(page.nextCursor);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [cursor, kind]);
+
+  const changeKind = (id: string) => {
+    setKind(id);
+    setOlder([]);
+    setOlderCursor(null);
+  };
+
+  const groups: Array<{ day: string; items: ActivityItem[] }> = [];
+  for (const item of items) {
+    const day = dayLabel(item.at);
+    const last = groups[groups.length - 1];
+    if (last && last.day === day) last.items.push(item);
+    else groups.push({ day, items: [item] });
+  }
+
+  return (
+    <DashboardLayout
+      title="Live activity"
+      subtitle="Executions, API calls, searches, jobs, health verdicts and sign-ups — newest first"
+      showBackButton
+    >
+      <RefreshBar updatedAt={feed.updatedAt} refreshing={feed.refreshing} onRefresh={feed.refresh}>
+        <Tabs size="sm" tabs={KINDS} activeTab={kind} onTabChange={changeKind} />
+      </RefreshBar>
+      <PageState loading={feed.loading} error={feed.error} onRetry={feed.refresh}>
+        {groups.length === 0 ? (
+          <p className="text-sm text-foreground-tertiary py-10 text-center">
+            Quiet so far — nothing recorded for this filter.
+          </p>
+        ) : (
+          groups.map((group) => (
+            <section key={group.day} className="mb-6">
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-foreground-tertiary mb-2">
+                {group.day}
+              </h2>
+              <ul className="bg-surface border border-border rounded-xl overflow-hidden">
+                {group.items.map((item) => (
+                  <EventRow key={`${item.kind}|${item.ref ?? ''}|${item.at}`} item={item} />
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
+        {cursor && (
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void loadMore()}
+              disabled={loadingMore}
+            >
+              {loadingMore ? 'Loading…' : 'Load older'}
+            </Button>
+          </div>
+        )}
+      </PageState>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/dashboard/admin/agents/page.tsx
+++ b/apps/web/src/app/dashboard/admin/agents/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
+import Link from 'next/link';
+import {
+  formatNumber,
+  Kpi,
+  Mono,
+  PageState,
+  Panel,
+  RefreshBar,
+  StatusBadge,
+  TimeAgo,
+} from '~/components/admin/AdminUi';
+import { useAdminResource } from '~/components/admin/useAdminResource';
+import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { AgentsAdmin } from '~/lib/admin/types';
+
+export default function AdminAgentsPage() {
+  const res = useAdminResource<AgentsAdmin>('/api/admin/agents', { refreshMs: 60_000 });
+  const d = res.data;
+
+  return (
+    <DashboardLayout
+      title="Agents"
+      subtitle="Every agent on the platform and the latest conversations"
+      showBackButton
+    >
+      <RefreshBar updatedAt={res.updatedAt} refreshing={res.refreshing} onRefresh={res.refresh} />
+      <PageState loading={res.loading} error={res.error} onRetry={res.refresh}>
+        {d && (
+          <div className="space-y-6">
+            <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Kpi label="Agents" value={formatNumber(d.totals.agents)} icon="terminal" />
+              <Kpi
+                label="Conversations"
+                value={formatNumber(d.totals.conversations)}
+                hint={`${d.totals.conversations24h} in the last 24h`}
+                icon="message"
+              />
+              <Kpi label="Messages" value={formatNumber(d.totals.messages)} icon="send" />
+              <Kpi
+                label="Public agents"
+                value={formatNumber(d.agents.filter((a) => a.isPublic).length)}
+                icon="globe"
+              />
+            </section>
+
+            <Panel title="Agents" description="Ordered by most recent conversation">
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Agent</TableHead>
+                      <TableHead>Owner</TableHead>
+                      <TableHead>Model</TableHead>
+                      <TableHead>Flags</TableHead>
+                      <TableHead className="text-right">Tools</TableHead>
+                      <TableHead className="text-right">Convs</TableHead>
+                      <TableHead className="text-right">Msgs</TableHead>
+                      <TableHead className="text-right">Runs</TableHead>
+                      <TableHead className="text-right">Last active</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {d.agents.map((a) => (
+                      <TableRow key={a.id}>
+                        <TableCell>
+                          <Link
+                            href={`/agents/${a.uid}`}
+                            className="font-medium hover:text-primary"
+                          >
+                            {a.name}
+                          </Link>
+                          <div className="text-xs text-foreground-tertiary">
+                            <Mono>{a.uid}</Mono>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-foreground-secondary">
+                          {a.owner.username ?? a.owner.email}
+                        </TableCell>
+                        <TableCell>
+                          <Mono>{`${a.provider}/${a.modelId}`}</Mono>
+                        </TableCell>
+                        <TableCell>
+                          <span className="flex flex-wrap gap-1">
+                            <StatusBadge status={a.isPublic ? 'public' : 'private'} />
+                            {a.sandboxEnabled && <StatusBadge status="sandbox" />}
+                            {a.dynamicToolDiscovery && <StatusBadge status="dynamic tools" />}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">{a.tools}</TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(a.conversationCount)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(a.messageCount)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(a.executionCount)}
+                        </TableCell>
+                        <TableCell className="text-right text-foreground-tertiary">
+                          <TimeAgo iso={a.lastConversationAt} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+
+            <Panel title="Recent conversations" description="Latest 40 across all agents">
+              {d.recentConversations.length === 0 ? (
+                <p className="text-sm text-foreground-tertiary">No conversations yet.</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Updated</TableHead>
+                        <TableHead>Agent</TableHead>
+                        <TableHead>Owner</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Messages</TableHead>
+                        <TableHead className="text-right">Tool calls</TableHead>
+                        <TableHead className="text-right">Started</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {d.recentConversations.map((c) => (
+                        <TableRow key={c.id}>
+                          <TableCell className="text-foreground-tertiary whitespace-nowrap">
+                            <TimeAgo iso={c.updatedAt} />
+                          </TableCell>
+                          <TableCell>
+                            <Link href={`/agents/${c.agentUid}`} className="hover:text-primary">
+                              {c.agentName}
+                            </Link>
+                          </TableCell>
+                          <TableCell className="text-foreground-secondary">
+                            {c.owner ?? '—'}
+                          </TableCell>
+                          <TableCell>
+                            <StatusBadge status={c.status} />
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">{c.messages}</TableCell>
+                          <TableCell className="text-right tabular-nums">{c.toolCalls}</TableCell>
+                          <TableCell className="text-right text-foreground-tertiary">
+                            <TimeAgo iso={c.createdAt} />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </Panel>
+          </div>
+        )}
+      </PageState>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/dashboard/admin/api-usage/page.tsx
+++ b/apps/web/src/app/dashboard/admin/api-usage/page.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
+import { useState } from 'react';
+import {
+  BarList,
+  formatMs,
+  formatNumber,
+  formatPercent,
+  HourlyChart,
+  Kpi,
+  Mono,
+  PageState,
+  Panel,
+  RefreshBar,
+  StatusBadge,
+  TimeAgo,
+  WindowTabs,
+} from '~/components/admin/AdminUi';
+import { useAdminResource } from '~/components/admin/useAdminResource';
+import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { ApiUsageStats } from '~/lib/admin/types';
+
+function LimitBar({ used, limit }: { used: number; limit: number }) {
+  const ratio = limit > 0 ? Math.min(1, used / limit) : 0;
+  const tone = ratio >= 0.9 ? 'bg-error' : ratio >= 0.6 ? 'bg-warning' : 'bg-success';
+  return (
+    <div className="min-w-[8rem]">
+      <div className="flex justify-between text-xs tabular-nums mb-1">
+        <span>{formatNumber(used)}</span>
+        <span className="text-foreground-tertiary">/ {formatNumber(limit)} per h</span>
+      </div>
+      <div className="h-1.5 rounded bg-border overflow-hidden">
+        <div className={`h-full rounded ${tone}`} style={{ width: `${ratio * 100}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function AdminApiUsagePage() {
+  const [hours, setHours] = useState(24);
+  const res = useAdminResource<ApiUsageStats>(`/api/admin/api-usage?hours=${hours}`, {
+    refreshMs: 30_000,
+  });
+  const d = res.data;
+
+  return (
+    <DashboardLayout
+      title="API usage"
+      subtitle="Platform API keys: who is calling what, how fast, and how close to their rate limit"
+      showBackButton
+    >
+      <RefreshBar updatedAt={res.updatedAt} refreshing={res.refreshing} onRefresh={res.refresh}>
+        <WindowTabs hours={hours} onChange={setHours} />
+      </RefreshBar>
+      <PageState loading={res.loading} error={res.error} onRetry={res.refresh}>
+        {d && (
+          <div className="space-y-6">
+            <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Kpi
+                label={`Requests · ${d.totals.window}`}
+                value={formatNumber(d.totals.total)}
+                icon="key"
+              />
+              <Kpi
+                label="4xx / 5xx"
+                value={formatNumber(d.totals.error)}
+                hint={formatPercent(d.totals.error, d.totals.total)}
+                tone={d.totals.error > 0 ? 'warn' : 'good'}
+                icon="alertCircle"
+              />
+              <Kpi label="p50 latency" value={formatMs(d.totals.p50Ms)} icon="clock" />
+              <Kpi label="p95 latency" value={formatMs(d.totals.p95Ms)} icon="clock" />
+            </section>
+
+            <Panel title="Requests per hour" description="Red = error responses">
+              <HourlyChart
+                points={d.hourly}
+                labels={{ primary: 'requests', secondary: 'errors' }}
+                secondaryColor="#ef4444"
+              />
+            </Panel>
+
+            <Panel
+              title="API keys"
+              description="Usage in the window and consumption of the current rolling-hour limit"
+            >
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Key</TableHead>
+                      <TableHead>Owner</TableHead>
+                      <TableHead>Tier</TableHead>
+                      <TableHead className="text-right">Requests</TableHead>
+                      <TableHead className="text-right">Errors</TableHead>
+                      <TableHead className="text-right">p50</TableHead>
+                      <TableHead>This hour</TableHead>
+                      <TableHead className="text-right">Last used</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {d.keys.map((k) => (
+                      <TableRow key={k.keyId}>
+                        <TableCell>
+                          <div className="font-medium">{k.name}</div>
+                          <div className="text-xs text-foreground-tertiary">
+                            <Mono>{k.keyPrefix}…</Mono>{' '}
+                            {!k.isActive && <StatusBadge status="inactive" />}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-foreground-secondary">
+                          {k.username ?? k.email ?? '—'}
+                        </TableCell>
+                        <TableCell>
+                          <StatusBadge status={k.tier} />
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(k.total)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {k.errors ? <span className="text-error">{k.errors}</span> : '0'}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatMs(k.p50Ms)}
+                        </TableCell>
+                        <TableCell>
+                          <LimitBar used={k.usedThisHour} limit={k.limitPerHour} />
+                        </TableCell>
+                        <TableCell className="text-right text-foreground-tertiary">
+                          <TimeAgo iso={k.lastUsedAt} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+
+            <div className="grid gap-6 lg:grid-cols-3">
+              <Panel title="Endpoints" className="lg:col-span-2">
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Endpoint</TableHead>
+                        <TableHead className="text-right">Requests</TableHead>
+                        <TableHead className="text-right">Errors</TableHead>
+                        <TableHead className="text-right">p50</TableHead>
+                        <TableHead className="text-right">p95</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {d.byEndpoint.map((e) => (
+                        <TableRow key={e.key}>
+                          <TableCell>
+                            <Mono>{e.key}</Mono>
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatNumber(e.count)}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {e.errors ? <span className="text-error">{e.errors}</span> : '0'}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatMs(e.p50Ms)}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatMs(e.p95Ms)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </Panel>
+              <Panel title="Status codes">
+                <BarList items={d.byStatusCode} />
+              </Panel>
+            </div>
+
+            <Panel title="Recent errors" description="Latest 4xx/5xx responses in the window">
+              {d.recentErrors.length === 0 ? (
+                <p className="text-sm text-foreground-tertiary">
+                  No error responses in this window.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>When</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Request</TableHead>
+                        <TableHead>Key</TableHead>
+                        <TableHead>Error</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {d.recentErrors.map((e, i) => (
+                        <TableRow key={`${e.at}-${i}`}>
+                          <TableCell className="text-foreground-tertiary whitespace-nowrap">
+                            <TimeAgo iso={e.at} />
+                          </TableCell>
+                          <TableCell>
+                            <StatusBadge status={String(e.statusCode)} />
+                          </TableCell>
+                          <TableCell>
+                            <Mono>{`${e.method} ${e.endpoint}`}</Mono>
+                          </TableCell>
+                          <TableCell className="text-foreground-secondary">
+                            {e.keyName ?? '—'}
+                          </TableCell>
+                          <TableCell className="text-xs text-error break-all max-w-md">
+                            {e.errorMessage ?? e.errorCode ?? '—'}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </Panel>
+          </div>
+        )}
+      </PageState>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/dashboard/admin/collections/page.tsx
+++ b/apps/web/src/app/dashboard/admin/collections/page.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { Input } from '@tpmjs/ui/Input/Input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  formatNumber,
+  Kpi,
+  Mono,
+  PageState,
+  Panel,
+  RefreshBar,
+  StatusBadge,
+  TimeAgo,
+} from '~/components/admin/AdminUi';
+import { useAdminResource } from '~/components/admin/useAdminResource';
+import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { CollectionsAdmin } from '~/lib/admin/types';
+
+export default function AdminCollectionsPage() {
+  const res = useAdminResource<CollectionsAdmin>('/api/admin/collections', { refreshMs: 60_000 });
+  const [filter, setFilter] = useState('');
+  const d = res.data;
+
+  const collections = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    const all = d?.collections ?? [];
+    if (!q) return all;
+    return all.filter((c) =>
+      [c.name, c.slug ?? '', c.owner.username ?? '', c.owner.email].some((v) =>
+        v.toLowerCase().includes(q)
+      )
+    );
+  }, [d, filter]);
+
+  const publicCount = d?.collections.filter((c) => c.isPublic).length ?? 0;
+  const withEnv = d?.collections.filter((c) => c.envVarNames.length > 0).length ?? 0;
+  const executions = d?.collections.reduce((s, c) => s + c.executionCount, 0) ?? 0;
+
+  return (
+    <DashboardLayout
+      title="Collections"
+      subtitle="Every collection on the platform, and the custom MCP servers behind them"
+      showBackButton
+    >
+      <RefreshBar updatedAt={res.updatedAt} refreshing={res.refreshing} onRefresh={res.refresh}>
+        <Input
+          aria-label="Filter collections"
+          placeholder="Filter by name, slug or owner…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="w-72"
+        />
+      </RefreshBar>
+      <PageState loading={res.loading} error={res.error} onRetry={res.refresh}>
+        {d && (
+          <div className="space-y-6">
+            <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Kpi
+                label="Collections"
+                value={formatNumber(d.collections.length)}
+                hint={`${publicCount} public`}
+                icon="folder"
+              />
+              <Kpi
+                label="With env vars"
+                value={formatNumber(withEnv)}
+                hint="owner-injected credentials"
+                icon="key"
+              />
+              <Kpi
+                label="Executions (all time)"
+                value={formatNumber(executions)}
+                icon="arrowRight"
+              />
+              <Kpi
+                label="Custom MCP servers"
+                value={formatNumber(d.customServers.length)}
+                icon="link"
+              />
+            </section>
+
+            <Panel title="Collections" description={`${collections.length} shown`}>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Collection</TableHead>
+                      <TableHead>Owner</TableHead>
+                      <TableHead>Visibility</TableHead>
+                      <TableHead className="text-right">Tools</TableHead>
+                      <TableHead>Env vars</TableHead>
+                      <TableHead>Executor</TableHead>
+                      <TableHead className="text-right">Runs</TableHead>
+                      <TableHead className="text-right">Views</TableHead>
+                      <TableHead className="text-right">Updated</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {collections.map((c) => (
+                      <TableRow key={c.id}>
+                        <TableCell>
+                          <Link
+                            href={
+                              c.slug && c.owner.username
+                                ? `/@${c.owner.username}/collections/${c.slug}`
+                                : `/dashboard/collections/${c.id}`
+                            }
+                            className="font-medium hover:text-primary"
+                          >
+                            {c.name}
+                          </Link>
+                          <div className="text-xs text-foreground-tertiary">
+                            <Mono>{c.slug ?? c.id}</Mono>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-foreground-secondary">
+                          {c.owner.username ?? c.owner.email}
+                        </TableCell>
+                        <TableCell>
+                          <StatusBadge status={c.isPublic ? 'public' : 'private'} />
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {c.registryTools}
+                          {c.customTools > 0 && (
+                            <span className="text-xs text-foreground-tertiary">
+                              {' '}
+                              +{c.customTools} custom
+                            </span>
+                          )}
+                          {c.bridgeTools > 0 && (
+                            <span className="text-xs text-foreground-tertiary">
+                              {' '}
+                              +{c.bridgeTools} bridge
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {c.envVarNames.length ? (
+                            <span className="flex flex-wrap gap-1">
+                              {c.envVarNames.map((n) => (
+                                <Mono
+                                  key={n}
+                                  className="px-1 rounded bg-surface-hover border border-border"
+                                >
+                                  {n}
+                                </Mono>
+                              ))}
+                            </span>
+                          ) : (
+                            <span className="text-foreground-tertiary">—</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-foreground-secondary">
+                          {c.executorType ?? 'default'}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(c.executionCount)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(c.viewCount)}
+                        </TableCell>
+                        <TableCell className="text-right text-foreground-tertiary">
+                          <TimeAgo iso={c.updatedAt} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+
+            <Panel
+              title="Custom MCP servers"
+              description="Remote servers users proxy through collections (tokens are never shown)"
+            >
+              {d.customServers.length === 0 ? (
+                <p className="text-sm text-foreground-tertiary">
+                  No custom MCP servers registered.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Server</TableHead>
+                        <TableHead>Host</TableHead>
+                        <TableHead>Owner</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Tools</TableHead>
+                        <TableHead className="text-right">Used by</TableHead>
+                        <TableHead className="text-right">Last sync</TableHead>
+                        <TableHead>Error</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {d.customServers.map((s) => (
+                        <TableRow key={s.id}>
+                          <TableCell className="font-medium">{s.name}</TableCell>
+                          <TableCell>
+                            <Mono>{s.host}</Mono>
+                          </TableCell>
+                          <TableCell className="text-foreground-secondary">
+                            {s.owner.username ?? s.owner.email}
+                          </TableCell>
+                          <TableCell>
+                            <StatusBadge status={s.status} />
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">{s.toolCount}</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {s.collectionsUsing} coll.
+                          </TableCell>
+                          <TableCell className="text-right text-foreground-tertiary">
+                            <TimeAgo iso={s.lastSyncAt} />
+                          </TableCell>
+                          <TableCell className="text-xs text-error break-all max-w-sm">
+                            {s.lastSyncError ?? '—'}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </Panel>
+          </div>
+        )}
+      </PageState>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/dashboard/admin/executions/page.tsx
+++ b/apps/web/src/app/dashboard/admin/executions/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { Button } from '@tpmjs/ui/Button/Button';
+import { Select } from '@tpmjs/ui/Select/Select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
+import { useMemo, useState } from 'react';
+import {
+  BarList,
+  formatMs,
+  formatNumber,
+  formatPercent,
+  HourlyChart,
+  Kpi,
+  Mono,
+  PageState,
+  Panel,
+  RefreshBar,
+  StatusBadge,
+  TimeAgo,
+  WindowTabs,
+} from '~/components/admin/AdminUi';
+import { useAdminResource } from '~/components/admin/useAdminResource';
+import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { ExecutionStats } from '~/lib/admin/types';
+
+const PAGE = 50;
+
+export default function AdminExecutionsPage() {
+  const [hours, setHours] = useState(24);
+  const [status, setStatus] = useState('');
+  const [pkg, setPkg] = useState('');
+  const [source, setSource] = useState('');
+  const [offset, setOffset] = useState(0);
+
+  const url = useMemo(() => {
+    const q = new URLSearchParams({
+      hours: String(hours),
+      limit: String(PAGE),
+      offset: String(offset),
+    });
+    if (status) q.set('status', status);
+    if (pkg) q.set('package', pkg);
+    if (source) q.set('source', source);
+    return `/api/admin/executions?${q.toString()}`;
+  }, [hours, status, pkg, source, offset]);
+
+  const res = useAdminResource<ExecutionStats>(url, { refreshMs: 30_000 });
+  const d = res.data;
+  const reset = () => setOffset(0);
+
+  return (
+    <DashboardLayout
+      title="Executions"
+      subtitle="Every tool call routed through the executor"
+      showBackButton
+    >
+      <RefreshBar updatedAt={res.updatedAt} refreshing={res.refreshing} onRefresh={res.refresh}>
+        <WindowTabs
+          hours={hours}
+          onChange={(h) => {
+            setHours(h);
+            reset();
+          }}
+        />
+        <Select
+          size="sm"
+          aria-label="Status"
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value);
+            reset();
+          }}
+          options={[
+            { value: '', label: 'status: all' },
+            ...(d?.facets.statuses ?? []).map((s) => ({ value: s, label: s })),
+          ]}
+        />
+        <Select
+          size="sm"
+          aria-label="Package"
+          value={pkg}
+          onChange={(e) => {
+            setPkg(e.target.value);
+            reset();
+          }}
+          options={[
+            { value: '', label: 'package: all' },
+            ...(d?.facets.packages ?? []).map((s) => ({ value: s, label: s })),
+          ]}
+        />
+        <Select
+          size="sm"
+          aria-label="Source"
+          value={source}
+          onChange={(e) => {
+            setSource(e.target.value);
+            reset();
+          }}
+          options={[
+            { value: '', label: 'source: all' },
+            ...(d?.facets.sources ?? []).map((s) => ({ value: s, label: s })),
+          ]}
+        />
+      </RefreshBar>
+
+      <PageState loading={res.loading} error={res.error} onRetry={res.refresh}>
+        {d && (
+          <div className="space-y-6">
+            <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Kpi
+                label={`Calls · ${d.totals.window}`}
+                value={formatNumber(d.totals.total)}
+                icon="arrowRight"
+              />
+              <Kpi
+                label="Failed"
+                value={formatNumber(d.totals.error)}
+                hint={formatPercent(d.totals.error, d.totals.total)}
+                tone={d.totals.error > 0 ? 'warn' : 'good'}
+                icon="alertCircle"
+              />
+              <Kpi label="p50 latency" value={formatMs(d.totals.p50Ms)} icon="clock" />
+              <Kpi label="p95 latency" value={formatMs(d.totals.p95Ms)} icon="clock" />
+            </section>
+
+            <Panel title="Calls per hour" description="Red = failures">
+              <HourlyChart
+                points={d.hourly}
+                labels={{ primary: 'calls', secondary: 'failures' }}
+                secondaryColor="#ef4444"
+              />
+            </Panel>
+
+            <div className="grid gap-6 lg:grid-cols-3">
+              <Panel title="By status">
+                <BarList items={d.byStatus} />
+              </Panel>
+              <Panel title="By error category">
+                <BarList items={d.byCategory} />
+              </Panel>
+              <Panel title="By source">
+                <BarList items={d.bySource} />
+              </Panel>
+            </div>
+
+            <Panel title="Top tools" description="Most-called package::tool in this window">
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Tool</TableHead>
+                      <TableHead className="text-right">Calls</TableHead>
+                      <TableHead className="text-right">Errors</TableHead>
+                      <TableHead className="text-right">Avg</TableHead>
+                      <TableHead className="text-right">p95</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {d.topTools.map((t) => (
+                      <TableRow key={t.key}>
+                        <TableCell>
+                          <Mono>{t.key}</Mono>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(t.count)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {t.errors ? <span className="text-error">{t.errors}</span> : '0'}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatMs(t.avgMs)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatMs(t.p95Ms)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+
+            <Panel
+              title="Recent executions"
+              description={`${formatNumber(d.total)} matching · showing ${offset + 1}–${Math.min(offset + PAGE, d.total)}`}
+              actions={
+                <>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={offset === 0}
+                    onClick={() => setOffset(Math.max(0, offset - PAGE))}
+                  >
+                    Newer
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={offset + PAGE >= d.total}
+                    onClick={() => setOffset(offset + PAGE)}
+                  >
+                    Older
+                  </Button>
+                </>
+              }
+            >
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>When</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Tool</TableHead>
+                      <TableHead>Source</TableHead>
+                      <TableHead>Caller</TableHead>
+                      <TableHead className="text-right">Duration</TableHead>
+                      <TableHead>Error</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {d.rows.map((r) => (
+                      <TableRow key={r.id}>
+                        <TableCell className="text-foreground-tertiary whitespace-nowrap">
+                          <TimeAgo iso={r.at} />
+                        </TableCell>
+                        <TableCell>
+                          <StatusBadge status={r.status} />
+                        </TableCell>
+                        <TableCell>
+                          <Mono>{`${r.packageName ?? r.eventType}::${r.toolName ?? '—'}`}</Mono>
+                        </TableCell>
+                        <TableCell className="text-foreground-secondary">{r.source}</TableCell>
+                        <TableCell className="text-foreground-secondary">
+                          {r.username ?? r.apiKeyName ?? '—'}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatMs(r.durationMs)}
+                        </TableCell>
+                        <TableCell className="max-w-sm">
+                          {r.errorMessage ? (
+                            <span className="text-xs text-error break-all" title={r.errorMessage}>
+                              {r.errorCategory && <Mono className="mr-1">{r.errorCategory}</Mono>}
+                              {r.errorMessage.slice(0, 140)}
+                            </span>
+                          ) : (
+                            '—'
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+          </div>
+        )}
+      </PageState>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/dashboard/admin/health/page.tsx
+++ b/apps/web/src/app/dashboard/admin/health/page.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
+import Link from 'next/link';
+import {
+  BarList,
+  formatMs,
+  formatNumber,
+  HourlyChart,
+  Kpi,
+  Mono,
+  PageState,
+  Panel,
+  RefreshBar,
+  StatusBadge,
+  TimeAgo,
+} from '~/components/admin/AdminUi';
+import { useAdminResource } from '~/components/admin/useAdminResource';
+import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { HealthOverview } from '~/lib/admin/types';
+
+export default function AdminHealthPage() {
+  const res = useAdminResource<HealthOverview>('/api/admin/health', { refreshMs: 30_000 });
+  const d = res.data;
+
+  const checksTotal = d?.checks24h.reduce((sum, c) => sum + c.count, 0) ?? 0;
+  const healthyChecks =
+    d?.checks24h.filter((c) => c.overall === 'HEALTHY').reduce((s, c) => s + c.count, 0) ?? 0;
+  const activeTools = d?.distribution.reduce((sum, r) => sum + r.count, 0) ?? 0;
+  const brokenTools =
+    d?.distribution
+      .filter((r) => r.importHealth === 'BROKEN' || r.executionHealth === 'BROKEN')
+      .reduce((s, r) => s + r.count, 0) ?? 0;
+
+  return (
+    <DashboardLayout
+      title="Health & jobs"
+      subtitle="Registry health checks, broken tools, background jobs and the executor"
+      showBackButton
+    >
+      <RefreshBar updatedAt={res.updatedAt} refreshing={res.refreshing} onRefresh={res.refresh} />
+      <PageState loading={res.loading} error={res.error} onRetry={res.refresh}>
+        {d && (
+          <div className="space-y-6">
+            <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Kpi
+                label="Executor"
+                value={d.executor.reachable ? 'up' : 'down'}
+                hint={
+                  d.executor.reachable
+                    ? `${d.executor.implementationVersion ?? '?'} · protocol ${d.executor.protocolVersion ?? '?'} · ${formatMs(d.executor.latencyMs)}`
+                    : (d.executor.error ?? 'unreachable')
+                }
+                tone={d.executor.reachable ? 'good' : 'bad'}
+                icon="terminal"
+              />
+              <Kpi
+                label="Active tools"
+                value={formatNumber(activeTools)}
+                hint={`${brokenTools} broken`}
+                tone={brokenTools ? 'warn' : 'good'}
+                icon="puzzle"
+              />
+              <Kpi
+                label="Checks · 24h"
+                value={formatNumber(checksTotal)}
+                hint={`${formatNumber(healthyChecks)} healthy`}
+                icon="checkCircle"
+              />
+              <Kpi
+                label="Inconclusive · 24h"
+                value={formatNumber(
+                  d.checks24h
+                    .filter((c) => c.overall === 'UNKNOWN')
+                    .reduce((s, c) => s + c.count, 0)
+                )}
+                hint="retried with backoff"
+                icon="alertTriangle"
+              />
+            </section>
+
+            <div className="grid gap-6 lg:grid-cols-3">
+              <Panel
+                title="Health checks per hour"
+                description="Red = not healthy"
+                className="lg:col-span-2"
+              >
+                <HourlyChart
+                  points={d.checksHourly}
+                  labels={{ primary: 'checks', secondary: 'not healthy' }}
+                  secondaryColor="#ef4444"
+                />
+              </Panel>
+              <Panel title="Tool health (active tools)" description="import / execution">
+                <BarList
+                  items={d.distribution.map((r) => ({
+                    key: `${r.importHealth} / ${r.executionHealth}`,
+                    count: r.count,
+                  }))}
+                />
+              </Panel>
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Panel title="Check outcomes · 24h" description="overall / import / execution">
+                <BarList
+                  items={d.checks24h.map((c) => ({
+                    key: `${c.overall} · ${c.importStatus} / ${c.executionStatus}`,
+                    count: c.count,
+                  }))}
+                />
+              </Panel>
+              <Panel title="Top failure reasons · 24h" description="normalised error messages">
+                <BarList
+                  items={d.topImportErrors.map((e) => ({
+                    key: `${e.key} (${e.tools} tool${e.tools === 1 ? '' : 's'})`,
+                    count: e.count,
+                  }))}
+                />
+              </Panel>
+            </div>
+
+            <Panel
+              title="Broken & failing tools"
+              description="Import/execution BROKEN or with a failure streak; ordered by streak"
+            >
+              {d.brokenTools.length === 0 ? (
+                <p className="text-sm text-foreground-tertiary">No broken tools. 🎉</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Tool</TableHead>
+                        <TableHead>Import</TableHead>
+                        <TableHead>Exec</TableHead>
+                        <TableHead className="text-right">Streak</TableHead>
+                        <TableHead>Last error</TableHead>
+                        <TableHead className="text-right">Checked</TableHead>
+                        <TableHead className="text-right">Next</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {d.brokenTools.map((t) => (
+                        <TableRow key={t.toolId}>
+                          <TableCell>
+                            <Link
+                              href={`/tool/${encodeURIComponent(t.packageName)}/${encodeURIComponent(t.toolName)}`}
+                              className="hover:text-primary"
+                            >
+                              <Mono>{`${t.packageName}@${t.npmVersion}::${t.toolName}`}</Mono>
+                            </Link>
+                          </TableCell>
+                          <TableCell>
+                            <StatusBadge status={t.importHealth} />
+                          </TableCell>
+                          <TableCell>
+                            <StatusBadge status={t.executionHealth} />
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {t.consecutiveImportFailures}
+                          </TableCell>
+                          <TableCell className="max-w-md">
+                            <span
+                              className="text-xs text-foreground-secondary break-all"
+                              title={t.error ?? ''}
+                            >
+                              {t.error ? t.error.slice(0, 120) : '—'}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-right text-foreground-tertiary">
+                            <TimeAgo iso={t.lastHealthCheck} />
+                          </TableCell>
+                          <TableCell className="text-right text-foreground-tertiary">
+                            <TimeAgo iso={t.nextCheckAt} />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </Panel>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Panel title="Background jobs — latest run per source">
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Source</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Processed</TableHead>
+                        <TableHead className="text-right">Errors</TableHead>
+                        <TableHead className="text-right">When</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {d.syncRuns.map((r) => (
+                        <TableRow key={r.source}>
+                          <TableCell className="font-medium">{r.source}</TableCell>
+                          <TableCell>
+                            <StatusBadge status={r.status} />
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatNumber(r.processed)}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {r.errors ? <span className="text-error">{r.errors}</span> : '0'}
+                          </TableCell>
+                          <TableCell className="text-right text-foreground-tertiary">
+                            <TimeAgo iso={r.createdAt} />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </Panel>
+              <Panel
+                title="Endpoint health reports"
+                description="External smoke checks of the public surfaces"
+              >
+                {d.endpointReports.length === 0 ? (
+                  <p className="text-sm text-foreground-tertiary">No reports yet.</p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>When</TableHead>
+                          <TableHead>Source</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead className="text-right">Pass / total</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {d.endpointReports.map((r, i) => (
+                          <TableRow key={`${r.at}-${i}`}>
+                            <TableCell className="text-foreground-tertiary whitespace-nowrap">
+                              <TimeAgo iso={r.at} />
+                            </TableCell>
+                            <TableCell>{r.source}</TableCell>
+                            <TableCell>
+                              <StatusBadge status={r.overallStatus} />
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {r.passCount} / {r.totalChecks}
+                              {r.failCount > 0 && (
+                                <span className="text-error ml-1">({r.failCount} failed)</span>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </Panel>
+            </div>
+
+            <Panel title="Recent job log" description="Last 40 sync_logs rows">
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>When</TableHead>
+                      <TableHead>Source</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead className="text-right">Processed</TableHead>
+                      <TableHead className="text-right">Errors</TableHead>
+                      <TableHead>Message</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {d.recentSyncLogs.map((r, i) => (
+                      <TableRow key={`${r.createdAt}-${i}`}>
+                        <TableCell className="text-foreground-tertiary whitespace-nowrap">
+                          <TimeAgo iso={r.createdAt} />
+                        </TableCell>
+                        <TableCell>{r.source}</TableCell>
+                        <TableCell>
+                          <StatusBadge status={r.status} />
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(r.processed)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {r.errors ? <span className="text-error">{r.errors}</span> : '0'}
+                        </TableCell>
+                        <TableCell
+                          className="max-w-lg truncate text-foreground-secondary"
+                          title={r.message ?? ''}
+                        >
+                          {r.message ?? '—'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+          </div>
+        )}
+      </PageState>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/dashboard/admin/page.tsx
+++ b/apps/web/src/app/dashboard/admin/page.tsx
@@ -1,45 +1,44 @@
 'use client';
 
-import { Badge } from '@tpmjs/ui/Badge/Badge';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
-import { Spinner } from '@tpmjs/ui/Spinner/Spinner';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import {
+  BarList,
+  formatMs,
+  formatNumber,
+  formatPercent,
+  HourlyChart,
+  Kpi,
+  PageState,
+  Panel,
+  RefreshBar,
+  StatusBadge,
+  TimeAgo,
+} from '~/components/admin/AdminUi';
+import { useAdminResource } from '~/components/admin/useAdminResource';
 import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
 import { AreaChart } from '~/components/stats/AreaChart';
+import type { AdminOverview, WindowStats } from '~/lib/admin/types';
 
 interface StatsSnapshot {
   date: string;
   totalTools: number;
-  totalPackages: number;
-  officialTools: number;
   executionsTotal: number;
-  executionsSuccessful: number;
   executionsFailed: number;
-  tokensTotal: number;
   dauCount: number;
   wauCount: number;
   mauCount: number;
   searchCount: number;
-  avgSearchLatencyMs: number | null;
-  topSearchQueries: Array<{ query: string; count: number }> | null;
-  mcpUniqueClients: number;
-  activeDevs7d: number;
-  totalCollections: number;
-  totalAgents: number;
-  totalSimulations: number;
   eventToolCalls: number;
-  eventAgentRuns: number;
-  importHealthy: number;
-  importBroken: number;
-  executionHealthy: number;
-  executionBroken: number;
-  errorCategories: Record<string, number> | null;
-  conversationStatuses: Record<string, number> | null;
-  avgContextMessages: number | null;
-  avgContextTokens: number | null;
-  avgAvailableTools: number | null;
-  totalConversationsDay: number;
+  mcpUniqueClients: number;
 }
 
 interface AdminStatsData {
@@ -49,312 +48,309 @@ interface AdminStatsData {
   totalSessions: number;
 }
 
-function StatCard({
-  label,
-  value,
-  icon,
-  trend,
-}: {
-  label: string;
-  value: string | number;
-  icon: string;
-  trend?: string;
-}) {
+const SECTIONS: Array<{ href: string; label: string; description: string }> = [
+  {
+    href: '/dashboard/admin/activity',
+    label: 'Live activity',
+    description: 'Everything as it happens',
+  },
+  {
+    href: '/dashboard/admin/executions',
+    label: 'Executions',
+    description: 'Tool calls, errors, latency',
+  },
+  {
+    href: '/dashboard/admin/api-usage',
+    label: 'API usage',
+    description: 'Keys, endpoints, rate limits',
+  },
+  {
+    href: '/dashboard/admin/health',
+    label: 'Health & jobs',
+    description: 'Registry health, crons, executor',
+  },
+  {
+    href: '/dashboard/admin/collections',
+    label: 'Collections',
+    description: 'All collections & MCP servers',
+  },
+  { href: '/dashboard/admin/agents', label: 'Agents', description: 'Agents & conversations' },
+  { href: '/dashboard/admin/search', label: 'Search', description: 'Queries, misses, latency' },
+  { href: '/dashboard/admin/users', label: 'Users', description: 'Roles, tiers, activity' },
+];
+
+function WindowRow({ label, stats, unit }: { label: string; stats: WindowStats[]; unit: string }) {
   return (
-    <div className="bg-surface border border-border rounded-xl p-5">
-      <div className="flex items-center justify-between mb-3">
-        <span className="text-foreground-tertiary text-sm">{label}</span>
-        <Icon icon={icon as 'home'} size="sm" className="text-foreground-tertiary" />
-      </div>
-      <div className="text-2xl font-bold text-foreground">{value}</div>
-      {trend && <div className="text-xs text-foreground-tertiary mt-1">{trend}</div>}
-    </div>
+    <TableRow>
+      <TableCell className="font-medium">{label}</TableCell>
+      {stats.map((w) => (
+        <TableCell key={w.window} className="text-right tabular-nums">
+          <div>{formatNumber(w.total)}</div>
+          <div className="text-xs text-foreground-tertiary">
+            {w.error ? (
+              <span className="text-error">{formatNumber(w.error)} err</span>
+            ) : (
+              'no errors'
+            )}
+            {w.p50Ms !== null && ` · p50 ${formatMs(w.p50Ms)}`}
+          </div>
+        </TableCell>
+      ))}
+      <TableCell className="text-right text-xs text-foreground-tertiary">{unit}</TableCell>
+    </TableRow>
   );
 }
 
 export default function AdminDashboardPage() {
-  const [data, setData] = useState<AdminStatsData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch('/api/admin/stats')
-      .then((res) => {
-        if (res.status === 403) throw new Error('Access denied. Admin role required.');
-        if (!res.ok) throw new Error('Failed to load stats');
-        return res.json();
-      })
-      .then((json) => setData(json.data))
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, []);
-
-  if (loading) {
-    return (
-      <DashboardLayout title="Admin" subtitle="Platform overview">
-        <div className="flex items-center justify-center py-20">
-          <Spinner size="lg" />
-        </div>
-      </DashboardLayout>
-    );
-  }
-
-  if (error) {
-    return (
-      <DashboardLayout title="Admin" subtitle="Platform overview">
-        <div className="flex flex-col items-center justify-center py-20 gap-4">
-          <Icon icon="alertCircle" size="lg" className="text-danger" />
-          <p className="text-foreground-secondary">{error}</p>
-        </div>
-      </DashboardLayout>
-    );
-  }
-
-  const latest = data?.latest;
+  const live = useAdminResource<AdminOverview>('/api/admin/overview', { refreshMs: 30_000 });
+  const daily = useAdminResource<AdminStatsData>('/api/admin/stats');
+  const o = live.data;
 
   return (
-    <DashboardLayout title="Admin" subtitle="Platform overview">
-      <div className="space-y-8">
-        {/* Key Metrics */}
-        <section>
-          <h2 className="text-lg font-semibold text-foreground mb-4">Key Metrics</h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard label="Total Users" value={data?.totalUsers ?? 0} icon="user" />
-            <StatCard label="DAU" value={latest?.dauCount ?? 0} icon="barChart" />
-            <StatCard label="WAU" value={latest?.wauCount ?? 0} icon="barChart" />
-            <StatCard label="MAU" value={latest?.mauCount ?? 0} icon="barChart" />
-          </div>
-        </section>
+    <DashboardLayout title="Admin" subtitle="Everything happening on TPMJS, live">
+      <RefreshBar updatedAt={live.updatedAt} refreshing={live.refreshing} onRefresh={live.refresh}>
+        <nav className="flex flex-wrap gap-2" aria-label="Admin sections">
+          {SECTIONS.map((s) => (
+            <Link
+              key={s.href}
+              href={s.href}
+              title={s.description}
+              className="text-xs px-2.5 py-1.5 rounded-md border border-border bg-surface hover:border-primary/60 hover:text-primary transition-colors"
+            >
+              {s.label}
+            </Link>
+          ))}
+        </nav>
+      </RefreshBar>
 
-        {/* Registry Stats */}
-        <section>
-          <h2 className="text-lg font-semibold text-foreground mb-4">Registry</h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard label="Total Tools" value={latest?.totalTools ?? 0} icon="puzzle" />
-            <StatCard label="Total Packages" value={latest?.totalPackages ?? 0} icon="folder" />
-            <StatCard label="Collections" value={latest?.totalCollections ?? 0} icon="folder" />
-            <StatCard label="Agents" value={latest?.totalAgents ?? 0} icon="terminal" />
-          </div>
-        </section>
+      <PageState loading={live.loading} error={live.error} onRetry={live.refresh}>
+        {o && (
+          <div className="space-y-8">
+            <section className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-6 gap-4">
+              <Kpi
+                label="Tool calls · 24h"
+                value={formatNumber(o.executions[1]?.total)}
+                hint={`${formatNumber(o.executions[0]?.total)} in the last hour`}
+                icon="arrowRight"
+              />
+              <Kpi
+                label="Error rate · 24h"
+                value={formatPercent(o.executions[1]?.error ?? 0, o.executions[1]?.total ?? 0)}
+                hint={`${formatNumber(o.executions[1]?.error)} failed`}
+                tone={(o.executions[1]?.error ?? 0) > 0 ? 'warn' : 'good'}
+                icon="alertCircle"
+              />
+              <Kpi
+                label="p95 latency · 24h"
+                value={formatMs(o.executions[1]?.p95Ms)}
+                hint={`p50 ${formatMs(o.executions[1]?.p50Ms)}`}
+                icon="clock"
+              />
+              <Kpi
+                label="API requests · 24h"
+                value={formatNumber(o.apiUsage[1]?.total)}
+                hint={`${o.keys.used24h} of ${o.keys.active} active keys used`}
+                icon="key"
+              />
+              <Kpi
+                label="Executor"
+                value={o.executor.reachable ? 'up' : 'down'}
+                hint={
+                  o.executor.reachable
+                    ? `${o.executor.implementationVersion ?? '?'} · ${formatMs(o.executor.latencyMs)}`
+                    : (o.executor.error ?? 'unreachable')
+                }
+                tone={o.executor.reachable ? 'good' : 'bad'}
+                icon="terminal"
+              />
+              <Kpi
+                label="Registry health"
+                value={formatPercent(o.registry.toolsHealthy, o.registry.toolsActive)}
+                hint={`${o.registry.toolsBroken} broken · ${o.registry.toolsUnknown} unknown`}
+                tone={o.registry.toolsBroken > 0 ? 'warn' : 'good'}
+                icon="checkCircle"
+              />
+            </section>
 
-        {/* Execution & Search Stats */}
-        <section>
-          <h2 className="text-lg font-semibold text-foreground mb-4">Activity (Daily)</h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard label="Tool Calls" value={latest?.eventToolCalls ?? 0} icon="play" />
-            <StatCard label="Agent Runs" value={latest?.eventAgentRuns ?? 0} icon="terminal" />
-            <StatCard
-              label="Searches"
-              value={latest?.searchCount ?? 0}
-              icon="search"
-              trend={latest?.avgSearchLatencyMs ? `Avg ${latest.avgSearchLatencyMs}ms` : undefined}
-            />
-            <StatCard label="MCP Clients (7d)" value={latest?.mcpUniqueClients ?? 0} icon="globe" />
-          </div>
-        </section>
+            <div className="grid gap-6 xl:grid-cols-3">
+              <Panel
+                title="Tool calls · last 24 hours"
+                description="Executions per hour; red = failures"
+                className="xl:col-span-2"
+              >
+                <HourlyChart
+                  points={o.hourly}
+                  labels={{ primary: 'calls', secondary: 'failures' }}
+                  secondaryColor="#ef4444"
+                />
+              </Panel>
+              <Panel title="Health checks · 24h" description="Outcomes across all checks">
+                <BarList items={o.healthChecks24h} linkFor={() => '/dashboard/admin/health'} />
+              </Panel>
+            </div>
 
-        {/* Health Status */}
-        <section>
-          <h2 className="text-lg font-semibold text-foreground mb-4">Health</h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard
-              label="Import Healthy"
-              value={latest?.importHealthy ?? 0}
-              icon="checkCircle"
-            />
-            <StatCard label="Import Broken" value={latest?.importBroken ?? 0} icon="alertCircle" />
-            <StatCard
-              label="Exec Healthy"
-              value={latest?.executionHealthy ?? 0}
-              icon="checkCircle"
-            />
-            <StatCard label="Exec Broken" value={latest?.executionBroken ?? 0} icon="alertCircle" />
-          </div>
-        </section>
+            <Panel
+              title="Traffic windows"
+              description="Counts, failures and median latency by window"
+            >
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Stream</TableHead>
+                      <TableHead className="text-right">1h</TableHead>
+                      <TableHead className="text-right">24h</TableHead>
+                      <TableHead className="text-right">7d</TableHead>
+                      <TableHead className="text-right" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    <WindowRow label="Tool executions" stats={o.executions} unit="executor" />
+                    <WindowRow label="Platform API (keys)" stats={o.apiUsage} unit="MCP / REST" />
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
 
-        {/* ML Tracking Metrics */}
-        <section>
-          <h2 className="text-lg font-semibold text-foreground mb-4">ML Tracking (Daily)</h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard
-              label="Conversations"
-              value={latest?.totalConversationsDay ?? 0}
-              icon="message"
-            />
-            <StatCard
-              label="Avg Context Msgs"
-              value={latest?.avgContextMessages ?? '—'}
-              icon="terminal"
-            />
-            <StatCard
-              label="Avg Context Tokens"
-              value={latest?.avgContextTokens ?? '—'}
-              icon="barChart"
-            />
-            <StatCard
-              label="Avg Tools Available"
-              value={latest?.avgAvailableTools != null ? latest.avgAvailableTools.toFixed(1) : '—'}
-              icon="puzzle"
-            />
-          </div>
-        </section>
+            <section className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-8 gap-4">
+              <Kpi
+                label="Users"
+                value={formatNumber(o.users.total)}
+                hint={`${o.users.admins} admins · +${o.users.new7d} this week`}
+                icon="user"
+              />
+              <Kpi
+                label="Active sessions"
+                value={formatNumber(o.users.activeSessions)}
+                icon="globe"
+              />
+              <Kpi
+                label="API keys"
+                value={formatNumber(o.keys.active)}
+                hint={`${o.keys.total} total`}
+                icon="key"
+              />
+              <Kpi
+                label="Collections"
+                value={formatNumber(o.collections.total)}
+                hint={`${o.collections.public} public`}
+                icon="folder"
+              />
+              <Kpi
+                label="MCP servers"
+                value={formatNumber(o.collections.customServers)}
+                hint={`${o.collections.bridgesConnected} bridges live`}
+                icon="link"
+              />
+              <Kpi
+                label="Agents"
+                value={formatNumber(o.agents.total)}
+                hint={`${o.agents.conversations24h} convs · ${o.agents.messages24h} msgs / 24h`}
+                icon="terminal"
+              />
+              <Kpi
+                label="Tools"
+                value={formatNumber(o.registry.toolsActive)}
+                hint={`${o.registry.packages} packages · ${o.registry.officialPackages} official`}
+                icon="puzzle"
+              />
+              <Kpi label="Searches · 24h" value={formatNumber(o.searches24h)} icon="search" />
+            </section>
 
-        {/* Error Categories + Conversation Status */}
-        {(latest?.errorCategories || latest?.conversationStatuses) && (
-          <section>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {latest?.errorCategories && Object.keys(latest.errorCategories).length > 0 && (
-                <div className="bg-surface border border-border rounded-xl p-5">
-                  <h3 className="text-sm font-medium text-foreground mb-3">Error Categories</h3>
-                  <div className="space-y-2">
-                    {Object.entries(latest.errorCategories)
-                      .sort(([, a], [, b]) => b - a)
-                      .map(([category, count]) => (
-                        <div key={category} className="flex justify-between items-center">
-                          <span className="text-sm text-foreground-secondary">
-                            {category.replace(/_/g, ' ')}
-                          </span>
-                          <Badge variant="error" className="text-xs">
-                            {count}
-                          </Badge>
-                        </div>
-                      ))}
-                  </div>
+            <Panel
+              title="Background jobs"
+              description="Latest run per sync source (cron timers on the box)"
+              actions={
+                <Link
+                  href="/dashboard/admin/health"
+                  className="text-xs text-primary hover:underline"
+                >
+                  details →
+                </Link>
+              }
+            >
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Source</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead className="text-right">Processed</TableHead>
+                      <TableHead className="text-right">Errors</TableHead>
+                      <TableHead>Message</TableHead>
+                      <TableHead className="text-right">When</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {o.syncRuns.map((r) => (
+                      <TableRow key={r.source}>
+                        <TableCell className="font-medium">{r.source}</TableCell>
+                        <TableCell>
+                          <StatusBadge status={r.status} />
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(r.processed)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {r.errors ? <span className="text-error">{r.errors}</span> : '0'}
+                        </TableCell>
+                        <TableCell
+                          className="max-w-md truncate text-foreground-secondary"
+                          title={r.message ?? ''}
+                        >
+                          {r.message ?? '—'}
+                        </TableCell>
+                        <TableCell className="text-right text-foreground-tertiary">
+                          <TimeAgo iso={r.createdAt} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+
+            <Panel
+              title="Daily snapshots"
+              description="Rolled up once a day by the tpmjs-cron timer"
+            >
+              {daily.error ? (
+                <p className="text-sm text-foreground-tertiary">{daily.error}</p>
+              ) : daily.data?.trend.length ? (
+                <div className="grid gap-6 lg:grid-cols-2">
+                  <AreaChart
+                    title="Tool calls per day"
+                    data={daily.data.trend.map((s) => ({
+                      date: s.date,
+                      value: s.eventToolCalls,
+                      secondaryValue: s.executionsFailed,
+                    }))}
+                    showSecondary
+                    labels={{ primary: 'tool calls', secondary: 'failed' }}
+                    secondaryColor="#ef4444"
+                    height={200}
+                  />
+                  <AreaChart
+                    title="Daily / weekly active users"
+                    data={daily.data.trend.map((s) => ({
+                      date: s.date,
+                      value: s.dauCount,
+                      secondaryValue: s.wauCount,
+                    }))}
+                    showSecondary
+                    labels={{ primary: 'DAU', secondary: 'WAU' }}
+                    height={200}
+                  />
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-sm text-foreground-tertiary">
+                  <Icon icon="info" size="xs" /> No snapshots yet.
                 </div>
               )}
-              {latest?.conversationStatuses &&
-                Object.keys(latest.conversationStatuses).length > 0 && (
-                  <div className="bg-surface border border-border rounded-xl p-5">
-                    <h3 className="text-sm font-medium text-foreground mb-3">
-                      Conversation Outcomes
-                    </h3>
-                    <div className="space-y-2">
-                      {Object.entries(latest.conversationStatuses)
-                        .sort(([, a], [, b]) => b - a)
-                        .map(([status, count]) => (
-                          <div key={status} className="flex justify-between items-center">
-                            <span className="text-sm text-foreground-secondary">{status}</span>
-                            <Badge
-                              variant={
-                                status === 'completed'
-                                  ? 'success'
-                                  : status === 'error'
-                                    ? 'error'
-                                    : 'secondary'
-                              }
-                              className="text-xs"
-                            >
-                              {count}
-                            </Badge>
-                          </div>
-                        ))}
-                    </div>
-                  </div>
-                )}
-            </div>
-          </section>
-        )}
-
-        {/* Trend Charts */}
-        {data?.trend && data.trend.length > 1 && (
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-4">Trends (30 days)</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div className="bg-surface border border-border rounded-xl p-4">
-                <AreaChart
-                  data={data.trend.map((s) => ({
-                    date: s.date,
-                    value: s.totalTools,
-                  }))}
-                  title="Total Tools"
-                  height={200}
-                />
-              </div>
-              <div className="bg-surface border border-border rounded-xl p-4">
-                <AreaChart
-                  data={data.trend.map((s) => ({
-                    date: s.date,
-                    value: s.dauCount,
-                    secondaryValue: s.wauCount,
-                  }))}
-                  title="Active Users"
-                  showSecondary
-                  labels={{ primary: 'DAU', secondary: 'WAU' }}
-                  height={200}
-                />
-              </div>
-              <div className="bg-surface border border-border rounded-xl p-4">
-                <AreaChart
-                  data={data.trend.map((s) => ({
-                    date: s.date,
-                    value: s.eventToolCalls,
-                    secondaryValue: s.eventAgentRuns,
-                  }))}
-                  title="Executions"
-                  showSecondary
-                  labels={{ primary: 'Tool Calls', secondary: 'Agent Runs' }}
-                  height={200}
-                />
-              </div>
-              <div className="bg-surface border border-border rounded-xl p-4">
-                <AreaChart
-                  data={data.trend.map((s) => ({
-                    date: s.date,
-                    value: s.searchCount,
-                  }))}
-                  title="Search Volume"
-                  height={200}
-                />
-              </div>
-            </div>
-          </section>
-        )}
-
-        {/* Top Search Queries */}
-        {latest?.topSearchQueries && latest.topSearchQueries.length > 0 && (
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-4">Top Searches (Today)</h2>
-            <div className="bg-surface border border-border rounded-xl overflow-hidden">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border bg-surface-secondary">
-                    <th className="text-left px-4 py-3 text-foreground-secondary font-medium">
-                      Query
-                    </th>
-                    <th className="text-right px-4 py-3 text-foreground-secondary font-medium">
-                      Count
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {latest.topSearchQueries.map((q) => (
-                    <tr key={q.query} className="border-b border-border last:border-0">
-                      <td className="px-4 py-3 text-foreground font-mono text-xs">{q.query}</td>
-                      <td className="text-right px-4 py-3">
-                        <Badge variant="secondary">{q.count}</Badge>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
-        )}
-
-        {/* Quick Links */}
-        <section>
-          <h2 className="text-lg font-semibold text-foreground mb-4">Manage</h2>
-          <div className="flex gap-4">
-            <Link
-              href="/dashboard/admin/users"
-              className="flex items-center gap-2 px-4 py-3 bg-surface border border-border rounded-xl hover:bg-surface-secondary transition-colors"
-            >
-              <Icon icon="user" size="sm" />
-              <span className="text-sm font-medium">Users</span>
-            </Link>
+            </Panel>
           </div>
-        </section>
-      </div>
+        )}
+      </PageState>
     </DashboardLayout>
   );
 }

--- a/apps/web/src/app/dashboard/admin/search/page.tsx
+++ b/apps/web/src/app/dashboard/admin/search/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
+import Link from 'next/link';
+import { useState } from 'react';
+import {
+  BarList,
+  formatMs,
+  formatNumber,
+  formatPercent,
+  HourlyChart,
+  Kpi,
+  PageState,
+  Panel,
+  RefreshBar,
+  TimeAgo,
+  WindowTabs,
+} from '~/components/admin/AdminUi';
+import { useAdminResource } from '~/components/admin/useAdminResource';
+import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { SearchAdmin } from '~/lib/admin/types';
+
+export default function AdminSearchPage() {
+  const [hours, setHours] = useState(168);
+  const res = useAdminResource<SearchAdmin>(`/api/admin/search?hours=${hours}`, {
+    refreshMs: 60_000,
+  });
+  const d = res.data;
+
+  return (
+    <DashboardLayout
+      title="Search"
+      subtitle="What people look for, what they don't find, and how fast"
+      showBackButton
+    >
+      <RefreshBar updatedAt={res.updatedAt} refreshing={res.refreshing} onRefresh={res.refresh}>
+        <WindowTabs hours={hours} onChange={setHours} />
+      </RefreshBar>
+      <PageState loading={res.loading} error={res.error} onRetry={res.refresh}>
+        {d && (
+          <div className="space-y-6">
+            <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Kpi label="Searches" value={formatNumber(d.total)} icon="search" />
+              <Kpi
+                label="Zero-result"
+                value={formatNumber(d.zeroResult)}
+                hint={formatPercent(d.zeroResult, d.total)}
+                tone={d.total && d.zeroResult / d.total > 0.25 ? 'warn' : undefined}
+                icon="alertCircle"
+              />
+              <Kpi label="p50 latency" value={formatMs(d.p50Ms)} icon="clock" />
+              <Kpi label="Window" value={`${hours}h`} icon="clock" />
+            </section>
+
+            <Panel title="Searches per hour" description="Red = zero results">
+              <HourlyChart
+                points={d.hourly}
+                labels={{ primary: 'searches', secondary: 'zero results' }}
+                secondaryColor="#ef4444"
+              />
+            </Panel>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Panel title="Top queries">
+                <BarList
+                  items={d.topQueries}
+                  linkFor={(q) => `/tools?q=${encodeURIComponent(q)}`}
+                  max={20}
+                />
+              </Panel>
+              <Panel
+                title="Queries with no results"
+                description="Demand the registry doesn't meet yet"
+              >
+                <BarList
+                  items={d.zeroResultQueries}
+                  emptyText="Every search found something."
+                  max={20}
+                />
+              </Panel>
+            </div>
+
+            <Panel title="Recent searches">
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>When</TableHead>
+                      <TableHead>Query</TableHead>
+                      <TableHead>User</TableHead>
+                      <TableHead className="text-right">Results</TableHead>
+                      <TableHead className="text-right">Latency</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {d.recent.map((s, i) => (
+                      <TableRow key={`${s.at}-${i}`}>
+                        <TableCell className="text-foreground-tertiary whitespace-nowrap">
+                          <TimeAgo iso={s.at} />
+                        </TableCell>
+                        <TableCell>
+                          <Link
+                            href={`/tools?q=${encodeURIComponent(s.query)}`}
+                            className="hover:text-primary"
+                          >
+                            {s.query}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="text-foreground-secondary">
+                          {s.username ?? 'anonymous'}
+                        </TableCell>
+                        <TableCell
+                          className={`text-right tabular-nums ${s.resultCount === 0 ? 'text-error' : ''}`}
+                        >
+                          {s.resultCount}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatMs(s.latencyMs)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </Panel>
+          </div>
+        )}
+      </PageState>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/dashboard/admin/users/page.tsx
+++ b/apps/web/src/app/dashboard/admin/users/page.tsx
@@ -1,61 +1,68 @@
 'use client';
 
-import { Badge } from '@tpmjs/ui/Badge/Badge';
 import { Button } from '@tpmjs/ui/Button/Button';
 import { Icon } from '@tpmjs/ui/Icon/Icon';
 import { Input } from '@tpmjs/ui/Input/Input';
-import { Spinner } from '@tpmjs/ui/Spinner/Spinner';
+import { Select } from '@tpmjs/ui/Select/Select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tpmjs/ui/Table/Table';
 import { useCallback, useEffect, useState } from 'react';
+import { useSession } from '@/lib/auth-client';
+import { PageState, StatusBadge, TimeAgo } from '~/components/admin/AdminUi';
 import { DashboardLayout } from '~/components/dashboard/DashboardLayout';
+import type { AdminUserRow } from '~/lib/admin/types';
 
-interface AdminUser {
-  id: string;
-  name: string;
-  email: string;
-  username: string | null;
-  image: string | null;
-  tier: string;
-  role: string;
-  signupSource: string | null;
-  emailVerified: boolean;
-  createdAt: string;
-  _count: {
-    collections: number;
-    agents: number;
-    activities: number;
-    toolLikes: number;
-    apiKeys: number;
-    tpmjsApiKeys: number;
-  };
+const ROLE_OPTIONS = [
+  { value: 'USER', label: 'USER' },
+  { value: 'ADMIN', label: 'ADMIN' },
+];
+const TIER_OPTIONS = [
+  { value: 'FREE', label: 'FREE' },
+  { value: 'PRO', label: 'PRO' },
+  { value: 'ENTERPRISE', label: 'ENTERPRISE' },
+];
+
+interface UsersPayload {
+  users: AdminUserRow[];
+  pagination: { hasMore: boolean };
 }
 
 export default function AdminUsersPage() {
-  const [users, setUsers] = useState<AdminUser[]>([]);
+  const { data: session } = useSession();
+  const [users, setUsers] = useState<AdminUserRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [search, setSearch] = useState('');
   const [searchInput, setSearchInput] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
 
   const fetchUsers = useCallback(async () => {
     setLoading(true);
     try {
       const params = new URLSearchParams({
         page: String(page),
-        limit: '20',
+        limit: '25',
         sortBy: 'createdAt',
         sortOrder: 'desc',
       });
       if (search) params.set('search', search);
-
       const res = await fetch(`/api/admin/users?${params}`);
-      if (res.status === 403) throw new Error('Access denied. Admin role required.');
+      if (res.status === 403 || res.status === 401)
+        throw new Error('Access denied. Admin role required.');
       if (!res.ok) throw new Error('Failed to load users');
-
-      const json = await res.json();
+      const json = (await res.json()) as { data: UsersPayload };
       setUsers(json.data.users);
       setHasMore(json.data.pagination.hasMore);
+      setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
     } finally {
@@ -64,133 +71,159 @@ export default function AdminUsersPage() {
   }, [page, search]);
 
   useEffect(() => {
-    fetchUsers();
+    void fetchUsers();
   }, [fetchUsers]);
 
-  const handleSearch = () => {
-    setPage(1);
-    setSearch(searchInput);
+  const updateUser = async (user: AdminUserRow, patch: { role?: string; tier?: string }) => {
+    const what = patch.role ? `role → ${patch.role}` : `tier → ${patch.tier}`;
+    if (patch.role && !window.confirm(`Set ${user.email} ${what}?`)) return;
+    setBusyId(user.id);
+    setNotice(null);
+    try {
+      const res = await fetch(`/api/admin/users/${user.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const json = (await res.json()) as { success: boolean; error?: string };
+      if (!res.ok || !json.success) throw new Error(json.error ?? `HTTP ${res.status}`);
+      setNotice(`${user.email}: ${what}`);
+      await fetchUsers();
+    } catch (err) {
+      setNotice(`Failed: ${err instanceof Error ? err.message : 'unknown error'}`);
+    } finally {
+      setBusyId(null);
+    }
   };
 
-  if (error) {
-    return (
-      <DashboardLayout
-        title="Users"
-        subtitle="Admin user management"
-        showBackButton
-        backUrl="/dashboard/admin"
-      >
-        <div className="flex flex-col items-center justify-center py-20 gap-4">
-          <Icon icon="alertCircle" size="lg" className="text-danger" />
-          <p className="text-foreground-secondary">{error}</p>
-        </div>
-      </DashboardLayout>
-    );
-  }
+  const admins = users.filter((u) => u.role === 'ADMIN').length;
 
   return (
     <DashboardLayout
       title="Users"
-      subtitle="Admin user management"
+      subtitle="Accounts, roles and tiers — promote or demote admins here"
       showBackButton
       backUrl="/dashboard/admin"
     >
       <div className="space-y-6">
-        {/* Search bar */}
-        <div className="flex gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Input
-            placeholder="Search by name, email, or username..."
+            aria-label="Search users"
+            placeholder="Search by name, email, or username…"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                setPage(1);
+                setSearch(searchInput);
+              }
+            }}
+            className="w-80"
           />
-          <Button variant="secondary" onClick={handleSearch}>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setPage(1);
+              setSearch(searchInput);
+            }}
+          >
             <Icon icon="search" size="sm" />
           </Button>
+          <span className="ml-auto text-xs text-foreground-tertiary">
+            {admins} admin{admins === 1 ? '' : 's'} on this page · you are{' '}
+            {session?.user?.email ?? '…'}
+          </span>
         </div>
 
-        {/* Users table */}
-        {loading ? (
-          <div className="flex items-center justify-center py-12">
-            <Spinner size="lg" />
-          </div>
-        ) : (
-          <div className="bg-surface border border-border rounded-xl overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border bg-surface-secondary">
-                  <th className="text-left px-4 py-3 text-foreground-secondary font-medium">
-                    User
-                  </th>
-                  <th className="text-left px-4 py-3 text-foreground-secondary font-medium">
-                    Role
-                  </th>
-                  <th className="text-left px-4 py-3 text-foreground-secondary font-medium">
-                    Tier
-                  </th>
-                  <th className="text-left px-4 py-3 text-foreground-secondary font-medium">
-                    Source
-                  </th>
-                  <th className="text-right px-4 py-3 text-foreground-secondary font-medium">
-                    Collections
-                  </th>
-                  <th className="text-right px-4 py-3 text-foreground-secondary font-medium">
-                    Agents
-                  </th>
-                  <th className="text-right px-4 py-3 text-foreground-secondary font-medium">
-                    Activities
-                  </th>
-                  <th className="text-left px-4 py-3 text-foreground-secondary font-medium">
-                    Joined
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {users.map((user) => (
-                  <tr
-                    key={user.id}
-                    className="border-b border-border last:border-0 hover:bg-surface-secondary/50"
-                  >
-                    <td className="px-4 py-3">
-                      <div>
-                        <div className="font-medium text-foreground">{user.name}</div>
-                        <div className="text-xs text-foreground-tertiary">{user.email}</div>
-                        {user.username && (
-                          <div className="text-xs text-foreground-tertiary">@{user.username}</div>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge variant={user.role === 'ADMIN' ? 'default' : 'secondary'}>
-                        {user.role}
-                      </Badge>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge variant="secondary">{user.tier}</Badge>
-                    </td>
-                    <td className="px-4 py-3 text-foreground-secondary text-xs">
-                      {user.signupSource || '-'}
-                    </td>
-                    <td className="text-right px-4 py-3 text-foreground-secondary">
-                      {user._count.collections}
-                    </td>
-                    <td className="text-right px-4 py-3 text-foreground-secondary">
-                      {user._count.agents}
-                    </td>
-                    <td className="text-right px-4 py-3 text-foreground-secondary">
-                      {user._count.activities}
-                    </td>
-                    <td className="px-4 py-3 text-foreground-secondary text-xs">
-                      {new Date(user.createdAt).toLocaleDateString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+        {notice && (
+          <div
+            className={`text-sm px-4 py-2 rounded-lg border ${notice.startsWith('Failed') ? 'border-error text-error bg-error/10' : 'border-success text-success bg-success/10'}`}
+          >
+            {notice}
           </div>
         )}
 
-        {/* Pagination */}
+        <PageState
+          loading={loading && users.length === 0}
+          error={error}
+          onRetry={() => void fetchUsers()}
+        >
+          <div className="bg-surface border border-border rounded-xl overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Tier</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead className="text-right">Collections</TableHead>
+                  <TableHead className="text-right">Agents</TableHead>
+                  <TableHead className="text-right">API keys</TableHead>
+                  <TableHead className="text-right">Joined</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.map((user) => {
+                  const isSelf = user.id === session?.user?.id;
+                  return (
+                    <TableRow key={user.id}>
+                      <TableCell>
+                        <div className="font-medium text-foreground flex items-center gap-2">
+                          {user.name}
+                          {user.role === 'ADMIN' && <StatusBadge status="admin" />}
+                          {isSelf && (
+                            <span className="text-xs text-foreground-tertiary">(you)</span>
+                          )}
+                        </div>
+                        <div className="text-xs text-foreground-tertiary">
+                          {user.email}
+                          {user.username && ` · @${user.username}`}
+                          {!user.emailVerified && ' · unverified'}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Select
+                          size="sm"
+                          aria-label={`Role for ${user.email}`}
+                          value={user.role}
+                          options={ROLE_OPTIONS}
+                          disabled={busyId === user.id || isSelf}
+                          onChange={(e) => void updateUser(user, { role: e.target.value })}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Select
+                          size="sm"
+                          aria-label={`Tier for ${user.email}`}
+                          value={user.tier}
+                          options={TIER_OPTIONS}
+                          disabled={busyId === user.id}
+                          onChange={(e) => void updateUser(user, { tier: e.target.value })}
+                        />
+                      </TableCell>
+                      <TableCell className="text-foreground-secondary text-xs">
+                        {user.signupSource || '—'}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {user._count.collections}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {user._count.agents}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {user._count.tpmjsApiKeys}
+                      </TableCell>
+                      <TableCell className="text-right text-foreground-tertiary">
+                        <TimeAgo iso={user.createdAt} />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </PageState>
+
         <div className="flex items-center justify-between">
           <Button
             variant="secondary"

--- a/apps/web/src/components/admin/AdminUi.tsx
+++ b/apps/web/src/components/admin/AdminUi.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { Badge } from '@tpmjs/ui/Badge/Badge';
+import { Button } from '@tpmjs/ui/Button/Button';
+import { ErrorState } from '@tpmjs/ui/ErrorState/ErrorState';
+import { Icon, type IconName } from '@tpmjs/ui/Icon/Icon';
+import { Spinner } from '@tpmjs/ui/Spinner/Spinner';
+import { Tabs } from '@tpmjs/ui/Tabs/Tabs';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { AreaChart } from '~/components/stats/AreaChart';
+import type { NamedCount, SeriesPoint } from '~/lib/admin/types';
+
+// ---------------------------------------------------------------- formatting
+
+export function formatNumber(value: number | null | undefined, digits = 0): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: digits }).format(value);
+}
+
+export function formatMs(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  if (value >= 10_000) return `${(value / 1000).toFixed(1)} s`;
+  return `${Math.round(value)} ms`;
+}
+
+export function formatPercent(part: number, total: number): string {
+  if (!total) return '—';
+  return `${((part / total) * 100).toFixed(part / total >= 0.995 || part === 0 ? 0 : 1)}%`;
+}
+
+export function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (diff < 0) return `in ${Math.round(-diff / 60)}m`;
+  if (diff < 45) return 'just now';
+  if (diff < 3600) return `${Math.round(diff / 60)}m ago`;
+  if (diff < 86_400) return `${Math.round(diff / 3600)}h ago`;
+  if (diff < 86_400 * 14) return `${Math.round(diff / 86_400)}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function TimeAgo({ iso }: { iso: string | null | undefined }) {
+  return (
+    <span
+      title={iso ? new Date(iso).toLocaleString() : undefined}
+      className="whitespace-nowrap tabular-nums"
+    >
+      {relativeTime(iso)}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------- status
+
+type BadgeVariant = 'default' | 'secondary' | 'outline' | 'success' | 'error' | 'warning';
+
+const GOOD = new Set([
+  'success',
+  'healthy',
+  'completed',
+  'active',
+  'connected',
+  'public',
+  'synced',
+  'ok',
+  'pass',
+  'passed',
+  'admin',
+]);
+const BAD = new Set(['error', 'failed', 'broken', 'inactive', 'disconnected', 'fail', 'cancelled']);
+const WARN = new Set([
+  'partial',
+  'unknown',
+  'stalled',
+  'pending',
+  'running',
+  'claimed',
+  'private',
+  'warning',
+  'degraded',
+]);
+
+export function toneFor(status: string | null | undefined): BadgeVariant {
+  if (!status) return 'outline';
+  const s = status.toLowerCase();
+  if (/^[45]\d\d$/.test(s)) return 'error';
+  if (/^[23]\d\d$/.test(s)) return 'success';
+  if (GOOD.has(s)) return 'success';
+  if (BAD.has(s)) return 'error';
+  if (WARN.has(s)) return 'warning';
+  return 'secondary';
+}
+
+export function StatusBadge({ status }: { status: string | null | undefined }) {
+  if (!status) return <span className="text-foreground-tertiary">—</span>;
+  return (
+    <Badge variant={toneFor(status)} size="sm">
+      {status}
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------- layout bits
+
+export function Kpi({
+  label,
+  value,
+  hint,
+  icon,
+  tone,
+}: {
+  label: string;
+  value: string | number;
+  hint?: ReactNode;
+  icon?: IconName;
+  tone?: 'good' | 'bad' | 'warn';
+}) {
+  const toneClass =
+    tone === 'bad'
+      ? 'text-error'
+      : tone === 'warn'
+        ? 'text-warning'
+        : tone === 'good'
+          ? 'text-success'
+          : 'text-foreground';
+  return (
+    <div className="bg-surface border border-border rounded-xl p-4 min-w-0">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <span className="text-foreground-tertiary text-xs uppercase tracking-wide truncate">
+          {label}
+        </span>
+        {icon && <Icon icon={icon} size="xs" className="text-foreground-tertiary shrink-0" />}
+      </div>
+      <div className={`text-2xl font-semibold tabular-nums ${toneClass}`}>{value}</div>
+      {hint && <div className="text-xs text-foreground-tertiary mt-1 truncate">{hint}</div>}
+    </div>
+  );
+}
+
+export function Panel({
+  title,
+  description,
+  actions,
+  children,
+  className,
+}: {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={`bg-surface border border-border rounded-xl ${className ?? ''}`}>
+      <header className="flex items-start justify-between gap-4 px-5 pt-4 pb-3 border-b border-border">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-foreground">{title}</h2>
+          {description && <p className="text-xs text-foreground-tertiary mt-0.5">{description}</p>}
+        </div>
+        {actions && <div className="shrink-0 flex items-center gap-2">{actions}</div>}
+      </header>
+      <div className="p-5">{children}</div>
+    </section>
+  );
+}
+
+export function PageState({
+  loading,
+  error,
+  onRetry,
+  children,
+}: {
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  children: ReactNode;
+}) {
+  if (error) {
+    return <ErrorState title="Couldn’t load admin data" message={error} onRetry={onRetry} />;
+  }
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+  return <>{children}</>;
+}
+
+export function RefreshBar({
+  updatedAt,
+  refreshing,
+  onRefresh,
+  children,
+}: {
+  updatedAt: Date | null;
+  refreshing: boolean;
+  onRefresh: () => void;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 mb-6">
+      {children}
+      <div className="ml-auto flex items-center gap-3 text-xs text-foreground-tertiary">
+        <span className="inline-flex items-center gap-1.5">
+          <span
+            className={`inline-block w-2 h-2 rounded-full ${refreshing ? 'bg-warning' : 'bg-success'}`}
+            aria-hidden="true"
+          />
+          {updatedAt ? `updated ${relativeTime(updatedAt.toISOString())}` : 'loading…'}
+        </span>
+        <Button size="sm" variant="outline" onClick={onRefresh} disabled={refreshing}>
+          <Icon icon="loader" size="xs" className={`mr-1 ${refreshing ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const WINDOWS: Array<{ id: string; label: string; hours: number }> = [
+  { id: '1', label: '1h', hours: 1 },
+  { id: '24', label: '24h', hours: 24 },
+  { id: '168', label: '7d', hours: 168 },
+  { id: '720', label: '30d', hours: 720 },
+];
+
+export function WindowTabs({
+  hours,
+  onChange,
+}: {
+  hours: number;
+  onChange: (hours: number) => void;
+}) {
+  return (
+    <Tabs
+      size="sm"
+      tabs={WINDOWS.map((w) => ({ id: w.id, label: w.label }))}
+      activeTab={String(WINDOWS.find((w) => w.hours === hours)?.id ?? '24')}
+      onTabChange={(id) => onChange(WINDOWS.find((w) => w.id === id)?.hours ?? 24)}
+    />
+  );
+}
+
+// ---------------------------------------------------------------- data viz
+
+export function HourlyChart({
+  points,
+  labels,
+  height = 180,
+  color,
+  secondaryColor,
+}: {
+  points: SeriesPoint[];
+  labels: { primary: string; secondary?: string };
+  height?: number;
+  color?: string;
+  secondaryColor?: string;
+}) {
+  const hasSecondary = Boolean(labels.secondary);
+  const data = points.map((p) => ({
+    date: p.at,
+    value: p.value,
+    secondaryValue: p.secondaryValue ?? 0,
+  }));
+  if (!points.some((p) => p.value > 0)) {
+    return (
+      <div className="text-sm text-foreground-tertiary py-8 text-center">
+        No events in this window.
+      </div>
+    );
+  }
+  return (
+    <AreaChart
+      data={data}
+      height={height}
+      color={color}
+      secondaryColor={secondaryColor}
+      showSecondary={hasSecondary}
+      labels={labels}
+      dateFormat={points.length > 48 ? 'MMM d' : 'HH:mm'}
+    />
+  );
+}
+
+export function BarList({
+  items,
+  total,
+  linkFor,
+  emptyText = 'Nothing yet.',
+  max = 12,
+}: {
+  items: NamedCount[];
+  total?: number;
+  linkFor?: (key: string) => string | null;
+  emptyText?: string;
+  max?: number;
+}) {
+  if (!items.length) return <p className="text-sm text-foreground-tertiary">{emptyText}</p>;
+  const peak = Math.max(1, ...items.map((i) => i.count));
+  const denominator = total ?? items.reduce((sum, i) => sum + i.count, 0);
+  return (
+    <ul className="space-y-2">
+      {items.slice(0, max).map((item) => {
+        const href = linkFor?.(item.key) ?? null;
+        const label = href ? (
+          <Link href={href} className="hover:text-primary truncate">
+            {item.key}
+          </Link>
+        ) : (
+          <span className="truncate">{item.key}</span>
+        );
+        return (
+          <li key={item.key} className="text-sm">
+            <div className="flex items-center justify-between gap-3 mb-1">
+              <span className="min-w-0 flex items-center gap-2 text-foreground">{label}</span>
+              <span className="text-foreground-tertiary tabular-nums shrink-0">
+                {formatNumber(item.count)}
+                {denominator > 0 && (
+                  <span className="ml-1 text-xs">({formatPercent(item.count, denominator)})</span>
+                )}
+              </span>
+            </div>
+            <div className="h-1.5 rounded bg-border overflow-hidden">
+              <div
+                className="h-full bg-primary rounded"
+                style={{ width: `${(item.count / peak) * 100}%` }}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function Mono({ children, className }: { children: ReactNode; className?: string }) {
+  return <code className={`font-mono text-xs ${className ?? ''}`}>{children}</code>;
+}

--- a/apps/web/src/components/admin/useAdminResource.ts
+++ b/apps/web/src/components/admin/useAdminResource.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ApiEnvelope } from '~/lib/admin/types';
+
+interface Options {
+  /** Re-fetch interval while the tab is visible; 0 disables auto-refresh. */
+  refreshMs?: number;
+}
+
+interface State<T> {
+  data: T | null;
+  error: string | null;
+  loading: boolean;
+  refreshing: boolean;
+  updatedAt: Date | null;
+  refresh: () => void;
+}
+
+/** GET an admin envelope; throws with a readable message on auth or API failure. */
+export async function fetchEnvelope<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (res.status === 401 || res.status === 403) {
+    throw new Error('Access denied. Admin role required.');
+  }
+  const body = (await res.json()) as ApiEnvelope<T>;
+  if (!body.success) throw new Error(body.error);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return body.data;
+}
+
+/**
+ * Fetches an admin API resource with visibility-aware auto-refresh.
+ * Keeps the last good payload on screen while a refresh is in flight, and maps
+ * 401/403 to an explicit access message so pages never render a generic failure.
+ */
+export function useAdminResource<T>(url: string | null, options: Options = {}): State<T> {
+  const refreshMs = options.refreshMs ?? 0;
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(Boolean(url));
+  const [refreshing, setRefreshing] = useState(false);
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
+  const generation = useRef(0);
+
+  const load = useCallback(async () => {
+    if (!url) return;
+    const gen = ++generation.current;
+    setRefreshing(true);
+    try {
+      const payload = await fetchEnvelope<T>(url);
+      if (gen !== generation.current) return;
+      setData(payload);
+      setError(null);
+      setUpdatedAt(new Date());
+    } catch (err) {
+      if (gen !== generation.current) return;
+      setError(err instanceof Error ? err.message : 'Request failed');
+    } finally {
+      if (gen === generation.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, [url]);
+
+  useEffect(() => {
+    setLoading(Boolean(url));
+    void load();
+  }, [load, url]);
+
+  useEffect(() => {
+    if (!refreshMs || !url) return;
+    const tick = () => {
+      if (document.visibilityState === 'visible') void load();
+    };
+    const timer = window.setInterval(tick, refreshMs);
+    document.addEventListener('visibilitychange', tick);
+    return () => {
+      window.clearInterval(timer);
+      document.removeEventListener('visibilitychange', tick);
+    };
+  }, [load, refreshMs, url]);
+
+  return { data, error, loading, refreshing, updatedAt, refresh: () => void load() };
+}

--- a/apps/web/src/components/dashboard/DashboardLayout.tsx
+++ b/apps/web/src/components/dashboard/DashboardLayout.tsx
@@ -45,6 +45,13 @@ const navSections: NavSection[] = [
 
 const adminNavItems: NavItem[] = [
   { href: '/dashboard/admin', label: 'Overview', icon: 'barChart' },
+  { href: '/dashboard/admin/activity', label: 'Live activity', icon: 'bell' },
+  { href: '/dashboard/admin/executions', label: 'Executions', icon: 'arrowRight' },
+  { href: '/dashboard/admin/api-usage', label: 'API usage', icon: 'key' },
+  { href: '/dashboard/admin/health', label: 'Health & jobs', icon: 'alertCircle' },
+  { href: '/dashboard/admin/collections', label: 'Collections', icon: 'folder' },
+  { href: '/dashboard/admin/agents', label: 'Agents', icon: 'terminal' },
+  { href: '/dashboard/admin/search', label: 'Search', icon: 'search' },
   { href: '/dashboard/admin/users', label: 'Users', icon: 'user' },
 ];
 
@@ -129,7 +136,7 @@ export function DashboardLayout({
   }, [pathname]);
 
   const isActive = (href: string) => {
-    if (href === '/dashboard') {
+    if (href === '/dashboard' || href === '/dashboard/admin') {
       return pathname === '/dashboard';
     }
     return pathname.startsWith(href);

--- a/apps/web/src/lib/admin/metrics.ts
+++ b/apps/web/src/lib/admin/metrics.ts
@@ -1,0 +1,1139 @@
+/**
+ * Server-side queries behind the admin monitoring API.
+ *
+ * Everything here is read-only and bounded: windows are capped, lists are limited, and
+ * UNION feeds limit each branch before sorting. Raw counts are cast to int/float in SQL
+ * so rows serialise as plain numbers (Postgres bigint would otherwise arrive as BigInt).
+ * No secret material is ever selected (env var *names* only, never values or tokens).
+ */
+
+import { Prisma, prisma } from '@tpmjs/db';
+import { env } from '~/env';
+import { RATE_LIMITS_BY_TIER } from '~/lib/api-keys';
+import { executorAuthHeaders } from '~/lib/executors/internal-auth';
+import type {
+  ActivityFeed,
+  ActivityItem,
+  AdminAgent,
+  AdminCollection,
+  AdminConversation,
+  AdminCustomServer,
+  AdminOverview,
+  AgentsAdmin,
+  ApiKeyUsage,
+  ApiUsageStats,
+  BrokenTool,
+  CollectionsAdmin,
+  ExecutionRow,
+  ExecutionStats,
+  ExecutorHealth,
+  HealthDistributionRow,
+  HealthOverview,
+  NamedCount,
+  SearchAdmin,
+  SeriesPoint,
+  SyncRunSummary,
+  WindowStats,
+} from './types';
+
+const MAX_HOURS = 24 * 30;
+
+export function clampHours(raw: string | null, fallback = 24): number {
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, MAX_HOURS);
+}
+
+export function clampInt(raw: string | null, fallback: number, max: number): number {
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+const iso = (value: Date | string | null | undefined): string | null =>
+  value ? new Date(value).toISOString() : null;
+const isoNow = (value: Date | string): string => new Date(value).toISOString();
+
+/** Fill missing hourly buckets with zeros so charts keep a continuous axis. */
+function fillHourly(
+  rows: Array<{ at: Date; value: number; secondary?: number }>,
+  hours: number
+): SeriesPoint[] {
+  const byHour = new Map<number, { value: number; secondaryValue?: number }>();
+  for (const row of rows) {
+    byHour.set(new Date(row.at).getTime(), { value: row.value, secondaryValue: row.secondary });
+  }
+  const out: SeriesPoint[] = [];
+  const end = new Date();
+  end.setUTCMinutes(0, 0, 0);
+  for (let i = hours - 1; i >= 0; i--) {
+    const bucket = end.getTime() - i * 3_600_000;
+    const hit = byHour.get(bucket);
+    out.push({
+      at: new Date(bucket).toISOString(),
+      value: hit?.value ?? 0,
+      secondaryValue: hit?.secondaryValue ?? 0,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------- windows
+
+async function executionWindow(hours: number, label: string): Promise<WindowStats> {
+  const [row] = await prisma.$queryRaw<
+    Array<{ total: number; success: number; error: number; p50: number | null; p95: number | null }>
+  >(Prisma.sql`
+    SELECT count(*)::int AS total,
+           count(*) FILTER (WHERE status = 'success')::int AS success,
+           count(*) FILTER (WHERE status <> 'success')::int AS error,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_ms)::float8 AS p50,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)::float8 AS p95
+    FROM execution_events
+    WHERE created_at > now() - make_interval(hours => ${hours})
+  `);
+  return {
+    window: label,
+    hours,
+    total: row?.total ?? 0,
+    success: row?.success ?? 0,
+    error: row?.error ?? 0,
+    p50Ms: row?.p50 ?? null,
+    p95Ms: row?.p95 ?? null,
+  };
+}
+
+async function apiUsageWindow(hours: number, label: string): Promise<WindowStats> {
+  const [row] = await prisma.$queryRaw<
+    Array<{ total: number; success: number; error: number; p50: number | null; p95: number | null }>
+  >(Prisma.sql`
+    SELECT count(*)::int AS total,
+           count(*) FILTER (WHERE status_code < 400)::int AS success,
+           count(*) FILTER (WHERE status_code >= 400)::int AS error,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)::float8 AS p50,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms)::float8 AS p95
+    FROM api_usage_records
+    WHERE created_at > now() - make_interval(hours => ${hours})
+  `);
+  return {
+    window: label,
+    hours,
+    total: row?.total ?? 0,
+    success: row?.success ?? 0,
+    error: row?.error ?? 0,
+    p50Ms: row?.p50 ?? null,
+    p95Ms: row?.p95 ?? null,
+  };
+}
+
+async function executionHourly(hours: number): Promise<SeriesPoint[]> {
+  const rows = await prisma.$queryRaw<
+    Array<{ at: Date; value: number; secondary: number }>
+  >(Prisma.sql`
+    SELECT date_trunc('hour', created_at) AS at,
+           count(*)::int AS value,
+           count(*) FILTER (WHERE status <> 'success')::int AS secondary
+    FROM execution_events
+    WHERE created_at > now() - make_interval(hours => ${hours})
+    GROUP BY 1 ORDER BY 1
+  `);
+  return fillHourly(rows, hours);
+}
+
+// ---------------------------------------------------------------- executor
+
+export async function executorHealth(): Promise<ExecutorHealth> {
+  const url = env.RAILWAY_EXECUTOR_URL ?? null;
+  if (!url) {
+    return {
+      reachable: false,
+      url: null,
+      implementationVersion: null,
+      protocolVersion: null,
+      status: null,
+      latencyMs: null,
+      error: 'RAILWAY_EXECUTOR_URL not configured',
+    };
+  }
+  const started = Date.now();
+  try {
+    const res = await fetch(`${url}/health`, {
+      headers: { Accept: 'application/json', ...executorAuthHeaders() },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    });
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const str = (key: string): string | null =>
+      typeof body[key] === 'string' ? (body[key] as string) : null;
+    return {
+      reachable: res.ok,
+      url,
+      implementationVersion: str('implementationVersion'),
+      protocolVersion: str('protocolVersion'),
+      status: str('status') ?? `HTTP ${res.status}`,
+      latencyMs: Date.now() - started,
+      error: res.ok ? null : `HTTP ${res.status}`,
+    };
+  } catch (error) {
+    return {
+      reachable: false,
+      url,
+      implementationVersion: null,
+      protocolVersion: null,
+      status: null,
+      latencyMs: Date.now() - started,
+      error: error instanceof Error ? error.message : 'fetch failed',
+    };
+  }
+}
+
+// ---------------------------------------------------------------- sync runs
+
+async function latestSyncRuns(): Promise<SyncRunSummary[]> {
+  const rows = await prisma.$queryRaw<
+    Array<{
+      source: string;
+      status: string;
+      processed: number;
+      skipped: number;
+      errors: number;
+      message: string | null;
+      created_at: Date;
+    }>
+  >(Prisma.sql`
+    SELECT DISTINCT ON (source) source, status, processed, skipped, errors, message, created_at
+    FROM sync_logs
+    WHERE created_at > now() - interval '14 days'
+    ORDER BY source, created_at DESC
+  `);
+  return rows.map((r) => ({
+    source: r.source,
+    status: r.status,
+    processed: r.processed,
+    skipped: r.skipped,
+    errors: r.errors,
+    message: r.message,
+    createdAt: isoNow(r.created_at),
+  }));
+}
+
+// ---------------------------------------------------------------- overview
+
+interface RegistryCounts {
+  toolsActive: number;
+  toolsRetired: number;
+  packages: number;
+  officialPackages: number;
+  toolsHealthy: number;
+  toolsBroken: number;
+  toolsUnknown: number;
+}
+
+async function registryCounts(): Promise<RegistryCounts> {
+  const [r] = await prisma.$queryRaw<Array<RegistryCounts>>(Prisma.sql`
+    SELECT (SELECT count(*) FROM tools WHERE is_active)::int AS "toolsActive",
+           (SELECT count(*) FROM tools WHERE NOT is_active)::int AS "toolsRetired",
+           (SELECT count(*) FROM packages)::int AS packages,
+           (SELECT count(*) FROM packages WHERE is_official)::int AS "officialPackages",
+           (SELECT count(*) FROM tools WHERE is_active AND import_health = 'HEALTHY' AND coalesce(execution_health::text, '') <> 'BROKEN')::int AS "toolsHealthy",
+           (SELECT count(*) FROM tools WHERE is_active AND (import_health = 'BROKEN' OR execution_health = 'BROKEN'))::int AS "toolsBroken",
+           (SELECT count(*) FROM tools WHERE is_active AND import_health IS DISTINCT FROM 'HEALTHY' AND import_health IS DISTINCT FROM 'BROKEN' AND coalesce(execution_health::text, '') <> 'BROKEN')::int AS "toolsUnknown"
+  `);
+  return (
+    r ?? {
+      toolsActive: 0,
+      toolsRetired: 0,
+      packages: 0,
+      officialPackages: 0,
+      toolsHealthy: 0,
+      toolsBroken: 0,
+      toolsUnknown: 0,
+    }
+  );
+}
+
+async function userCounts(): Promise<AdminOverview['users']> {
+  const [r] = await prisma.$queryRaw<Array<AdminOverview['users']>>(Prisma.sql`
+    SELECT (SELECT count(*) FROM users)::int AS total,
+           (SELECT count(*) FROM users WHERE role = 'ADMIN')::int AS admins,
+           (SELECT count(*) FROM users WHERE created_at > now() - interval '7 days')::int AS "new7d",
+           (SELECT count(*) FROM sessions WHERE expires_at > now())::int AS "activeSessions"
+  `);
+  return r ?? { total: 0, admins: 0, new7d: 0, activeSessions: 0 };
+}
+
+async function keyCounts(): Promise<AdminOverview['keys']> {
+  const [r] = await prisma.$queryRaw<Array<AdminOverview['keys']>>(Prisma.sql`
+    SELECT count(*)::int AS total,
+           count(*) FILTER (WHERE is_active)::int AS active,
+           count(*) FILTER (WHERE last_used_at > now() - interval '24 hours')::int AS "used24h"
+    FROM tpmjs_api_keys
+  `);
+  return r ?? { total: 0, active: 0, used24h: 0 };
+}
+
+async function collectionCounts(): Promise<AdminOverview['collections']> {
+  const [r] = await prisma.$queryRaw<Array<AdminOverview['collections']>>(Prisma.sql`
+    SELECT (SELECT count(*) FROM collections)::int AS total,
+           (SELECT count(*) FROM collections WHERE is_public)::int AS public,
+           (SELECT count(*) FROM custom_mcp_servers)::int AS "customServers",
+           (SELECT count(*) FROM bridge_connections WHERE status = 'connected')::int AS "bridgesConnected"
+  `);
+  return r ?? { total: 0, public: 0, customServers: 0, bridgesConnected: 0 };
+}
+
+async function agentCounts(): Promise<AdminOverview['agents']> {
+  const [r] = await prisma.$queryRaw<Array<AdminOverview['agents']>>(Prisma.sql`
+    SELECT (SELECT count(*) FROM agents)::int AS total,
+           (SELECT count(*) FROM conversations WHERE created_at > now() - interval '24 hours')::int AS "conversations24h",
+           (SELECT count(*) FROM messages WHERE created_at > now() - interval '24 hours')::int AS "messages24h"
+  `);
+  return r ?? { total: 0, conversations24h: 0, messages24h: 0 };
+}
+
+async function searches24h(): Promise<number> {
+  const [r] = await prisma.$queryRaw<Array<{ c: number }>>(Prisma.sql`
+    SELECT count(*)::int AS c FROM search_logs WHERE created_at > now() - interval '24 hours'
+  `);
+  return r?.c ?? 0;
+}
+
+async function healthChecks24h(): Promise<NamedCount[]> {
+  return prisma.$queryRaw<NamedCount[]>(Prisma.sql`
+    SELECT overall_status::text AS key, count(*)::int AS count
+    FROM health_checks WHERE created_at > now() - interval '24 hours'
+    GROUP BY 1 ORDER BY 2 DESC
+  `);
+}
+
+export async function getAdminOverview(): Promise<AdminOverview> {
+  const [
+    executions,
+    apiUsage,
+    registry,
+    users,
+    keys,
+    collections,
+    agents,
+    searches,
+    healthChecks,
+    syncRuns,
+    executor,
+    hourly,
+  ] = await Promise.all([
+    Promise.all([
+      executionWindow(1, '1h'),
+      executionWindow(24, '24h'),
+      executionWindow(24 * 7, '7d'),
+    ]),
+    Promise.all([apiUsageWindow(1, '1h'), apiUsageWindow(24, '24h'), apiUsageWindow(24 * 7, '7d')]),
+    registryCounts(),
+    userCounts(),
+    keyCounts(),
+    collectionCounts(),
+    agentCounts(),
+    searches24h(),
+    healthChecks24h(),
+    latestSyncRuns(),
+    executorHealth(),
+    executionHourly(24),
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    executions,
+    apiUsage,
+    registry,
+    users,
+    keys,
+    collections,
+    agents,
+    searches24h: searches,
+    healthChecks24h: healthChecks,
+    syncRuns,
+    executor,
+    hourly,
+  };
+}
+
+// ---------------------------------------------------------------- activity feed
+
+const ACTIVITY_KINDS = new Set<ActivityItem['kind']>([
+  'execution',
+  'api',
+  'search',
+  'sync',
+  'health',
+  'collection',
+  'agent',
+  'user',
+  'key',
+]);
+
+export function parseActivityKind(raw: string | null): ActivityItem['kind'] | null {
+  return raw && ACTIVITY_KINDS.has(raw as ActivityItem['kind'])
+    ? (raw as ActivityItem['kind'])
+    : null;
+}
+
+export async function getActivityFeed(options: {
+  limit: number;
+  before: string | null;
+  kind: ActivityItem['kind'] | null;
+}): Promise<ActivityFeed> {
+  const { limit, before, kind } = options;
+  const rows = await prisma.$queryRaw<
+    Array<{
+      kind: ActivityItem['kind'];
+      at: Date;
+      actor: string | null;
+      title: string;
+      detail: string | null;
+      status: string | null;
+      ref: string | null;
+    }>
+  >(Prisma.sql`
+    SELECT kind, at, actor, title, detail, status, ref FROM (
+      (SELECT 'execution'::text AS kind, e.created_at AS at, coalesce(u.username, k.name) AS actor,
+              coalesce(e.package_name, e.source) || '::' || coalesce(e.tool_name, e.event_type) AS title,
+              left(coalesce(e.error_message, e.output_summary::text), 220) AS detail, e.status AS status, e.id AS ref
+       FROM execution_events e
+       LEFT JOIN users u ON u.id = e.user_id
+       LEFT JOIN tpmjs_api_keys k ON k.id = e.api_key_id
+       WHERE (${before}::timestamptz IS NULL OR e.created_at < ${before}::timestamptz)
+       ORDER BY e.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'api', r.created_at, k.name, r.method || ' ' || r.endpoint, left(r.error_message, 220), r.status_code::text, r.id
+       FROM api_usage_records r LEFT JOIN tpmjs_api_keys k ON k.id = r.api_key_id
+       WHERE (${before}::timestamptz IS NULL OR r.created_at < ${before}::timestamptz)
+       ORDER BY r.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'search', s.created_at, u.username, 'search: ' || s.query, s.result_count || ' results · ' || s.latency_ms || ' ms', NULL, s.id
+       FROM search_logs s LEFT JOIN users u ON u.id = s.user_id
+       WHERE (${before}::timestamptz IS NULL OR s.created_at < ${before}::timestamptz)
+       ORDER BY s.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'sync', l.created_at, 'cron', l.source, left(l.message, 220), l.status, l.id
+       FROM sync_logs l
+       WHERE (${before}::timestamptz IS NULL OR l.created_at < ${before}::timestamptz)
+       ORDER BY l.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'health', h.created_at, h.trigger_source, p.npm_package_name || '::' || t.name,
+              left(coalesce(h.import_error, h.execution_error), 220), h.overall_status::text, h.id
+       FROM health_checks h JOIN tools t ON t.id = h.tool_id JOIN packages p ON p.id = t.package_id
+       WHERE h.overall_status <> 'UNKNOWN' AND (${before}::timestamptz IS NULL OR h.created_at < ${before}::timestamptz)
+       ORDER BY h.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'collection', c.created_at, u.username, 'collection created: ' || c.name, c.slug,
+              CASE WHEN c.is_public THEN 'public' ELSE 'private' END, c.id
+       FROM collections c JOIN users u ON u.id = c.user_id
+       WHERE (${before}::timestamptz IS NULL OR c.created_at < ${before}::timestamptz)
+       ORDER BY c.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'agent', a.created_at, u.username, 'agent created: ' || a.name, a.model_id, NULL, a.id
+       FROM agents a JOIN users u ON u.id = a.user_id
+       WHERE (${before}::timestamptz IS NULL OR a.created_at < ${before}::timestamptz)
+       ORDER BY a.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'user', u.created_at, u.username, 'user signed up: ' || coalesce(u.username, u.email), u.signup_source, u.tier::text, u.id
+       FROM users u
+       WHERE (${before}::timestamptz IS NULL OR u.created_at < ${before}::timestamptz)
+       ORDER BY u.created_at DESC LIMIT ${limit})
+      UNION ALL
+      (SELECT 'key', k.created_at, u.username, 'API key created: ' || k.name, k.key_prefix,
+              CASE WHEN k.is_active THEN 'active' ELSE 'inactive' END, k.id
+       FROM tpmjs_api_keys k JOIN users u ON u.id = k.user_id
+       WHERE (${before}::timestamptz IS NULL OR k.created_at < ${before}::timestamptz)
+       ORDER BY k.created_at DESC LIMIT ${limit})
+    ) feed
+    WHERE (${kind}::text IS NULL OR kind = ${kind}::text)
+    ORDER BY at DESC
+    LIMIT ${limit}
+  `);
+  const items: ActivityItem[] = rows.map((r) => ({
+    kind: r.kind,
+    at: isoNow(r.at),
+    actor: r.actor,
+    title: r.title,
+    detail: r.detail,
+    status: r.status,
+    ref: r.ref,
+  }));
+  return {
+    items,
+    nextCursor: items.length === limit ? (items[items.length - 1]?.at ?? null) : null,
+  };
+}
+
+// ---------------------------------------------------------------- executions
+
+export async function getExecutionStats(options: {
+  hours: number;
+  status: string | null;
+  packageName: string | null;
+  source: string | null;
+  tool: string | null;
+  limit: number;
+  offset: number;
+}): Promise<ExecutionStats> {
+  const { hours, status, packageName, source, tool, limit, offset } = options;
+  const where = Prisma.sql`
+    e.created_at > now() - make_interval(hours => ${hours})
+    AND (${status}::text IS NULL OR e.status = ${status}::text)
+    AND (${packageName}::text IS NULL OR e.package_name = ${packageName}::text)
+    AND (${source}::text IS NULL OR e.source = ${source}::text)
+    AND (${tool}::text IS NULL OR e.tool_name = ${tool}::text)
+  `;
+
+  const [
+    totalsRow,
+    byStatus,
+    byCategory,
+    bySource,
+    topTools,
+    hourlyRows,
+    rows,
+    totalRow,
+    facetPackages,
+    facetSources,
+    facetStatuses,
+  ] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        total: number;
+        success: number;
+        error: number;
+        p50: number | null;
+        p95: number | null;
+      }>
+    >(Prisma.sql`
+        SELECT count(*)::int AS total,
+               count(*) FILTER (WHERE e.status = 'success')::int AS success,
+               count(*) FILTER (WHERE e.status <> 'success')::int AS error,
+               percentile_cont(0.5) WITHIN GROUP (ORDER BY e.duration_ms)::float8 AS p50,
+               percentile_cont(0.95) WITHIN GROUP (ORDER BY e.duration_ms)::float8 AS p95
+        FROM execution_events e WHERE ${where}
+      `),
+    prisma.$queryRaw<NamedCount[]>(Prisma.sql`
+        SELECT e.status AS key, count(*)::int AS count FROM execution_events e WHERE ${where} GROUP BY 1 ORDER BY 2 DESC
+      `),
+    prisma.$queryRaw<NamedCount[]>(Prisma.sql`
+        SELECT coalesce(e.error_category, 'none') AS key, count(*)::int AS count FROM execution_events e WHERE ${where} GROUP BY 1 ORDER BY 2 DESC
+      `),
+    prisma.$queryRaw<NamedCount[]>(Prisma.sql`
+        SELECT e.source AS key, count(*)::int AS count FROM execution_events e WHERE ${where} GROUP BY 1 ORDER BY 2 DESC
+      `),
+    prisma.$queryRaw<
+      Array<{
+        key: string;
+        count: number;
+        errors: number;
+        avgMs: number | null;
+        p95Ms: number | null;
+      }>
+    >(Prisma.sql`
+        SELECT coalesce(e.package_name, e.source) || '::' || coalesce(e.tool_name, e.event_type) AS key,
+               count(*)::int AS count,
+               count(*) FILTER (WHERE e.status <> 'success')::int AS errors,
+               avg(e.duration_ms)::float8 AS "avgMs",
+               percentile_cont(0.95) WITHIN GROUP (ORDER BY e.duration_ms)::float8 AS "p95Ms"
+        FROM execution_events e WHERE ${where}
+        GROUP BY 1 ORDER BY 2 DESC LIMIT 25
+      `),
+    prisma.$queryRaw<Array<{ at: Date; value: number; secondary: number }>>(Prisma.sql`
+        SELECT date_trunc('hour', e.created_at) AS at, count(*)::int AS value,
+               count(*) FILTER (WHERE e.status <> 'success')::int AS secondary
+        FROM execution_events e WHERE ${where} GROUP BY 1 ORDER BY 1
+      `),
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        created_at: Date;
+        source: string;
+        event_type: string;
+        status: string;
+        tool_name: string | null;
+        package_name: string | null;
+        duration_ms: number | null;
+        error_category: string | null;
+        error_message: string | null;
+        user_id: string | null;
+        username: string | null;
+        api_key_name: string | null;
+        collection_id: string | null;
+        agent_id: string | null;
+      }>
+    >(Prisma.sql`
+        SELECT e.id, e.created_at, e.source, e.event_type, e.status, e.tool_name, e.package_name, e.duration_ms,
+               e.error_category, left(e.error_message, 300) AS error_message, e.user_id, u.username, k.name AS api_key_name,
+               e.collection_id, e.agent_id
+        FROM execution_events e
+        LEFT JOIN users u ON u.id = e.user_id
+        LEFT JOIN tpmjs_api_keys k ON k.id = e.api_key_id
+        WHERE ${where}
+        ORDER BY e.created_at DESC LIMIT ${limit} OFFSET ${offset}
+      `),
+    prisma.$queryRaw<Array<{ c: number }>>(
+      Prisma.sql`SELECT count(*)::int AS c FROM execution_events e WHERE ${where}`
+    ),
+    prisma.$queryRaw<Array<{ key: string }>>(Prisma.sql`
+        SELECT DISTINCT package_name AS key FROM execution_events WHERE package_name IS NOT NULL AND created_at > now() - make_interval(hours => ${hours}) ORDER BY 1
+      `),
+    prisma.$queryRaw<Array<{ key: string }>>(Prisma.sql`
+        SELECT DISTINCT source AS key FROM execution_events WHERE created_at > now() - make_interval(hours => ${hours}) ORDER BY 1
+      `),
+    prisma.$queryRaw<Array<{ key: string }>>(Prisma.sql`
+        SELECT DISTINCT status AS key FROM execution_events WHERE created_at > now() - make_interval(hours => ${hours}) ORDER BY 1
+      `),
+  ]);
+
+  const t = totalsRow[0];
+  const executionRows: ExecutionRow[] = rows.map((r) => ({
+    id: r.id,
+    at: isoNow(r.created_at),
+    source: r.source,
+    eventType: r.event_type,
+    status: r.status,
+    toolName: r.tool_name,
+    packageName: r.package_name,
+    durationMs: r.duration_ms,
+    errorCategory: r.error_category,
+    errorMessage: r.error_message,
+    userId: r.user_id,
+    username: r.username,
+    apiKeyName: r.api_key_name,
+    collectionId: r.collection_id,
+    agentId: r.agent_id,
+  }));
+
+  return {
+    hours,
+    totals: {
+      window: `${hours}h`,
+      hours,
+      total: t?.total ?? 0,
+      success: t?.success ?? 0,
+      error: t?.error ?? 0,
+      p50Ms: t?.p50 ?? null,
+      p95Ms: t?.p95 ?? null,
+    },
+    byStatus,
+    byCategory,
+    bySource,
+    topTools,
+    hourly: fillHourly(hourlyRows, Math.min(hours, 24 * 7)),
+    rows: executionRows,
+    total: totalRow[0]?.c ?? 0,
+    facets: {
+      packages: facetPackages.map((r) => r.key),
+      sources: facetSources.map((r) => r.key),
+      statuses: facetStatuses.map((r) => r.key),
+    },
+  };
+}
+
+// ---------------------------------------------------------------- API usage
+
+export async function getApiUsageStats(hours: number): Promise<ApiUsageStats> {
+  const [totals, byEndpoint, byStatusCode, keyRows, hourlyRows, errorRows] = await Promise.all([
+    apiUsageWindow(hours, `${hours}h`),
+    prisma.$queryRaw<
+      Array<{
+        key: string;
+        count: number;
+        errors: number;
+        p50Ms: number | null;
+        p95Ms: number | null;
+      }>
+    >(Prisma.sql`
+      SELECT endpoint AS key, count(*)::int AS count,
+             count(*) FILTER (WHERE status_code >= 400)::int AS errors,
+             percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)::float8 AS "p50Ms",
+             percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms)::float8 AS "p95Ms"
+      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours})
+      GROUP BY 1 ORDER BY 2 DESC LIMIT 40
+    `),
+    prisma.$queryRaw<NamedCount[]>(Prisma.sql`
+      SELECT status_code::text AS key, count(*)::int AS count
+      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours})
+      GROUP BY 1 ORDER BY 2 DESC
+    `),
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        name: string;
+        key_prefix: string;
+        is_active: boolean;
+        rate_limit: number | null;
+        last_used_at: Date | null;
+        username: string | null;
+        email: string | null;
+        tier: string;
+        total: number;
+        errors: number;
+        p50: number | null;
+        used_hour: number;
+      }>
+    >(Prisma.sql`
+      SELECT k.id, k.name, k.key_prefix, k.is_active, k.rate_limit, k.last_used_at, u.username, u.email, u.tier::text AS tier,
+             (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}))::int AS total,
+             (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}) AND r.status_code >= 400)::int AS errors,
+             (SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY r.latency_ms) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}))::float8 AS p50,
+             (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - interval '1 hour')::int AS used_hour
+      FROM tpmjs_api_keys k JOIN users u ON u.id = k.user_id
+      ORDER BY total DESC, k.last_used_at DESC NULLS LAST
+    `),
+    prisma.$queryRaw<Array<{ at: Date; value: number; secondary: number }>>(Prisma.sql`
+      SELECT date_trunc('hour', created_at) AS at, count(*)::int AS value,
+             count(*) FILTER (WHERE status_code >= 400)::int AS secondary
+      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours})
+      GROUP BY 1 ORDER BY 1
+    `),
+    prisma.$queryRaw<
+      Array<{
+        created_at: Date;
+        endpoint: string;
+        method: string;
+        status_code: number;
+        key_name: string | null;
+        error_code: string | null;
+        error_message: string | null;
+      }>
+    >(Prisma.sql`
+      SELECT r.created_at, r.endpoint, r.method, r.status_code, k.name AS key_name, r.error_code, left(r.error_message, 200) AS error_message
+      FROM api_usage_records r LEFT JOIN tpmjs_api_keys k ON k.id = r.api_key_id
+      WHERE r.status_code >= 400 AND r.created_at > now() - make_interval(hours => ${hours})
+      ORDER BY r.created_at DESC LIMIT 40
+    `),
+  ]);
+
+  const keys: ApiKeyUsage[] = keyRows.map((k) => {
+    const tier = k.tier as keyof typeof RATE_LIMITS_BY_TIER;
+    return {
+      keyId: k.id,
+      name: k.name,
+      keyPrefix: k.key_prefix,
+      isActive: k.is_active,
+      username: k.username,
+      email: k.email,
+      tier: k.tier,
+      limitPerHour: k.rate_limit ?? RATE_LIMITS_BY_TIER[tier] ?? RATE_LIMITS_BY_TIER.FREE,
+      usedThisHour: k.used_hour,
+      total: k.total,
+      errors: k.errors,
+      p50Ms: k.p50,
+      lastUsedAt: iso(k.last_used_at),
+    };
+  });
+
+  return {
+    hours,
+    totals,
+    byEndpoint,
+    byStatusCode,
+    keys,
+    hourly: fillHourly(hourlyRows, Math.min(hours, 24 * 7)),
+    recentErrors: errorRows.map((r) => ({
+      at: isoNow(r.created_at),
+      endpoint: r.endpoint,
+      method: r.method,
+      statusCode: r.status_code,
+      keyName: r.key_name,
+      errorCode: r.error_code,
+      errorMessage: r.error_message,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------- health
+
+export async function getHealthOverview(): Promise<HealthOverview> {
+  const [
+    distribution,
+    checks24h,
+    checksHourlyRows,
+    brokenRows,
+    topImportErrors,
+    syncRuns,
+    recentSync,
+    endpointRows,
+    executor,
+  ] = await Promise.all([
+    prisma.$queryRaw<HealthDistributionRow[]>(Prisma.sql`
+        SELECT coalesce(import_health::text, 'NONE') AS "importHealth",
+               coalesce(execution_health::text, 'NONE') AS "executionHealth",
+               count(*)::int AS count
+        FROM tools WHERE is_active GROUP BY 1, 2 ORDER BY 3 DESC
+      `),
+    prisma.$queryRaw<
+      Array<{ overall: string; importStatus: string; executionStatus: string; count: number }>
+    >(Prisma.sql`
+        SELECT overall_status::text AS overall, import_status::text AS "importStatus", execution_status::text AS "executionStatus", count(*)::int AS count
+        FROM health_checks WHERE created_at > now() - interval '24 hours'
+        GROUP BY 1, 2, 3 ORDER BY 4 DESC
+      `),
+    prisma.$queryRaw<Array<{ at: Date; value: number; secondary: number }>>(Prisma.sql`
+        SELECT date_trunc('hour', created_at) AS at, count(*)::int AS value,
+               count(*) FILTER (WHERE overall_status <> 'HEALTHY')::int AS secondary
+        FROM health_checks WHERE created_at > now() - interval '24 hours' GROUP BY 1 ORDER BY 1
+      `),
+    prisma.$queryRaw<
+      Array<{
+        tool_id: string;
+        tool_name: string;
+        package_name: string;
+        npm_version: string;
+        import_health: string | null;
+        execution_health: string | null;
+        consecutive: number;
+        last_health_check: Date | null;
+        next_at: Date | null;
+        error: string | null;
+      }>
+    >(Prisma.sql`
+        SELECT t.id AS tool_id, t.name AS tool_name, p.npm_package_name AS package_name, p.npm_version,
+               t.import_health::text AS import_health, t.execution_health::text AS execution_health,
+               t.consecutive_import_failures AS consecutive, t.last_health_check, t.health_check_next_at AS next_at,
+               left(t.health_check_error, 240) AS error
+        FROM tools t JOIN packages p ON p.id = t.package_id
+        WHERE t.is_active AND (t.import_health = 'BROKEN' OR t.execution_health = 'BROKEN' OR t.consecutive_import_failures > 0)
+        ORDER BY t.consecutive_import_failures DESC, t.last_health_check DESC NULLS LAST
+        LIMIT 100
+      `),
+    prisma.$queryRaw<Array<{ key: string; count: number; tools: number }>>(Prisma.sql`
+        SELECT left(regexp_replace(coalesce(h.import_error, h.execution_error), '[0-9a-f]{12,}|/tmp/[^ ]*|https?://[^ ]*', '…', 'g'), 160) AS key,
+               count(*)::int AS count, count(DISTINCT h.tool_id)::int AS tools
+        FROM health_checks h
+        WHERE h.created_at > now() - interval '24 hours' AND h.overall_status <> 'HEALTHY'
+          AND coalesce(h.import_error, h.execution_error) IS NOT NULL
+        GROUP BY 1 ORDER BY 2 DESC LIMIT 15
+      `),
+    latestSyncRuns(),
+    prisma.$queryRaw<
+      Array<{
+        source: string;
+        status: string;
+        processed: number;
+        skipped: number;
+        errors: number;
+        message: string | null;
+        created_at: Date;
+      }>
+    >(Prisma.sql`
+        SELECT source, status, processed, skipped, errors, left(message, 300) AS message, created_at
+        FROM sync_logs ORDER BY created_at DESC LIMIT 40
+      `),
+    prisma.$queryRaw<
+      Array<{
+        timestamp: Date;
+        source: string;
+        pass_count: number;
+        fail_count: number;
+        total_checks: number;
+        overall_status: string;
+      }>
+    >(Prisma.sql`
+        SELECT timestamp, source, pass_count, fail_count, total_checks, overall_status
+        FROM endpoint_health_reports ORDER BY timestamp DESC LIMIT 12
+      `),
+    executorHealth(),
+  ]);
+
+  const brokenTools: BrokenTool[] = brokenRows.map((r) => ({
+    toolId: r.tool_id,
+    toolName: r.tool_name,
+    packageName: r.package_name,
+    npmVersion: r.npm_version,
+    importHealth: r.import_health,
+    executionHealth: r.execution_health,
+    consecutiveImportFailures: r.consecutive,
+    lastHealthCheck: iso(r.last_health_check),
+    nextCheckAt: iso(r.next_at),
+    error: r.error,
+  }));
+
+  return {
+    distribution,
+    checks24h,
+    checksHourly: fillHourly(checksHourlyRows, 24),
+    brokenTools,
+    topImportErrors,
+    syncRuns,
+    recentSyncLogs: recentSync.map((r) => ({
+      source: r.source,
+      status: r.status,
+      processed: r.processed,
+      skipped: r.skipped,
+      errors: r.errors,
+      message: r.message,
+      createdAt: isoNow(r.created_at),
+    })),
+    endpointReports: endpointRows.map((r) => ({
+      at: isoNow(r.timestamp),
+      source: r.source,
+      passCount: r.pass_count,
+      failCount: r.fail_count,
+      totalChecks: r.total_checks,
+      overallStatus: r.overall_status,
+    })),
+    executor,
+  };
+}
+
+// ---------------------------------------------------------------- collections
+
+export async function getCollectionsAdmin(): Promise<CollectionsAdmin> {
+  const [collectionRows, serverRows] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        name: string;
+        slug: string | null;
+        is_public: boolean;
+        username: string | null;
+        email: string;
+        executor_type: string | null;
+        env_names: string[];
+        registry_tools: number;
+        custom_tools: number;
+        bridge_tools: number;
+        execution_count: number;
+        view_count: number;
+        like_count: number;
+        fork_count: number;
+        created_at: Date;
+        updated_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT c.id, c.name, c.slug, c.is_public, u.username, u.email, c.executor_type,
+             CASE WHEN jsonb_typeof(c.env_vars) = 'object'
+                  THEN (SELECT coalesce(array_agg(k ORDER BY k), '{}') FROM jsonb_object_keys(c.env_vars) AS k)
+                  ELSE '{}'::text[] END AS env_names,
+             (SELECT count(*) FROM collection_tools ct WHERE ct.collection_id = c.id)::int AS registry_tools,
+             (SELECT count(*) FROM collection_custom_tools cct WHERE cct.collection_id = c.id)::int AS custom_tools,
+             (SELECT count(*) FROM collection_bridge_tools cbt WHERE cbt.collection_id = c.id)::int AS bridge_tools,
+             c.execution_count, c.view_count, c.like_count, c.fork_count, c.created_at, c.updated_at
+      FROM collections c JOIN users u ON u.id = c.user_id
+      ORDER BY c.updated_at DESC
+    `),
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        name: string;
+        url: string;
+        status: string;
+        tool_count: number;
+        username: string | null;
+        email: string;
+        last_sync_at: Date | null;
+        last_sync_error: string | null;
+        collections_using: number;
+      }>
+    >(Prisma.sql`
+      SELECT s.id, s.name, s.url, s.status,
+             CASE WHEN jsonb_typeof(s.tools) = 'array' THEN jsonb_array_length(s.tools) ELSE 0 END AS tool_count,
+             u.username, u.email, s.last_sync_at, left(s.last_sync_error, 200) AS last_sync_error,
+             (SELECT count(DISTINCT cct.collection_id) FROM collection_custom_tools cct WHERE cct.server_id = s.id)::int AS collections_using
+      FROM custom_mcp_servers s JOIN users u ON u.id = s.user_id
+      ORDER BY s.created_at DESC
+    `),
+  ]);
+
+  const collections: AdminCollection[] = collectionRows.map((c) => ({
+    id: c.id,
+    name: c.name,
+    slug: c.slug,
+    isPublic: c.is_public,
+    owner: { username: c.username, email: c.email },
+    executorType: c.executor_type,
+    envVarNames: c.env_names,
+    registryTools: c.registry_tools,
+    customTools: c.custom_tools,
+    bridgeTools: c.bridge_tools,
+    executionCount: c.execution_count,
+    viewCount: c.view_count,
+    likeCount: c.like_count,
+    forkCount: c.fork_count,
+    createdAt: isoNow(c.created_at),
+    updatedAt: isoNow(c.updated_at),
+  }));
+
+  const customServers: AdminCustomServer[] = serverRows.map((s) => {
+    let host = s.url;
+    try {
+      host = new URL(s.url).host;
+    } catch {
+      /* keep raw */
+    }
+    return {
+      id: s.id,
+      name: s.name,
+      host,
+      status: s.status,
+      toolCount: s.tool_count,
+      owner: { username: s.username, email: s.email },
+      lastSyncAt: iso(s.last_sync_at),
+      lastSyncError: s.last_sync_error,
+      collectionsUsing: s.collections_using,
+    };
+  });
+
+  return { collections, customServers };
+}
+
+// ---------------------------------------------------------------- agents
+
+export async function getAgentsAdmin(): Promise<AgentsAdmin> {
+  const [agentRows, conversationRows, totals] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        uid: string;
+        name: string;
+        username: string | null;
+        email: string;
+        provider: string;
+        model_id: string;
+        is_public: boolean;
+        sandbox_enabled: boolean;
+        dynamic_tool_discovery: boolean;
+        conversation_count: number;
+        message_count: number;
+        execution_count: number;
+        tools: number;
+        created_at: Date;
+        last_conversation_at: Date | null;
+      }>
+    >(Prisma.sql`
+      SELECT a.id, a.uid, a.name, u.username, u.email, a.provider::text AS provider, a.model_id, a.is_public, a.sandbox_enabled,
+             a.dynamic_tool_discovery, a.conversation_count, a.message_count, a.execution_count,
+             (SELECT count(*) FROM agent_tools at WHERE at.agent_id = a.id)::int AS tools,
+             a.created_at,
+             (SELECT max(c.created_at) FROM conversations c WHERE c.agent_id = a.id) AS last_conversation_at
+      FROM agents a JOIN users u ON u.id = a.user_id
+      ORDER BY last_conversation_at DESC NULLS LAST, a.created_at DESC
+    `),
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        agent_name: string;
+        agent_uid: string;
+        owner: string | null;
+        status: string;
+        messages: number;
+        tool_calls: number;
+        created_at: Date;
+        updated_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT c.id, a.name AS agent_name, a.uid AS agent_uid, u.username AS owner, c.status,
+             (SELECT count(*) FROM messages m WHERE m.conversation_id = c.id)::int AS messages,
+             (SELECT count(*) FROM messages m WHERE m.conversation_id = c.id AND m.tool_calls IS NOT NULL)::int AS tool_calls,
+             c.created_at, c.updated_at
+      FROM conversations c JOIN agents a ON a.id = c.agent_id JOIN users u ON u.id = a.user_id
+      ORDER BY c.updated_at DESC LIMIT 40
+    `),
+    prisma.$queryRaw<
+      Array<{ agents: number; conversations: number; messages: number; conversations24h: number }>
+    >(Prisma.sql`
+      SELECT (SELECT count(*) FROM agents)::int AS agents,
+             (SELECT count(*) FROM conversations)::int AS conversations,
+             (SELECT count(*) FROM messages)::int AS messages,
+             (SELECT count(*) FROM conversations WHERE created_at > now() - interval '24 hours')::int AS conversations24h
+    `),
+  ]);
+
+  const agents: AdminAgent[] = agentRows.map((a) => ({
+    id: a.id,
+    uid: a.uid,
+    name: a.name,
+    owner: { username: a.username, email: a.email },
+    provider: a.provider,
+    modelId: a.model_id,
+    isPublic: a.is_public,
+    sandboxEnabled: a.sandbox_enabled,
+    dynamicToolDiscovery: a.dynamic_tool_discovery,
+    conversationCount: a.conversation_count,
+    messageCount: a.message_count,
+    executionCount: a.execution_count,
+    tools: a.tools,
+    createdAt: isoNow(a.created_at),
+    lastConversationAt: iso(a.last_conversation_at),
+  }));
+  const recentConversations: AdminConversation[] = conversationRows.map((c) => ({
+    id: c.id,
+    agentName: c.agent_name,
+    agentUid: c.agent_uid,
+    owner: c.owner,
+    status: c.status,
+    messages: c.messages,
+    toolCalls: c.tool_calls,
+    createdAt: isoNow(c.created_at),
+    updatedAt: isoNow(c.updated_at),
+  }));
+  const t = totals[0];
+  return {
+    agents,
+    recentConversations,
+    totals: {
+      agents: t?.agents ?? 0,
+      conversations: t?.conversations ?? 0,
+      messages: t?.messages ?? 0,
+      conversations24h: t?.conversations24h ?? 0,
+    },
+  };
+}
+
+// ---------------------------------------------------------------- search
+
+export async function getSearchAdmin(hours: number): Promise<SearchAdmin> {
+  const [totals, topQueries, zeroQueries, hourlyRows, recent] = await Promise.all([
+    prisma.$queryRaw<Array<{ total: number; zero: number; p50: number | null }>>(Prisma.sql`
+      SELECT count(*)::int AS total, count(*) FILTER (WHERE result_count = 0)::int AS zero,
+             percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)::float8 AS p50
+      FROM search_logs WHERE created_at > now() - make_interval(hours => ${hours})
+    `),
+    prisma.$queryRaw<NamedCount[]>(Prisma.sql`
+      SELECT lower(query) AS key, count(*)::int AS count FROM search_logs
+      WHERE created_at > now() - make_interval(hours => ${hours}) GROUP BY 1 ORDER BY 2 DESC LIMIT 25
+    `),
+    prisma.$queryRaw<NamedCount[]>(Prisma.sql`
+      SELECT lower(query) AS key, count(*)::int AS count FROM search_logs
+      WHERE created_at > now() - make_interval(hours => ${hours}) AND result_count = 0 GROUP BY 1 ORDER BY 2 DESC LIMIT 25
+    `),
+    prisma.$queryRaw<Array<{ at: Date; value: number; secondary: number }>>(Prisma.sql`
+      SELECT date_trunc('hour', created_at) AS at, count(*)::int AS value, count(*) FILTER (WHERE result_count = 0)::int AS secondary
+      FROM search_logs WHERE created_at > now() - make_interval(hours => ${hours}) GROUP BY 1 ORDER BY 1
+    `),
+    prisma.$queryRaw<
+      Array<{
+        created_at: Date;
+        query: string;
+        result_count: number;
+        latency_ms: number;
+        username: string | null;
+      }>
+    >(Prisma.sql`
+      SELECT s.created_at, s.query, s.result_count, s.latency_ms, u.username
+      FROM search_logs s LEFT JOIN users u ON u.id = s.user_id
+      ORDER BY s.created_at DESC LIMIT 60
+    `),
+  ]);
+  const t = totals[0];
+  return {
+    hours,
+    total: t?.total ?? 0,
+    zeroResult: t?.zero ?? 0,
+    p50Ms: t?.p50 ?? null,
+    topQueries,
+    zeroResultQueries: zeroQueries,
+    hourly: fillHourly(hourlyRows, Math.min(hours, 24 * 7)),
+    recent: recent.map((r) => ({
+      at: isoNow(r.created_at),
+      query: r.query,
+      resultCount: r.result_count,
+      latencyMs: r.latency_ms,
+      username: r.username,
+    })),
+  };
+}

--- a/apps/web/src/lib/admin/metrics.ts
+++ b/apps/web/src/lib/admin/metrics.ts
@@ -90,7 +90,7 @@ async function executionWindow(hours: number, label: string): Promise<WindowStat
            percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_ms)::float8 AS p50,
            percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)::float8 AS p95
     FROM execution_events
-    WHERE created_at > now() - make_interval(hours => ${hours})
+    WHERE created_at > now() - make_interval(hours => ${hours}::int)
   `);
   return {
     window: label,
@@ -113,7 +113,7 @@ async function apiUsageWindow(hours: number, label: string): Promise<WindowStats
            percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)::float8 AS p50,
            percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms)::float8 AS p95
     FROM api_usage_records
-    WHERE created_at > now() - make_interval(hours => ${hours})
+    WHERE created_at > now() - make_interval(hours => ${hours}::int)
   `);
   return {
     window: label,
@@ -134,7 +134,7 @@ async function executionHourly(hours: number): Promise<SeriesPoint[]> {
            count(*)::int AS value,
            count(*) FILTER (WHERE status <> 'success')::int AS secondary
     FROM execution_events
-    WHERE created_at > now() - make_interval(hours => ${hours})
+    WHERE created_at > now() - make_interval(hours => ${hours}::int)
     GROUP BY 1 ORDER BY 1
   `);
   return fillHourly(rows, hours);
@@ -478,7 +478,7 @@ export async function getExecutionStats(options: {
 }): Promise<ExecutionStats> {
   const { hours, status, packageName, source, tool, limit, offset } = options;
   const where = Prisma.sql`
-    e.created_at > now() - make_interval(hours => ${hours})
+    e.created_at > now() - make_interval(hours => ${hours}::int)
     AND (${status}::text IS NULL OR e.status = ${status}::text)
     AND (${packageName}::text IS NULL OR e.package_name = ${packageName}::text)
     AND (${source}::text IS NULL OR e.source = ${source}::text)
@@ -577,13 +577,13 @@ export async function getExecutionStats(options: {
       Prisma.sql`SELECT count(*)::int AS c FROM execution_events e WHERE ${where}`
     ),
     prisma.$queryRaw<Array<{ key: string }>>(Prisma.sql`
-        SELECT DISTINCT package_name AS key FROM execution_events WHERE package_name IS NOT NULL AND created_at > now() - make_interval(hours => ${hours}) ORDER BY 1
+        SELECT DISTINCT package_name AS key FROM execution_events WHERE package_name IS NOT NULL AND created_at > now() - make_interval(hours => ${hours}::int) ORDER BY 1
       `),
     prisma.$queryRaw<Array<{ key: string }>>(Prisma.sql`
-        SELECT DISTINCT source AS key FROM execution_events WHERE created_at > now() - make_interval(hours => ${hours}) ORDER BY 1
+        SELECT DISTINCT source AS key FROM execution_events WHERE created_at > now() - make_interval(hours => ${hours}::int) ORDER BY 1
       `),
     prisma.$queryRaw<Array<{ key: string }>>(Prisma.sql`
-        SELECT DISTINCT status AS key FROM execution_events WHERE created_at > now() - make_interval(hours => ${hours}) ORDER BY 1
+        SELECT DISTINCT status AS key FROM execution_events WHERE created_at > now() - make_interval(hours => ${hours}::int) ORDER BY 1
       `),
   ]);
 
@@ -650,12 +650,12 @@ export async function getApiUsageStats(hours: number): Promise<ApiUsageStats> {
              count(*) FILTER (WHERE status_code >= 400)::int AS errors,
              percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)::float8 AS "p50Ms",
              percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms)::float8 AS "p95Ms"
-      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours})
+      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours}::int)
       GROUP BY 1 ORDER BY 2 DESC LIMIT 40
     `),
     prisma.$queryRaw<NamedCount[]>(Prisma.sql`
       SELECT status_code::text AS key, count(*)::int AS count
-      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours})
+      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours}::int)
       GROUP BY 1 ORDER BY 2 DESC
     `),
     prisma.$queryRaw<
@@ -676,9 +676,9 @@ export async function getApiUsageStats(hours: number): Promise<ApiUsageStats> {
       }>
     >(Prisma.sql`
       SELECT k.id, k.name, k.key_prefix, k.is_active, k.rate_limit, k.last_used_at, u.username, u.email, u.tier::text AS tier,
-             (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}))::int AS total,
-             (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}) AND r.status_code >= 400)::int AS errors,
-             (SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY r.latency_ms) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}))::float8 AS p50,
+             (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}::int))::int AS total,
+             (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}::int) AND r.status_code >= 400)::int AS errors,
+             (SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY r.latency_ms) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - make_interval(hours => ${hours}::int))::float8 AS p50,
              (SELECT count(*) FROM api_usage_records r WHERE r.api_key_id = k.id AND r.created_at > now() - interval '1 hour')::int AS used_hour
       FROM tpmjs_api_keys k JOIN users u ON u.id = k.user_id
       ORDER BY total DESC, k.last_used_at DESC NULLS LAST
@@ -686,7 +686,7 @@ export async function getApiUsageStats(hours: number): Promise<ApiUsageStats> {
     prisma.$queryRaw<Array<{ at: Date; value: number; secondary: number }>>(Prisma.sql`
       SELECT date_trunc('hour', created_at) AS at, count(*)::int AS value,
              count(*) FILTER (WHERE status_code >= 400)::int AS secondary
-      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours})
+      FROM api_usage_records WHERE created_at > now() - make_interval(hours => ${hours}::int)
       GROUP BY 1 ORDER BY 1
     `),
     prisma.$queryRaw<
@@ -702,7 +702,7 @@ export async function getApiUsageStats(hours: number): Promise<ApiUsageStats> {
     >(Prisma.sql`
       SELECT r.created_at, r.endpoint, r.method, r.status_code, k.name AS key_name, r.error_code, left(r.error_message, 200) AS error_message
       FROM api_usage_records r LEFT JOIN tpmjs_api_keys k ON k.id = r.api_key_id
-      WHERE r.status_code >= 400 AND r.created_at > now() - make_interval(hours => ${hours})
+      WHERE r.status_code >= 400 AND r.created_at > now() - make_interval(hours => ${hours}::int)
       ORDER BY r.created_at DESC LIMIT 40
     `),
   ]);
@@ -1091,19 +1091,19 @@ export async function getSearchAdmin(hours: number): Promise<SearchAdmin> {
     prisma.$queryRaw<Array<{ total: number; zero: number; p50: number | null }>>(Prisma.sql`
       SELECT count(*)::int AS total, count(*) FILTER (WHERE result_count = 0)::int AS zero,
              percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)::float8 AS p50
-      FROM search_logs WHERE created_at > now() - make_interval(hours => ${hours})
+      FROM search_logs WHERE created_at > now() - make_interval(hours => ${hours}::int)
     `),
     prisma.$queryRaw<NamedCount[]>(Prisma.sql`
       SELECT lower(query) AS key, count(*)::int AS count FROM search_logs
-      WHERE created_at > now() - make_interval(hours => ${hours}) GROUP BY 1 ORDER BY 2 DESC LIMIT 25
+      WHERE created_at > now() - make_interval(hours => ${hours}::int) GROUP BY 1 ORDER BY 2 DESC LIMIT 25
     `),
     prisma.$queryRaw<NamedCount[]>(Prisma.sql`
       SELECT lower(query) AS key, count(*)::int AS count FROM search_logs
-      WHERE created_at > now() - make_interval(hours => ${hours}) AND result_count = 0 GROUP BY 1 ORDER BY 2 DESC LIMIT 25
+      WHERE created_at > now() - make_interval(hours => ${hours}::int) AND result_count = 0 GROUP BY 1 ORDER BY 2 DESC LIMIT 25
     `),
     prisma.$queryRaw<Array<{ at: Date; value: number; secondary: number }>>(Prisma.sql`
       SELECT date_trunc('hour', created_at) AS at, count(*)::int AS value, count(*) FILTER (WHERE result_count = 0)::int AS secondary
-      FROM search_logs WHERE created_at > now() - make_interval(hours => ${hours}) GROUP BY 1 ORDER BY 1
+      FROM search_logs WHERE created_at > now() - make_interval(hours => ${hours}::int) GROUP BY 1 ORDER BY 1
     `),
     prisma.$queryRaw<
       Array<{

--- a/apps/web/src/lib/admin/types.ts
+++ b/apps/web/src/lib/admin/types.ts
@@ -1,0 +1,332 @@
+/**
+ * Response contracts for the admin monitoring API (`/api/admin/*`).
+ *
+ * Shared by the server-side metric queries and the admin dashboard pages so the
+ * two cannot drift. Every count is a plain number (raw SQL counts are cast from
+ * bigint server-side) and every timestamp is ISO-8601.
+ */
+
+export interface WindowStats {
+  /** Human window label, e.g. "1h", "24h", "7d" */
+  window: string;
+  hours: number;
+  total: number;
+  success: number;
+  error: number;
+  p50Ms: number | null;
+  p95Ms: number | null;
+}
+
+export interface SeriesPoint {
+  /** Bucket start, ISO-8601 */
+  at: string;
+  value: number;
+  secondaryValue?: number;
+}
+
+export interface NamedCount {
+  key: string;
+  count: number;
+}
+
+export interface SyncRunSummary {
+  source: string;
+  status: string;
+  processed: number;
+  skipped: number;
+  errors: number;
+  message: string | null;
+  createdAt: string;
+}
+
+export interface ExecutorHealth {
+  reachable: boolean;
+  url: string | null;
+  implementationVersion: string | null;
+  protocolVersion: string | null;
+  status: string | null;
+  latencyMs: number | null;
+  error: string | null;
+}
+
+export interface HealthDistributionRow {
+  importHealth: string;
+  executionHealth: string;
+  count: number;
+}
+
+export interface AdminOverview {
+  generatedAt: string;
+  executions: WindowStats[];
+  apiUsage: WindowStats[];
+  registry: {
+    toolsActive: number;
+    toolsRetired: number;
+    packages: number;
+    officialPackages: number;
+    toolsHealthy: number;
+    toolsBroken: number;
+    toolsUnknown: number;
+  };
+  users: { total: number; admins: number; new7d: number; activeSessions: number };
+  keys: { total: number; active: number; used24h: number };
+  collections: { total: number; public: number; customServers: number; bridgesConnected: number };
+  agents: { total: number; conversations24h: number; messages24h: number };
+  searches24h: number;
+  healthChecks24h: NamedCount[];
+  syncRuns: SyncRunSummary[];
+  executor: ExecutorHealth;
+  hourly: SeriesPoint[];
+}
+
+export interface ActivityItem {
+  kind:
+    | 'execution'
+    | 'api'
+    | 'search'
+    | 'sync'
+    | 'health'
+    | 'collection'
+    | 'agent'
+    | 'user'
+    | 'key';
+  at: string;
+  actor: string | null;
+  title: string;
+  detail: string | null;
+  status: string | null;
+  ref: string | null;
+}
+
+export interface ActivityFeed {
+  items: ActivityItem[];
+  nextCursor: string | null;
+}
+
+export interface ExecutionRow {
+  id: string;
+  at: string;
+  source: string;
+  eventType: string;
+  status: string;
+  toolName: string | null;
+  packageName: string | null;
+  durationMs: number | null;
+  errorCategory: string | null;
+  errorMessage: string | null;
+  userId: string | null;
+  username: string | null;
+  apiKeyName: string | null;
+  collectionId: string | null;
+  agentId: string | null;
+}
+
+export interface ExecutionStats {
+  hours: number;
+  totals: WindowStats;
+  byStatus: NamedCount[];
+  byCategory: NamedCount[];
+  bySource: NamedCount[];
+  topTools: Array<{
+    key: string;
+    count: number;
+    errors: number;
+    avgMs: number | null;
+    p95Ms: number | null;
+  }>;
+  hourly: SeriesPoint[];
+  rows: ExecutionRow[];
+  total: number;
+  facets: { packages: string[]; sources: string[]; statuses: string[] };
+}
+
+export interface ApiKeyUsage {
+  keyId: string;
+  name: string;
+  keyPrefix: string;
+  isActive: boolean;
+  username: string | null;
+  email: string | null;
+  tier: string;
+  limitPerHour: number;
+  usedThisHour: number;
+  total: number;
+  errors: number;
+  p50Ms: number | null;
+  lastUsedAt: string | null;
+}
+
+export interface ApiUsageStats {
+  hours: number;
+  totals: WindowStats;
+  byEndpoint: Array<{
+    key: string;
+    count: number;
+    errors: number;
+    p50Ms: number | null;
+    p95Ms: number | null;
+  }>;
+  byStatusCode: NamedCount[];
+  keys: ApiKeyUsage[];
+  hourly: SeriesPoint[];
+  recentErrors: Array<{
+    at: string;
+    endpoint: string;
+    method: string;
+    statusCode: number;
+    keyName: string | null;
+    errorCode: string | null;
+    errorMessage: string | null;
+  }>;
+}
+
+export interface BrokenTool {
+  toolId: string;
+  toolName: string;
+  packageName: string;
+  npmVersion: string;
+  importHealth: string | null;
+  executionHealth: string | null;
+  consecutiveImportFailures: number;
+  lastHealthCheck: string | null;
+  nextCheckAt: string | null;
+  error: string | null;
+}
+
+export interface HealthOverview {
+  distribution: HealthDistributionRow[];
+  checks24h: Array<{
+    overall: string;
+    importStatus: string;
+    executionStatus: string;
+    count: number;
+  }>;
+  checksHourly: SeriesPoint[];
+  brokenTools: BrokenTool[];
+  topImportErrors: Array<{ key: string; count: number; tools: number }>;
+  syncRuns: SyncRunSummary[];
+  recentSyncLogs: SyncRunSummary[];
+  endpointReports: Array<{
+    at: string;
+    source: string;
+    passCount: number;
+    failCount: number;
+    totalChecks: number;
+    overallStatus: string;
+  }>;
+  executor: ExecutorHealth;
+}
+
+export interface AdminCollection {
+  id: string;
+  name: string;
+  slug: string | null;
+  isPublic: boolean;
+  owner: { username: string | null; email: string };
+  executorType: string | null;
+  envVarNames: string[];
+  registryTools: number;
+  customTools: number;
+  bridgeTools: number;
+  executionCount: number;
+  viewCount: number;
+  likeCount: number;
+  forkCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AdminCustomServer {
+  id: string;
+  name: string;
+  host: string;
+  status: string;
+  toolCount: number;
+  owner: { username: string | null; email: string };
+  lastSyncAt: string | null;
+  lastSyncError: string | null;
+  collectionsUsing: number;
+}
+
+export interface CollectionsAdmin {
+  collections: AdminCollection[];
+  customServers: AdminCustomServer[];
+}
+
+export interface AdminAgent {
+  id: string;
+  uid: string;
+  name: string;
+  owner: { username: string | null; email: string };
+  provider: string;
+  modelId: string;
+  isPublic: boolean;
+  sandboxEnabled: boolean;
+  dynamicToolDiscovery: boolean;
+  conversationCount: number;
+  messageCount: number;
+  executionCount: number;
+  tools: number;
+  createdAt: string;
+  lastConversationAt: string | null;
+}
+
+export interface AdminConversation {
+  id: string;
+  agentName: string;
+  agentUid: string;
+  owner: string | null;
+  status: string;
+  messages: number;
+  toolCalls: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AgentsAdmin {
+  agents: AdminAgent[];
+  recentConversations: AdminConversation[];
+  totals: { agents: number; conversations: number; messages: number; conversations24h: number };
+}
+
+export interface AdminSearchLog {
+  at: string;
+  query: string;
+  resultCount: number;
+  latencyMs: number;
+  username: string | null;
+}
+
+export interface SearchAdmin {
+  hours: number;
+  total: number;
+  zeroResult: number;
+  p50Ms: number | null;
+  topQueries: NamedCount[];
+  zeroResultQueries: NamedCount[];
+  hourly: SeriesPoint[];
+  recent: AdminSearchLog[];
+}
+
+export interface AdminUserRow {
+  id: string;
+  name: string;
+  email: string;
+  username: string | null;
+  image: string | null;
+  tier: string;
+  role: string;
+  signupSource: string | null;
+  emailVerified: boolean;
+  createdAt: string;
+  _count: {
+    collections: number;
+    agents: number;
+    activities: number;
+    toolLikes: number;
+    apiKeys: number;
+    tpmjsApiKeys: number;
+  };
+}
+
+export type ApiEnvelope<T> = { success: true; data: T } | { success: false; error: string };

--- a/apps/web/src/lib/health-check/health-check-service.ts
+++ b/apps/web/src/lib/health-check/health-check-service.ts
@@ -21,7 +21,11 @@ import {
   renderHealthCheckParams,
   resolveCleanupParams,
 } from '~/lib/health-check/health-check-config';
-import { nextHealthCheckAt, releaseHealthLease } from '~/lib/maintenance/bounded-work';
+import {
+  nextHealthCheckAt,
+  recentInconclusiveStreak,
+  releaseHealthLease,
+} from '~/lib/maintenance/bounded-work';
 import { importFailureStreakUpdate } from '~/lib/tool-health-policy';
 
 const RAILWAY_EXECUTOR_URL = env.RAILWAY_EXECUTOR_URL;
@@ -358,7 +362,9 @@ export async function performHealthCheck(
   const nextExecution =
     executionResult.status === 'UNKNOWN' ? tool.executionHealth : executionResult.status;
   const checkedAt = new Date();
-  const nextAt = nextHealthCheckAt(tool.id, overallStatus, checkedAt);
+  const inconclusiveStreak =
+    overallStatus === 'UNKNOWN' ? await recentInconclusiveStreak(tool.id) : 0;
+  const nextAt = nextHealthCheckAt(tool.id, overallStatus, checkedAt, inconclusiveStreak);
 
   // The audit row, current status, schedule, and lease release are one commit.
   // A worker whose lease expired and was reassigned cannot publish a stale

--- a/apps/web/src/lib/maintenance/bounded-work.ts
+++ b/apps/web/src/lib/maintenance/bounded-work.ts
@@ -36,14 +36,40 @@ function stableJitter(key: string, windowMs: number): number {
  * every tool every day. Newly published and on-demand tools can be enqueued
  * immediately; the background lane revisits definitive results without waves.
  */
-export function nextHealthCheckAt(toolId: string, status: HealthStatus, now = new Date()): Date {
+export function nextHealthCheckAt(
+  toolId: string,
+  status: HealthStatus,
+  now = new Date(),
+  inconclusiveStreak = 0
+): Date {
+  // An UNKNOWN verdict is retried soon, but a tool that keeps coming back inconclusive
+  // (e.g. an unpublished package whose import can never resolve) backs off
+  // exponentially — 15m, 30m, 1h, 2h, 4h, 8h, then 12h — instead of burning an
+  // executor import every quarter hour forever.
+  const inconclusiveBase = Math.min(
+    15 * MINUTE_MS * 2 ** Math.min(inconclusiveStreak, 6),
+    12 * HOUR_MS
+  );
   const [base, jitterWindow] =
     status === 'HEALTHY'
       ? [7 * DAY_MS, 12 * HOUR_MS]
       : status === 'BROKEN'
         ? [DAY_MS, 6 * HOUR_MS]
-        : [15 * MINUTE_MS, 15 * MINUTE_MS];
+        : [inconclusiveBase, 15 * MINUTE_MS];
   return new Date(now.getTime() + base + stableJitter(toolId, jitterWindow));
+}
+
+/** Consecutive inconclusive (UNKNOWN) outcomes for a tool within the last two days. */
+export async function recentInconclusiveStreak(toolId: string): Promise<number> {
+  const rows = await prisma.$queryRaw<Array<{ streak: number }>>(Prisma.sql`
+    SELECT count(*)::int AS streak FROM (
+      SELECT overall_status FROM health_checks
+      WHERE tool_id = ${toolId} AND created_at > now() - interval '2 days'
+      ORDER BY created_at DESC LIMIT 64
+    ) recent
+    WHERE overall_status = 'UNKNOWN'
+  `);
+  return rows[0]?.streak ?? 0;
 }
 
 export function retryHealthCheckAt(toolId: string, now = new Date()): Date {


### PR DESCRIPTION
## Summary
- **Full admin monitoring dashboard** under `/dashboard/admin` (ADMIN role): Overview (live 1h/24h/7d windows, error rates, p50/p95, executor health, job runs, hourly chart, daily snapshots), **Live activity** feed (executions, API calls, searches, jobs, health verdicts, new collections/agents/users/keys), **Executions** (filters, breakdowns, top tools, paged rows), **API usage** (per-key rolling-hour rate-limit consumption, endpoints, status codes, recent errors), **Health & jobs** (tool health, check outcomes, failure reasons, broken tools, sync/cron runs, endpoint reports), **Collections** (+ custom MCP servers; env var names only), **Agents** (+ recent conversations), **Search** analytics.
- **Role management**: `PATCH /api/admin/users/[id]` + controls on the Users page to promote/demote ADMIN and change tier (self-demotion and demoting the last admin are refused).
- **Health-check backoff**: inconclusive (UNKNOWN) verdicts back off exponentially (15m → 12h cap) on the tool's recent inconclusive streak; previously ~87% of daily checks re-imported the same handful of unpublished packages every 15 minutes.

## Implementation notes
- Shared response contracts in `lib/admin/types.ts`; bounded raw SQL in `lib/admin/metrics.ts` with `::int`/`::float8` casts (no BigInt), union feeds limit each branch before sorting, secrets are never selected.
- Pages use `@tpmjs/ui` (Table, Select, Tabs, Badge, Button, Input, ErrorState, Spinner) and the existing `AreaChart`; shared `components/admin/{AdminUi,useAdminResource}` (visibility-aware auto-refresh).

## Test plan
- [x] biome, type-check, vitest (278 passed), type-coverage 98.77%, knip, `next build` (all admin routes emitted)
- [x] Every metrics function smoke-run against the production database
- [ ] After merge: `scripts/deploy-on-box.sh web`, then verify `/dashboard/admin/*` as the admin user

🤖 Generated with [Claude Code](https://claude.com/claude-code)