### PR TITLE
feat(tools): five provider-agnostic weapon packages (mail, discord-chat, x, image-gen, web-research)

### DIFF
--- a/packages/tools/official/discord-chat/CHANGELOG.md
+++ b/packages/tools/official/discord-chat/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-discord-chat
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/tools/official/discord-chat/README.md
+++ b/packages/tools/official/discord-chat/README.md
@@ -1,0 +1,45 @@
+# @tpmjs/tools-discord-chat
+
+Read and post in Discord the way a person does: channels by name, catch up on what happened since a time, post or reply, react — bot token or plain webhook.
+
+Part of the **ajax weapons** set: task-level, provider-agnostic tools that an agent can pick up without learning a vendor API. Credentials come from the environment; on tpmjs add them as collection env vars (the collection owner's calls get them injected, everyone else supplies their own).
+
+## Installation
+
+```bash
+npm install @tpmjs/tools-discord-chat
+```
+
+## Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `DISCORD_BOT_TOKEN` | no | Discord bot token (required for reading; posting can fall back to DISCORD_WEBHOOK_URL) |
+| `DISCORD_GUILD_ID` | no | Default server (guild) id used to resolve channel names |
+| `DISCORD_WEBHOOK_URL` | no | Webhook URL used by discordPost when no bot token / channel is given |
+
+## Tools
+
+| Export | What it does |
+| --- | --- |
+| `discordChannels` | List the text channels the bot can see (id, name, topic, server), optionally filtered by name. |
+| `discordRead` | Read recent messages from a channel by name or id, newest last, with authors, attachments and reply links. |
+| `discordCatchUp` | Catch up on everything posted since a point in time (e.g. "24h") across one, several or all text channels. |
+| `discordPost` | Post a message to a channel by name or id (optionally as a reply), or to DISCORD_WEBHOOK_URL when no channel is given. |
+| `discordReact` | Add an emoji reaction to a message in a channel. |
+
+## Usage
+
+```typescript
+import { discordCatchUp, discordPost } from '@tpmjs/tools-discord-chat';
+
+const ctx = { toolCallId: 'c1', messages: [] };
+const recap = await discordCatchUp.execute({ since: '24h' }, ctx);
+await discordPost.execute({ channel: 'general', content: 'Morning! Shipping the admin console today.' }, ctx);
+```
+
+Every tool throws a readable error on provider failures (status code + provider message), so agents can react instead of guessing.
+
+## License
+
+MIT

--- a/packages/tools/official/discord-chat/package.json
+++ b/packages/tools/official/discord-chat/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "@tpmjs/tools-discord-chat",
+  "version": "0.1.0",
+  "description": "Read and post in Discord the way a person does: channels by name, catch up on what happened since a time, post or reply, react \u2014 bot token or plain webhook",
+  "type": "module",
+  "keywords": [
+    "tpmjs",
+    "communication",
+    "discord",
+    "chat",
+    "messages",
+    "webhook"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --sourcemap --logLevel warn",
+    "dev": "tsdown --sourcemap --watch",
+    "type-check": "tsc --checkers 1 --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@tpmjs/tsconfig": "workspace:*",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "ai": "6.0.49"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tpmjs/tpmjs.git",
+    "directory": "packages/tools/official/discord-chat"
+  },
+  "homepage": "https://tpmjs.com",
+  "license": "MIT",
+  "tpmjs": {
+    "category": "communication",
+    "frameworks": [
+      "vercel-ai"
+    ],
+    "env": [
+      {
+        "name": "DISCORD_BOT_TOKEN",
+        "description": "Discord bot token (required for reading; posting can fall back to DISCORD_WEBHOOK_URL)",
+        "required": false
+      },
+      {
+        "name": "DISCORD_GUILD_ID",
+        "description": "Default server (guild) id used to resolve channel names",
+        "required": false
+      },
+      {
+        "name": "DISCORD_WEBHOOK_URL",
+        "description": "Webhook URL used by discordPost when no bot token / channel is given",
+        "required": false
+      }
+    ],
+    "tools": [
+      {
+        "name": "discordChannels",
+        "description": "List the text channels the bot can see (id, name, topic, server), optionally filtered by name."
+      },
+      {
+        "name": "discordRead",
+        "description": "Read recent messages from a channel by name or id, newest last, with authors, attachments and reply links."
+      },
+      {
+        "name": "discordCatchUp",
+        "description": "Catch up on everything posted since a point in time (e.g. \"24h\") across one, several or all text channels."
+      },
+      {
+        "name": "discordPost",
+        "description": "Post a message to a channel by name or id (optionally as a reply), or to DISCORD_WEBHOOK_URL when no channel is given."
+      },
+      {
+        "name": "discordReact",
+        "description": "Add an emoji reaction to a message in a channel."
+      }
+    ]
+  }
+}

--- a/packages/tools/official/discord-chat/src/index.ts
+++ b/packages/tools/official/discord-chat/src/index.ts
@@ -1,0 +1,415 @@
+/**
+ * @tpmjs/tools-discord-chat — Discord the way a person uses it.
+ *
+ * Channels are addressed by NAME (or id), reads come back as clean normalised messages,
+ * "catch up" summarises everything since a point in time across channels, and posting
+ * works with a bot token or falls back to a plain webhook URL.
+ *
+ * @env DISCORD_BOT_TOKEN  bot token (reading, reacting, posting as the bot)
+ * @env DISCORD_GUILD_ID   default server used to resolve channel names (optional)
+ * @env DISCORD_WEBHOOK_URL webhook used by discordPost when no channel is given (optional)
+ */
+
+import { jsonSchema, tool } from 'ai';
+
+const API = 'https://discord.com/api/v10';
+const DISCORD_EPOCH = 1_420_070_400_000n;
+
+function envValue(name: string): string | undefined {
+  const value = globalThis.process?.env?.[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function botToken(): string {
+  const token = envValue('DISCORD_BOT_TOKEN');
+  if (!token) {
+    throw new Error(
+      'DISCORD_BOT_TOKEN is required for this operation (create one at https://discord.com/developers/applications).'
+    );
+  }
+  return token;
+}
+
+async function api<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: { Authorization: `Bot ${botToken()}`, 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (res.status === 429) {
+    const retry = Number(res.headers.get('retry-after') ?? '1');
+    await new Promise((r) => setTimeout(r, Math.min(retry, 5) * 1000));
+    return api<T>(method, path, body);
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `Discord ${method} ${path} failed: ${res.status}${text ? ` — ${text.slice(0, 300)}` : ''}`
+    );
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+// ─── channel resolution ──────────────────────────────────────────────────────
+
+interface RawGuild {
+  id: string;
+  name: string;
+}
+interface RawChannel {
+  id: string;
+  name: string;
+  type: number;
+  topic?: string | null;
+  guild_id?: string;
+  parent_id?: string | null;
+  last_message_id?: string | null;
+}
+
+export interface ChannelInfo {
+  id: string;
+  name: string;
+  topic: string | null;
+  guildId: string;
+  guild: string;
+  kind: 'text' | 'announcement' | 'forum' | 'voice' | 'thread' | 'other';
+}
+
+const TEXT_TYPES = new Set([0, 5, 15, 10, 11, 12]);
+function kindOf(type: number): ChannelInfo['kind'] {
+  if (type === 0) return 'text';
+  if (type === 5) return 'announcement';
+  if (type === 15) return 'forum';
+  if (type === 2 || type === 13) return 'voice';
+  if (type === 10 || type === 11 || type === 12) return 'thread';
+  return 'other';
+}
+
+async function listGuilds(): Promise<RawGuild[]> {
+  const forced = envValue('DISCORD_GUILD_ID');
+  if (forced) {
+    const guild = await api<RawGuild>('GET', `/guilds/${forced}`);
+    return [guild];
+  }
+  return api<RawGuild[]>('GET', '/users/@me/guilds');
+}
+
+let channelCache: { at: number; channels: ChannelInfo[] } | null = null;
+
+async function allChannels(): Promise<ChannelInfo[]> {
+  if (channelCache && Date.now() - channelCache.at < 60_000) return channelCache.channels;
+  const guilds = await listGuilds();
+  const out: ChannelInfo[] = [];
+  for (const guild of guilds) {
+    const channels = await api<RawChannel[]>('GET', `/guilds/${guild.id}/channels`);
+    for (const c of channels) {
+      if (!TEXT_TYPES.has(c.type) && c.type !== 2 && c.type !== 13) continue;
+      out.push({
+        id: c.id,
+        name: c.name,
+        topic: c.topic ?? null,
+        guildId: guild.id,
+        guild: guild.name,
+        kind: kindOf(c.type),
+      });
+    }
+  }
+  channelCache = { at: Date.now(), channels: out };
+  return out;
+}
+
+async function resolveChannel(ref: string): Promise<ChannelInfo> {
+  if (/^\d{15,22}$/.test(ref)) {
+    const c = await api<RawChannel>('GET', `/channels/${ref}`);
+    return {
+      id: c.id,
+      name: c.name,
+      topic: c.topic ?? null,
+      guildId: c.guild_id ?? '',
+      guild: '',
+      kind: kindOf(c.type),
+    };
+  }
+  const wanted = ref.replace(/^#/, '').toLowerCase();
+  const channels = await allChannels();
+  const exact = channels.filter((c) => c.name.toLowerCase() === wanted);
+  const hit = exact[0] ?? channels.find((c) => c.name.toLowerCase().includes(wanted));
+  if (!hit) {
+    throw new Error(
+      `No channel named "${ref}". Known: ${channels
+        .slice(0, 40)
+        .map((c) => `#${c.name}`)
+        .join(', ')}`
+    );
+  }
+  return hit;
+}
+
+// ─── messages ────────────────────────────────────────────────────────────────
+
+interface RawMessage {
+  id: string;
+  content: string;
+  timestamp: string;
+  author: { id: string; username: string; global_name?: string | null; bot?: boolean };
+  attachments?: Array<{ url: string; filename: string; content_type?: string }>;
+  embeds?: Array<{ title?: string; url?: string; description?: string }>;
+  referenced_message?: { id: string; author?: { username: string } } | null;
+  reactions?: Array<{ emoji: { name: string }; count: number }>;
+  thread?: { id: string; name: string } | null;
+}
+
+export interface Message {
+  id: string;
+  at: string;
+  author: string;
+  bot: boolean;
+  content: string;
+  attachments: string[];
+  embeds: Array<{ title?: string; url?: string; description?: string }>;
+  replyTo: string | null;
+  reactions: Array<{ emoji: string; count: number }>;
+}
+
+function normalise(m: RawMessage): Message {
+  return {
+    id: m.id,
+    at: m.timestamp,
+    author: m.author.global_name || m.author.username,
+    bot: Boolean(m.author.bot),
+    content: m.content,
+    attachments: (m.attachments ?? []).map((a) => a.url),
+    embeds: (m.embeds ?? [])
+      .map((e) => ({ title: e.title, url: e.url, description: e.description }))
+      .filter((e) => e.title || e.url || e.description),
+    replyTo: m.referenced_message?.id ?? null,
+    reactions: (m.reactions ?? []).map((r) => ({ emoji: r.emoji.name, count: r.count })),
+  };
+}
+
+/** "24h", "7d", "90m", or an ISO date → Date */
+function parseSince(value: string): Date {
+  const rel = /^(\d+)\s*([mhd])$/i.exec(value.trim());
+  if (rel) {
+    const n = Number(rel[1]);
+    const unit = (rel[2] as string).toLowerCase();
+    const ms = unit === 'm' ? 60_000 : unit === 'h' ? 3_600_000 : 86_400_000;
+    return new Date(Date.now() - n * ms);
+  }
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime()))
+    throw new Error(`Unrecognised time "${value}" — use "24h", "7d", "90m" or an ISO date.`);
+  return d;
+}
+
+const snowflakeFor = (date: Date): string =>
+  ((BigInt(date.getTime()) - DISCORD_EPOCH) << 22n).toString();
+
+async function readSince(channelId: string, since: Date | null, limit: number): Promise<Message[]> {
+  const out: RawMessage[] = [];
+  let after = since ? snowflakeFor(since) : undefined;
+  let before: string | undefined;
+  while (out.length < limit) {
+    const page = Math.min(100, limit - out.length);
+    const query = after
+      ? `after=${after}&limit=${page}`
+      : `limit=${page}${before ? `&before=${before}` : ''}`;
+    const batch = await api<RawMessage[]>('GET', `/channels/${channelId}/messages?${query}`);
+    if (batch.length === 0) break;
+    out.push(...batch);
+    if (batch.length < page) break;
+    if (after)
+      after = batch.reduce(
+        (max, m) => (BigInt(m.id) > BigInt(max) ? m.id : max),
+        batch[0]?.id ?? after
+      );
+    else before = batch[batch.length - 1]?.id;
+  }
+  const sorted = out.sort((a, b) => (BigInt(a.id) < BigInt(b.id) ? -1 : 1));
+  return sorted.slice(-limit).map(normalise);
+}
+
+// ─── tools ───────────────────────────────────────────────────────────────────
+
+export const discordChannels = tool({
+  description:
+    'List the text channels the bot can see (id, name, topic, server), optionally filtered by name.',
+  inputSchema: jsonSchema<{ filter?: string }>({
+    type: 'object',
+    properties: {
+      filter: { type: 'string', description: 'Substring to match channel names against' },
+    },
+    additionalProperties: false,
+  }),
+  async execute({ filter }): Promise<{ channels: ChannelInfo[] }> {
+    const channels = await allChannels();
+    const q = filter?.replace(/^#/, '').toLowerCase();
+    return { channels: q ? channels.filter((c) => c.name.toLowerCase().includes(q)) : channels };
+  },
+});
+
+export const discordRead = tool({
+  description:
+    'Read recent messages from a channel by name or id, newest last, with authors, attachments and reply links.',
+  inputSchema: jsonSchema<{ channel: string; limit?: number; since?: string }>({
+    type: 'object',
+    properties: {
+      channel: {
+        type: 'string',
+        description: 'Channel name (e.g. "general" or "#general") or channel id',
+      },
+      limit: { type: 'integer', description: 'Max messages (default 25, max 200)', default: 25 },
+      since: {
+        type: 'string',
+        description: 'Only messages after this point: "24h", "7d", "90m" or an ISO date',
+      },
+    },
+    required: ['channel'],
+    additionalProperties: false,
+  }),
+  async execute({
+    channel,
+    limit = 25,
+    since,
+  }): Promise<{ channel: ChannelInfo; messages: Message[] }> {
+    const info = await resolveChannel(channel);
+    const messages = await readSince(
+      info.id,
+      since ? parseSince(since) : null,
+      Math.min(Math.max(1, limit), 200)
+    );
+    return { channel: info, messages };
+  },
+});
+
+export const discordCatchUp = tool({
+  description:
+    'Catch up on everything posted since a point in time (e.g. "24h") across one, several or all text channels; returns messages grouped per channel, quiet channels omitted.',
+  inputSchema: jsonSchema<{ since?: string; channels?: string[]; perChannelLimit?: number }>({
+    type: 'object',
+    properties: {
+      since: {
+        type: 'string',
+        description: '"24h", "7d", "90m" or ISO date (default 24h)',
+        default: '24h',
+      },
+      channels: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Channel names/ids; omit for all text channels',
+      },
+      perChannelLimit: {
+        type: 'integer',
+        description: 'Max messages per channel (default 50, max 200)',
+        default: 50,
+      },
+    },
+    additionalProperties: false,
+  }),
+  async execute({ since = '24h', channels, perChannelLimit = 50 }) {
+    const sinceDate = parseSince(since);
+    const targets = channels?.length
+      ? await Promise.all(channels.map((c) => resolveChannel(c)))
+      : (await allChannels()).filter((c) => c.kind === 'text' || c.kind === 'announcement');
+    const limit = Math.min(Math.max(1, perChannelLimit), 200);
+    const results: Array<{ channel: ChannelInfo; messages: Message[] }> = [];
+    for (const target of targets) {
+      try {
+        const messages = await readSince(target.id, sinceDate, limit);
+        if (messages.length) results.push({ channel: target, messages });
+      } catch {
+        // channels the bot cannot read are skipped, not fatal
+      }
+    }
+    const total = results.reduce((n, r) => n + r.messages.length, 0);
+    return {
+      since: sinceDate.toISOString(),
+      channelsChecked: targets.length,
+      totalMessages: total,
+      channels: results,
+    };
+  },
+});
+
+export const discordPost = tool({
+  description:
+    'Post a message to a channel by name or id (optionally as a reply to a message id), or to DISCORD_WEBHOOK_URL when no channel is given.',
+  inputSchema: jsonSchema<{
+    content: string;
+    channel?: string;
+    replyTo?: string;
+    username?: string;
+    embedTitle?: string;
+    embedUrl?: string;
+  }>({
+    type: 'object',
+    properties: {
+      content: { type: 'string', description: 'Message text (Discord markdown, ≤ 2000 chars)' },
+      channel: {
+        type: 'string',
+        description: 'Channel name or id; omit to use DISCORD_WEBHOOK_URL',
+      },
+      replyTo: { type: 'string', description: 'Message id to reply to (bot token only)' },
+      username: { type: 'string', description: 'Display name override (webhook only)' },
+      embedTitle: { type: 'string', description: 'Optional embed title' },
+      embedUrl: { type: 'string', description: 'Optional embed URL' },
+    },
+    required: ['content'],
+    additionalProperties: false,
+  }),
+  async execute({ content, channel, replyTo, username, embedTitle, embedUrl }) {
+    if (content.length > 2000)
+      throw new Error(`Message is ${content.length} chars; Discord allows 2000.`);
+    const embeds = embedTitle || embedUrl ? [{ title: embedTitle, url: embedUrl }] : undefined;
+    if (!channel) {
+      const webhook = envValue('DISCORD_WEBHOOK_URL');
+      if (!webhook)
+        throw new Error('Pass `channel` (needs DISCORD_BOT_TOKEN) or set DISCORD_WEBHOOK_URL.');
+      const res = await fetch(`${webhook}?wait=true`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content, username, embeds }),
+      });
+      if (!res.ok)
+        throw new Error(`Webhook post failed: ${res.status} ${await res.text().catch(() => '')}`);
+      const m = (await res.json()) as RawMessage & { channel_id?: string };
+      return { ok: true, via: 'webhook', messageId: m.id, channelId: m.channel_id ?? null };
+    }
+    const info = await resolveChannel(channel);
+    const m = await api<RawMessage>('POST', `/channels/${info.id}/messages`, {
+      content,
+      embeds,
+      message_reference: replyTo ? { message_id: replyTo } : undefined,
+    });
+    return {
+      ok: true,
+      via: 'bot',
+      messageId: m.id,
+      channel: info,
+      url: `https://discord.com/channels/${info.guildId || '@me'}/${info.id}/${m.id}`,
+    };
+  },
+});
+
+export const discordReact = tool({
+  description: 'Add an emoji reaction to a message in a channel.',
+  inputSchema: jsonSchema<{ channel: string; messageId: string; emoji: string }>({
+    type: 'object',
+    properties: {
+      channel: { type: 'string', description: 'Channel name or id' },
+      messageId: { type: 'string' },
+      emoji: { type: 'string', description: 'Unicode emoji (👍) or custom "name:id"' },
+    },
+    required: ['channel', 'messageId', 'emoji'],
+    additionalProperties: false,
+  }),
+  async execute({ channel, messageId, emoji }) {
+    const info = await resolveChannel(channel);
+    await api<undefined>(
+      'PUT',
+      `/channels/${info.id}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}/@me`
+    );
+    return { ok: true, channel: info.name, messageId, emoji };
+  },
+});

--- a/packages/tools/official/discord-chat/tsconfig.json
+++ b/packages/tools/official/discord-chat/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tpmjs/tsconfig/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tools/official/image-gen/CHANGELOG.md
+++ b/packages/tools/official/image-gen/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-image-gen
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/tools/official/image-gen/README.md
+++ b/packages/tools/official/image-gen/README.md
@@ -1,0 +1,45 @@
+# @tpmjs/tools-image-gen
+
+Generate and describe images with whichever AI provider you have a key for — OpenAI, Gemini/Imagen, fal.ai or Replicate — and deliver results as URLs (Discord) instead of megabytes of base64.
+
+Part of the **ajax weapons** set: task-level, provider-agnostic tools that an agent can pick up without learning a vendor API. Credentials come from the environment; on tpmjs add them as collection env vars (the collection owner's calls get them injected, everyone else supplies their own).
+
+## Installation
+
+```bash
+npm install @tpmjs/tools-image-gen
+```
+
+## Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | no | OpenAI key (gpt-image-1 / dall-e-3 and vision) |
+| `GEMINI_API_KEY` | no | Google AI Studio key (Imagen 3 and Gemini vision) |
+| `FAL_KEY` | no | fal.ai key (FLUX models; returns hosted URLs) |
+| `REPLICATE_API_TOKEN` | no | Replicate token (FLUX models; returns hosted URLs) |
+| `DISCORD_WEBHOOK_URL` | no | If set, generated images are posted there and returned as durable Discord CDN URLs |
+| `IMAGE_PROVIDER` | no | Force a provider: openai | gemini | fal | replicate (default: first configured, preferring URL-returning providers) |
+
+## Tools
+
+| Export | What it does |
+| --- | --- |
+| `generateImage` | Generate one or more images from a prompt using the first configured provider, returning URLs (via Discord delivery or the provider) or inline data. |
+| `describeImage` | Describe an image or answer a question about it using a vision model (OpenAI or Gemini). |
+
+## Usage
+
+```typescript
+import { generateImage, describeImage } from '@tpmjs/tools-image-gen';
+
+const ctx = { toolCallId: 'c1', messages: [] };
+const { urls } = await generateImage.execute({ prompt: 'a pig in a spacesuit, film still', aspect: 'landscape' }, ctx);
+console.log(await describeImage.execute({ imageUrl: urls[0] }, ctx));
+```
+
+Every tool throws a readable error on provider failures (status code + provider message), so agents can react instead of guessing.
+
+## License
+
+MIT

--- a/packages/tools/official/image-gen/package.json
+++ b/packages/tools/official/image-gen/package.json
@@ -1,0 +1,97 @@
+{
+  "name": "@tpmjs/tools-image-gen",
+  "version": "0.1.0",
+  "description": "Generate and describe images with whichever AI provider you have a key for \u2014 OpenAI, Gemini/Imagen, fal.ai or Replicate \u2014 and deliver results as URLs (Discord) instead of megabytes of base64",
+  "type": "module",
+  "keywords": [
+    "tpmjs",
+    "ai-ml",
+    "image",
+    "generation",
+    "ai",
+    "openai",
+    "imagen",
+    "flux",
+    "vision"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --sourcemap --logLevel warn",
+    "dev": "tsdown --sourcemap --watch",
+    "type-check": "tsc --checkers 1 --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@tpmjs/tsconfig": "workspace:*",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "ai": "6.0.49"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tpmjs/tpmjs.git",
+    "directory": "packages/tools/official/image-gen"
+  },
+  "homepage": "https://tpmjs.com",
+  "license": "MIT",
+  "tpmjs": {
+    "category": "ai-ml",
+    "frameworks": [
+      "vercel-ai"
+    ],
+    "env": [
+      {
+        "name": "OPENAI_API_KEY",
+        "description": "OpenAI key (gpt-image-1 / dall-e-3 and vision)",
+        "required": false
+      },
+      {
+        "name": "GEMINI_API_KEY",
+        "description": "Google AI Studio key (Imagen 3 and Gemini vision)",
+        "required": false
+      },
+      {
+        "name": "FAL_KEY",
+        "description": "fal.ai key (FLUX models; returns hosted URLs)",
+        "required": false
+      },
+      {
+        "name": "REPLICATE_API_TOKEN",
+        "description": "Replicate token (FLUX models; returns hosted URLs)",
+        "required": false
+      },
+      {
+        "name": "DISCORD_WEBHOOK_URL",
+        "description": "If set, generated images are posted there and returned as durable Discord CDN URLs",
+        "required": false
+      },
+      {
+        "name": "IMAGE_PROVIDER",
+        "description": "Force a provider: openai | gemini | fal | replicate (default: first configured, preferring URL-returning providers)",
+        "required": false
+      }
+    ],
+    "tools": [
+      {
+        "name": "generateImage",
+        "description": "Generate one or more images from a prompt using the first configured provider, returning URLs (via Discord delivery or the provider) or inline data."
+      },
+      {
+        "name": "describeImage",
+        "description": "Describe an image or answer a question about it using a vision model (OpenAI or Gemini)."
+      }
+    ]
+  }
+}

--- a/packages/tools/official/image-gen/src/index.ts
+++ b/packages/tools/official/image-gen/src/index.ts
@@ -1,0 +1,414 @@
+/**
+ * @tpmjs/tools-image-gen — generate and describe images with whatever provider you have.
+ *
+ * Providers (auto-detected, or forced with IMAGE_PROVIDER): fal.ai and Replicate return
+ * hosted URLs; OpenAI (gpt-image-1 / dall-e-3) and Gemini Imagen return base64. Because a
+ * tool result full of base64 is useless to an agent, base64 results are delivered to
+ * DISCORD_WEBHOOK_URL when configured and come back as durable Discord CDN URLs.
+ *
+ * @env OPENAI_API_KEY | GEMINI_API_KEY | FAL_KEY | REPLICATE_API_TOKEN, DISCORD_WEBHOOK_URL (optional), IMAGE_PROVIDER (optional)
+ */
+
+import { jsonSchema, tool } from 'ai';
+
+type Provider = 'fal' | 'replicate' | 'openai' | 'gemini';
+type Aspect = 'square' | 'landscape' | 'portrait';
+
+function envValue(name: string): string | undefined {
+  const value = globalThis.process?.env?.[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+const PROVIDER_KEYS: Array<[Provider, string]> = [
+  ['fal', 'FAL_KEY'],
+  ['replicate', 'REPLICATE_API_TOKEN'],
+  ['openai', 'OPENAI_API_KEY'],
+  ['gemini', 'GEMINI_API_KEY'],
+];
+
+function detectProvider(force?: string): Provider {
+  const wanted = (force ?? envValue('IMAGE_PROVIDER'))?.toLowerCase() as Provider | undefined;
+  if (wanted) {
+    const hit = PROVIDER_KEYS.find(([p]) => p === wanted);
+    if (!hit)
+      throw new Error(`Unknown image provider "${wanted}" (fal | replicate | openai | gemini).`);
+    if (!envValue(hit[1])) throw new Error(`${hit[1]} is not configured for provider ${wanted}.`);
+    return wanted;
+  }
+  const first = PROVIDER_KEYS.find(([, key]) => envValue(key));
+  if (!first) {
+    throw new Error(
+      'No image provider configured. Set FAL_KEY, REPLICATE_API_TOKEN, OPENAI_API_KEY or GEMINI_API_KEY.'
+    );
+  }
+  return first[0];
+}
+
+async function fail(res: Response, provider: string): Promise<never> {
+  const text = await res.text().catch(() => '');
+  throw new Error(
+    `${provider} image request failed: ${res.status}${text ? ` — ${text.slice(0, 300)}` : ''}`
+  );
+}
+
+interface Generated {
+  url?: string;
+  b64?: string;
+  mimeType: string;
+}
+
+// ─── providers ───────────────────────────────────────────────────────────────
+
+async function viaFal(
+  prompt: string,
+  n: number,
+  aspect: Aspect,
+  model?: string
+): Promise<Generated[]> {
+  const size =
+    aspect === 'landscape'
+      ? 'landscape_16_9'
+      : aspect === 'portrait'
+        ? 'portrait_16_9'
+        : 'square_hd';
+  const res = await fetch(`https://fal.run/${model ?? 'fal-ai/flux/schnell'}`, {
+    method: 'POST',
+    headers: { Authorization: `Key ${envValue('FAL_KEY')}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt, image_size: size, num_images: n }),
+  });
+  if (!res.ok) await fail(res, 'fal.ai');
+  const data = (await res.json()) as { images: Array<{ url: string; content_type?: string }> };
+  return data.images.map((i) => ({ url: i.url, mimeType: i.content_type ?? 'image/jpeg' }));
+}
+
+async function viaReplicate(
+  prompt: string,
+  n: number,
+  aspect: Aspect,
+  model?: string
+): Promise<Generated[]> {
+  const ratio = aspect === 'landscape' ? '16:9' : aspect === 'portrait' ? '9:16' : '1:1';
+  const res = await fetch(
+    `https://api.replicate.com/v1/models/${model ?? 'black-forest-labs/flux-schnell'}/predictions`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${envValue('REPLICATE_API_TOKEN')}`,
+        'Content-Type': 'application/json',
+        Prefer: 'wait=60',
+      },
+      body: JSON.stringify({
+        input: { prompt, num_outputs: n, aspect_ratio: ratio, output_format: 'jpg' },
+      }),
+    }
+  );
+  if (!res.ok) await fail(res, 'Replicate');
+  const data = (await res.json()) as { output?: string | string[]; status: string; error?: string };
+  if (data.error) throw new Error(`Replicate: ${data.error}`);
+  const urls = Array.isArray(data.output) ? data.output : data.output ? [data.output] : [];
+  if (!urls.length) throw new Error(`Replicate prediction ${data.status} without output.`);
+  return urls.map((url) => ({ url, mimeType: 'image/jpeg' }));
+}
+
+const OPENAI_SIZES: Record<'legacy' | 'modern', Record<Aspect, string>> = {
+  legacy: { square: '1024x1024', landscape: '1792x1024', portrait: '1024x1792' },
+  modern: { square: '1024x1024', landscape: '1536x1024', portrait: '1024x1536' },
+};
+
+async function viaOpenAI(
+  prompt: string,
+  n: number,
+  aspect: Aspect,
+  quality: string,
+  model?: string
+): Promise<Generated[]> {
+  const m = model ?? 'gpt-image-1';
+  const legacy = m.startsWith('dall-e');
+  const size = OPENAI_SIZES[legacy ? 'legacy' : 'modern'][aspect];
+  const body: Record<string, unknown> = legacy
+    ? { model: m, prompt, n: 1, size, response_format: 'url' }
+    : { model: m, prompt, n, size, quality, output_format: 'jpeg' };
+  const res = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${envValue('OPENAI_API_KEY')}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) await fail(res, 'OpenAI');
+  const data = (await res.json()) as { data: Array<{ url?: string; b64_json?: string }> };
+  return data.data.map((d) => ({
+    url: d.url,
+    b64: d.b64_json,
+    mimeType: legacy ? 'image/png' : 'image/jpeg',
+  }));
+}
+
+async function viaGemini(
+  prompt: string,
+  n: number,
+  aspect: Aspect,
+  model?: string
+): Promise<Generated[]> {
+  const ratio = aspect === 'landscape' ? '16:9' : aspect === 'portrait' ? '9:16' : '1:1';
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model ?? 'imagen-3.0-generate-002'}:predict?key=${envValue('GEMINI_API_KEY')}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        instances: [{ prompt }],
+        parameters: { sampleCount: n, aspectRatio: ratio },
+      }),
+    }
+  );
+  if (!res.ok) await fail(res, 'Gemini Imagen');
+  const data = (await res.json()) as {
+    predictions?: Array<{ bytesBase64Encoded: string; mimeType?: string }>;
+  };
+  return (data.predictions ?? []).map((p) => ({
+    b64: p.bytesBase64Encoded,
+    mimeType: p.mimeType ?? 'image/png',
+  }));
+}
+
+function produce(
+  provider: Provider,
+  prompt: string,
+  n: number,
+  aspect: Aspect,
+  quality: string,
+  model?: string
+): Promise<Generated[]> {
+  switch (provider) {
+    case 'fal':
+      return viaFal(prompt, n, aspect, model);
+    case 'replicate':
+      return viaReplicate(prompt, n, aspect, model);
+    case 'openai':
+      return viaOpenAI(prompt, n, aspect, quality, model);
+    default:
+      return viaGemini(prompt, n, aspect, model);
+  }
+}
+
+// ─── delivery ────────────────────────────────────────────────────────────────
+
+function b64ToBlob(b64: string, mimeType: string): Blob {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new Blob([bytes], { type: mimeType });
+}
+
+/** Post images to a Discord webhook and return their CDN URLs (durable, no base64 in the result). */
+async function deliverToDiscord(images: Generated[], caption: string): Promise<string[]> {
+  const webhook = envValue('DISCORD_WEBHOOK_URL');
+  if (!webhook) throw new Error('DISCORD_WEBHOOK_URL is not configured for Discord delivery.');
+  const form = new FormData();
+  form.append('payload_json', JSON.stringify({ content: caption.slice(0, 1900) }));
+  images.forEach((img, i) => {
+    const ext = img.mimeType.includes('png') ? 'png' : 'jpg';
+    if (img.b64)
+      form.append(`files[${i}]`, b64ToBlob(img.b64, img.mimeType), `image-${i + 1}.${ext}`);
+  });
+  const res = await fetch(`${webhook}?wait=true`, { method: 'POST', body: form });
+  if (!res.ok) await fail(res, 'Discord webhook');
+  const m = (await res.json()) as { attachments?: Array<{ url: string }> };
+  return (m.attachments ?? []).map((a) => a.url);
+}
+
+export interface GenerateImageInput {
+  prompt: string;
+  count?: number;
+  aspect?: Aspect;
+  quality?: 'low' | 'medium' | 'high';
+  provider?: Provider;
+  model?: string;
+  deliver?: 'auto' | 'inline' | 'discord';
+}
+
+interface GenerateImageResult {
+  provider: Provider;
+  prompt: string;
+  count: number;
+  urls: string[];
+  dataUrls?: string[];
+  note?: string;
+  deliveredVia: 'discord' | 'provider' | 'inline';
+}
+
+async function generate(input: GenerateImageInput): Promise<GenerateImageResult> {
+  const {
+    prompt,
+    count = 1,
+    aspect = 'square',
+    quality = 'medium',
+    provider,
+    model,
+    deliver = 'auto',
+  } = input;
+  const chosen = detectProvider(provider);
+  const images = await produce(
+    chosen,
+    prompt,
+    Math.min(4, Math.max(1, count)),
+    aspect,
+    quality,
+    model
+  );
+  const hosted = images.filter((i) => i.url).map((i) => i.url as string);
+  const pending = images.filter((i) => !i.url && i.b64);
+  const useDiscord =
+    deliver === 'discord' || (deliver === 'auto' && Boolean(envValue('DISCORD_WEBHOOK_URL')));
+  if (pending.length && useDiscord) {
+    const delivered = await deliverToDiscord(pending, `🎨 ${prompt}`);
+    return {
+      provider: chosen,
+      prompt,
+      count: images.length,
+      urls: [...hosted, ...delivered],
+      deliveredVia: 'discord',
+    };
+  }
+  if (pending.length) {
+    return {
+      provider: chosen,
+      prompt,
+      count: images.length,
+      urls: hosted,
+      dataUrls: pending.map((i) => `data:${i.mimeType};base64,${i.b64}`),
+      note: 'Inline base64 returned because no Discord webhook is configured; set DISCORD_WEBHOOK_URL to get URLs.',
+      deliveredVia: 'inline',
+    };
+  }
+  return { provider: chosen, prompt, count: images.length, urls: hosted, deliveredVia: 'provider' };
+}
+
+// ─── tools ───────────────────────────────────────────────────────────────────
+
+export const generateImage = tool({
+  description:
+    'Generate one or more images from a prompt using the first configured provider (fal.ai, Replicate, OpenAI gpt-image-1/dall-e-3, Gemini Imagen). Returns image URLs — via the provider or Discord delivery — or inline data URLs when asked.',
+  inputSchema: jsonSchema<GenerateImageInput>({
+    type: 'object',
+    properties: {
+      prompt: { type: 'string', description: 'What to draw' },
+      count: { type: 'integer', description: '1–4 images (default 1)', default: 1 },
+      aspect: { type: 'string', enum: ['square', 'landscape', 'portrait'], default: 'square' },
+      quality: {
+        type: 'string',
+        enum: ['low', 'medium', 'high'],
+        description: 'OpenAI only (default medium)',
+        default: 'medium',
+      },
+      provider: {
+        type: 'string',
+        enum: ['fal', 'replicate', 'openai', 'gemini'],
+        description: 'Force a provider',
+      },
+      model: {
+        type: 'string',
+        description: 'Provider-specific model override (e.g. dall-e-3, fal-ai/flux-pro)',
+      },
+      deliver: {
+        type: 'string',
+        enum: ['auto', 'inline', 'discord'],
+        description:
+          'How to return base64 results: auto = Discord webhook if configured else inline data URL',
+        default: 'auto',
+      },
+    },
+    required: ['prompt'],
+    additionalProperties: false,
+  }),
+  async execute(input): Promise<GenerateImageResult> {
+    return generate(input);
+  },
+});
+
+async function describeWithOpenAI(imageUrl: string, question: string): Promise<string> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${envValue('OPENAI_API_KEY')}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4.1-mini',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: question },
+            { type: 'image_url', image_url: { url: imageUrl } },
+          ],
+        },
+      ],
+      max_tokens: 600,
+    }),
+  });
+  if (!res.ok) await fail(res, 'OpenAI vision');
+  const data = (await res.json()) as { choices: Array<{ message: { content: string } }> };
+  return data.choices[0]?.message.content ?? '';
+}
+
+async function describeWithGemini(imageUrl: string, question: string): Promise<string> {
+  const download = await fetch(imageUrl);
+  if (!download.ok) throw new Error(`Could not download ${imageUrl}: ${download.status}`);
+  const mime = download.headers.get('content-type') ?? 'image/jpeg';
+  const bytes = new Uint8Array(await download.arrayBuffer());
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${envValue('GEMINI_API_KEY')}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [
+          { parts: [{ text: question }, { inline_data: { mime_type: mime, data: btoa(bin) } }] },
+        ],
+      }),
+    }
+  );
+  if (!res.ok) await fail(res, 'Gemini vision');
+  const data = (await res.json()) as {
+    candidates?: Array<{ content: { parts: Array<{ text?: string }> } }>;
+  };
+  return data.candidates?.[0]?.content.parts.map((p) => p.text ?? '').join('') ?? '';
+}
+
+export const describeImage = tool({
+  description:
+    'Describe an image or answer a question about it using a vision model (OpenAI gpt-4.1-mini or Gemini).',
+  inputSchema: jsonSchema<{ imageUrl: string; question?: string; provider?: 'openai' | 'gemini' }>({
+    type: 'object',
+    properties: {
+      imageUrl: { type: 'string', description: 'Public image URL (or data URL)' },
+      question: {
+        type: 'string',
+        description: 'What to ask about the image (default: describe it in detail)',
+      },
+      provider: { type: 'string', enum: ['openai', 'gemini'] },
+    },
+    required: ['imageUrl'],
+    additionalProperties: false,
+  }),
+  async execute({
+    imageUrl,
+    question = 'Describe this image in detail: subjects, setting, text, style, anything notable.',
+    provider,
+  }) {
+    const use =
+      provider ??
+      (envValue('OPENAI_API_KEY') ? 'openai' : envValue('GEMINI_API_KEY') ? 'gemini' : null);
+    if (!use) throw new Error('describeImage needs OPENAI_API_KEY or GEMINI_API_KEY.');
+    const answer =
+      use === 'openai'
+        ? await describeWithOpenAI(imageUrl, question)
+        : await describeWithGemini(imageUrl, question);
+    return { provider: use, answer };
+  },
+});

--- a/packages/tools/official/image-gen/tsconfig.json
+++ b/packages/tools/official/image-gen/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tpmjs/tsconfig/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tools/official/mail/CHANGELOG.md
+++ b/packages/tools/official/mail/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-mail
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/tools/official/mail/README.md
+++ b/packages/tools/official/mail/README.md
@@ -1,0 +1,46 @@
+# @tpmjs/tools-mail
+
+Send email through whichever provider you have a key for — Resend, Postmark, SendGrid or Mailgun — with one consistent sendEmail tool.
+
+Part of the **ajax weapons** set: task-level, provider-agnostic tools that an agent can pick up without learning a vendor API. Credentials come from the environment; on tpmjs add them as collection env vars (the collection owner's calls get them injected, everyone else supplies their own).
+
+## Installation
+
+```bash
+npm install @tpmjs/tools-mail
+```
+
+## Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `RESEND_API_KEY` | no | Resend API key (https://resend.com) — one of the provider keys is required |
+| `POSTMARK_SERVER_TOKEN` | no | Postmark server token (https://postmarkapp.com) |
+| `SENDGRID_API_KEY` | no | SendGrid API key |
+| `MAILGUN_API_KEY` | no | Mailgun API key (needs MAILGUN_DOMAIN) |
+| `MAILGUN_DOMAIN` | no | Mailgun sending domain |
+| `EMAIL_FROM` | no | Default sender, e.g. "Ajax <ajax@example.com>" |
+| `EMAIL_PROVIDER` | no | Force a provider: resend | postmark | sendgrid | mailgun (default: auto-detect from keys) |
+
+## Tools
+
+| Export | What it does |
+| --- | --- |
+| `sendEmail` | Send an email (text and/or HTML, cc/bcc/reply-to) through the first configured provider: Resend, Postmark, SendGrid or Mailgun. |
+
+## Usage
+
+```typescript
+import { sendEmail } from '@tpmjs/tools-mail';
+
+await sendEmail.execute(
+  { to: 'you@example.com', subject: 'Deploy done', text: 'All green.' },
+  { toolCallId: 'c1', messages: [] }
+);
+```
+
+Every tool throws a readable error on provider failures (status code + provider message), so agents can react instead of guessing.
+
+## License
+
+MIT

--- a/packages/tools/official/mail/package.json
+++ b/packages/tools/official/mail/package.json
@@ -1,0 +1,97 @@
+{
+  "name": "@tpmjs/tools-mail",
+  "version": "0.1.0",
+  "description": "Send email through whichever provider you have a key for \u2014 Resend, Postmark, SendGrid or Mailgun \u2014 with one consistent sendEmail tool",
+  "type": "module",
+  "keywords": [
+    "tpmjs",
+    "communication",
+    "email",
+    "mail",
+    "resend",
+    "postmark",
+    "sendgrid",
+    "mailgun"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --sourcemap --logLevel warn",
+    "dev": "tsdown --sourcemap --watch",
+    "type-check": "tsc --checkers 1 --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@tpmjs/tsconfig": "workspace:*",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "ai": "6.0.49"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tpmjs/tpmjs.git",
+    "directory": "packages/tools/official/mail"
+  },
+  "homepage": "https://tpmjs.com",
+  "license": "MIT",
+  "tpmjs": {
+    "category": "communication",
+    "frameworks": [
+      "vercel-ai"
+    ],
+    "env": [
+      {
+        "name": "RESEND_API_KEY",
+        "description": "Resend API key (https://resend.com) \u2014 one of the provider keys is required",
+        "required": false
+      },
+      {
+        "name": "POSTMARK_SERVER_TOKEN",
+        "description": "Postmark server token (https://postmarkapp.com)",
+        "required": false
+      },
+      {
+        "name": "SENDGRID_API_KEY",
+        "description": "SendGrid API key",
+        "required": false
+      },
+      {
+        "name": "MAILGUN_API_KEY",
+        "description": "Mailgun API key (needs MAILGUN_DOMAIN)",
+        "required": false
+      },
+      {
+        "name": "MAILGUN_DOMAIN",
+        "description": "Mailgun sending domain",
+        "required": false
+      },
+      {
+        "name": "EMAIL_FROM",
+        "description": "Default sender, e.g. \"Ajax <ajax@example.com>\"",
+        "required": false
+      },
+      {
+        "name": "EMAIL_PROVIDER",
+        "description": "Force a provider: resend | postmark | sendgrid | mailgun (default: auto-detect from keys)",
+        "required": false
+      }
+    ],
+    "tools": [
+      {
+        "name": "sendEmail",
+        "description": "Send an email (text and/or HTML, cc/bcc/reply-to) through the first configured provider: Resend, Postmark, SendGrid or Mailgun."
+      }
+    ]
+  }
+}

--- a/packages/tools/official/mail/src/index.ts
+++ b/packages/tools/official/mail/src/index.ts
@@ -1,0 +1,259 @@
+/**
+ * @tpmjs/tools-mail — one `sendEmail` for whichever provider you have a key for.
+ *
+ * Provider is auto-detected from the environment (first match wins) or forced with
+ * EMAIL_PROVIDER: Resend, Postmark, SendGrid, Mailgun. Every provider is driven over
+ * plain HTTPS so the tool runs anywhere fetch does.
+ *
+ * @env RESEND_API_KEY | POSTMARK_SERVER_TOKEN | SENDGRID_API_KEY | MAILGUN_API_KEY + MAILGUN_DOMAIN
+ * @env EMAIL_FROM default sender ("Name <addr>"), EMAIL_PROVIDER optional override
+ */
+
+import { jsonSchema, tool } from 'ai';
+
+type Provider = 'resend' | 'postmark' | 'sendgrid' | 'mailgun';
+
+interface Detected {
+  provider: Provider;
+  key: string;
+  domain?: string;
+}
+
+function envValue(name: string): string | undefined {
+  const value = globalThis.process?.env?.[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function detectProvider(): Detected {
+  const forced = envValue('EMAIL_PROVIDER')?.toLowerCase() as Provider | undefined;
+  const candidates: Array<Detected | null> = [
+    envValue('RESEND_API_KEY')
+      ? { provider: 'resend', key: envValue('RESEND_API_KEY') as string }
+      : null,
+    envValue('POSTMARK_SERVER_TOKEN')
+      ? { provider: 'postmark', key: envValue('POSTMARK_SERVER_TOKEN') as string }
+      : null,
+    envValue('SENDGRID_API_KEY')
+      ? { provider: 'sendgrid', key: envValue('SENDGRID_API_KEY') as string }
+      : null,
+    envValue('MAILGUN_API_KEY') && envValue('MAILGUN_DOMAIN')
+      ? {
+          provider: 'mailgun',
+          key: envValue('MAILGUN_API_KEY') as string,
+          domain: envValue('MAILGUN_DOMAIN'),
+        }
+      : null,
+  ];
+  const available = candidates.filter((c): c is Detected => c !== null);
+  if (forced) {
+    const hit = available.find((c) => c.provider === forced);
+    if (!hit) throw new Error(`EMAIL_PROVIDER=${forced} but its credentials are not configured.`);
+    return hit;
+  }
+  if (!available[0]) {
+    throw new Error(
+      'No email provider configured. Set one of RESEND_API_KEY, POSTMARK_SERVER_TOKEN, SENDGRID_API_KEY, or MAILGUN_API_KEY + MAILGUN_DOMAIN.'
+    );
+  }
+  return available[0];
+}
+
+const toList = (value: string | string[] | undefined): string[] =>
+  value === undefined
+    ? []
+    : Array.isArray(value)
+      ? value
+      : value
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+
+async function readError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  return `${res.status} ${res.statusText}${text ? ` — ${text.slice(0, 300)}` : ''}`;
+}
+
+export interface SendEmailInput {
+  to: string | string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  from?: string;
+  replyTo?: string;
+  cc?: string | string[];
+  bcc?: string | string[];
+}
+
+export interface SendEmailResult {
+  ok: true;
+  provider: Provider;
+  id: string | null;
+  from: string;
+  to: string[];
+  subject: string;
+}
+
+interface Outgoing {
+  from: string;
+  to: string[];
+  cc: string[];
+  bcc: string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  replyTo?: string;
+}
+
+async function viaResend(key: string, m: Outgoing): Promise<string | null> {
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      from: m.from,
+      to: m.to,
+      subject: m.subject,
+      text: m.text,
+      html: m.html,
+      reply_to: m.replyTo,
+      cc: m.cc.length ? m.cc : undefined,
+      bcc: m.bcc.length ? m.bcc : undefined,
+    }),
+  });
+  if (!res.ok) throw new Error(`Resend rejected the email: ${await readError(res)}`);
+  return ((await res.json()) as { id?: string }).id ?? null;
+}
+
+async function viaPostmark(key: string, m: Outgoing): Promise<string | null> {
+  const res = await fetch('https://api.postmarkapp.com/email', {
+    method: 'POST',
+    headers: {
+      'X-Postmark-Server-Token': key,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      From: m.from,
+      To: m.to.join(','),
+      Cc: m.cc.join(',') || undefined,
+      Bcc: m.bcc.join(',') || undefined,
+      Subject: m.subject,
+      TextBody: m.text,
+      HtmlBody: m.html,
+      ReplyTo: m.replyTo,
+    }),
+  });
+  if (!res.ok) throw new Error(`Postmark rejected the email: ${await readError(res)}`);
+  return ((await res.json()) as { MessageID?: string }).MessageID ?? null;
+}
+
+async function viaSendgrid(key: string, m: Outgoing): Promise<string | null> {
+  const content = [
+    ...(m.text ? [{ type: 'text/plain', value: m.text }] : []),
+    ...(m.html ? [{ type: 'text/html', value: m.html }] : []),
+  ];
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      personalizations: [
+        {
+          to: m.to.map((email) => ({ email })),
+          cc: m.cc.length ? m.cc.map((email) => ({ email })) : undefined,
+          bcc: m.bcc.length ? m.bcc.map((email) => ({ email })) : undefined,
+        },
+      ],
+      from: { email: m.from.replace(/^.*<(.+)>$/, '$1') },
+      reply_to: m.replyTo ? { email: m.replyTo } : undefined,
+      subject: m.subject,
+      content,
+    }),
+  });
+  if (!res.ok) throw new Error(`SendGrid rejected the email: ${await readError(res)}`);
+  return res.headers.get('x-message-id');
+}
+
+async function viaMailgun(key: string, domain: string, m: Outgoing): Promise<string | null> {
+  const form = new URLSearchParams();
+  form.set('from', m.from);
+  for (const r of m.to) form.append('to', r);
+  for (const r of m.cc) form.append('cc', r);
+  for (const r of m.bcc) form.append('bcc', r);
+  form.set('subject', m.subject);
+  if (m.text) form.set('text', m.text);
+  if (m.html) form.set('html', m.html);
+  if (m.replyTo) form.set('h:Reply-To', m.replyTo);
+  const res = await fetch(`https://api.mailgun.net/v3/${domain}/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Basic ${btoa(`api:${key}`)}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error(`Mailgun rejected the email: ${await readError(res)}`);
+  return ((await res.json()) as { id?: string }).id ?? null;
+}
+
+const SENDERS: Record<Provider, (d: Detected, m: Outgoing) => Promise<string | null>> = {
+  resend: (d, m) => viaResend(d.key, m),
+  postmark: (d, m) => viaPostmark(d.key, m),
+  sendgrid: (d, m) => viaSendgrid(d.key, m),
+  mailgun: (d, m) => viaMailgun(d.key, d.domain ?? '', m),
+};
+
+export async function sendEmailWith(input: SendEmailInput): Promise<SendEmailResult> {
+  const detected = detectProvider();
+  const from = input.from ?? envValue('EMAIL_FROM');
+  if (!from) {
+    throw new Error('No sender: pass `from` or set EMAIL_FROM (e.g. "Ajax <ajax@example.com>").');
+  }
+  if (!input.text && !input.html) throw new Error('Provide `text` and/or `html`.');
+  const outgoing: Outgoing = {
+    from,
+    to: toList(input.to),
+    cc: toList(input.cc),
+    bcc: toList(input.bcc),
+    subject: input.subject,
+    text: input.text,
+    html: input.html,
+    replyTo: input.replyTo,
+  };
+  if (outgoing.to.length === 0) throw new Error('At least one recipient is required.');
+  const id = await SENDERS[detected.provider](detected, outgoing);
+  return {
+    ok: true,
+    provider: detected.provider,
+    id,
+    from,
+    to: outgoing.to,
+    subject: input.subject,
+  };
+}
+
+export const sendEmail = tool({
+  description:
+    'Send an email (text and/or HTML, cc/bcc/reply-to) through the first configured provider: Resend, Postmark, SendGrid or Mailgun. Returns the provider message id.',
+  inputSchema: jsonSchema<SendEmailInput>({
+    type: 'object',
+    properties: {
+      to: {
+        description: 'Recipient address, comma-separated list, or array',
+        anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+      },
+      subject: { type: 'string', description: 'Subject line' },
+      text: {
+        type: 'string',
+        description: 'Plain-text body (recommended even when html is given)',
+      },
+      html: { type: 'string', description: 'HTML body' },
+      from: { type: 'string', description: 'Sender ("Name <addr>"); defaults to EMAIL_FROM' },
+      replyTo: { type: 'string', description: 'Reply-To address' },
+      cc: { anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }] },
+      bcc: { anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }] },
+    },
+    required: ['to', 'subject'],
+    additionalProperties: false,
+  }),
+  async execute(input): Promise<SendEmailResult> {
+    return sendEmailWith(input);
+  },
+});
+
+export default sendEmail;

--- a/packages/tools/official/mail/tsconfig.json
+++ b/packages/tools/official/mail/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tpmjs/tsconfig/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tools/official/web-research/CHANGELOG.md
+++ b/packages/tools/official/web-research/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-web-research
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/tools/official/web-research/README.md
+++ b/packages/tools/official/web-research/README.md
@@ -1,0 +1,49 @@
+# @tpmjs/tools-web-research
+
+The everyday research kit: read any page as markdown, search the web through your preferred provider, ask Perplexity with citations, find Wayback snapshots and search archive.org.
+
+Part of the **ajax weapons** set: task-level, provider-agnostic tools that an agent can pick up without learning a vendor API. Credentials come from the environment; on tpmjs add them as collection env vars (the collection owner's calls get them injected, everyone else supplies their own).
+
+## Installation
+
+```bash
+npm install @tpmjs/tools-web-research
+```
+
+## Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `FIRECRAWL_API_KEY` | no | Firecrawl key for webSearch (one of the search keys is required for webSearch) |
+| `BRAVE_SEARCH_API_KEY` | no | Brave Search API key for webSearch |
+| `SERPER_API_KEY` | no | Serper (Google) key for webSearch |
+| `TAVILY_API_KEY` | no | Tavily key for webSearch |
+| `PERPLEXITY_API_KEY` | no | Perplexity key for askPerplexity |
+| `JINA_API_KEY` | no | Optional Jina key for higher readPage rate limits |
+
+## Tools
+
+| Export | What it does |
+| --- | --- |
+| `readPage` | Fetch a web page and return its readable content as markdown (title, text, links), with length control. |
+| `webSearch` | Search the web through the first configured provider (Firecrawl, Brave, Serper or Tavily) and return normalised results. |
+| `askPerplexity` | Ask Perplexity (sonar) a research question and get a sourced answer with citations. |
+| `waybackSnapshot` | Find the closest Wayback Machine snapshot of a URL, optionally near a date. |
+| `archiveSearch` | Search the Internet Archive catalog (books, texts, audio, video) and return items with identifiers and links. |
+
+## Usage
+
+```typescript
+import { readPage, webSearch, askPerplexity, waybackSnapshot, archiveSearch } from '@tpmjs/tools-web-research';
+
+const ctx = { toolCallId: 'c1', messages: [] };
+const page = await readPage.execute({ url: 'https://tpmjs.com' }, ctx);
+const hits = await webSearch.execute({ query: 'pgvector HNSW tuning' }, ctx);
+const snap = await waybackSnapshot.execute({ url: 'https://example.com', timestamp: '2016' }, ctx);
+```
+
+Every tool throws a readable error on provider failures (status code + provider message), so agents can react instead of guessing.
+
+## License
+
+MIT

--- a/packages/tools/official/web-research/package.json
+++ b/packages/tools/official/web-research/package.json
@@ -1,0 +1,109 @@
+{
+  "name": "@tpmjs/tools-web-research",
+  "version": "0.1.0",
+  "description": "The everyday research kit: read any page as markdown, search the web through your preferred provider, ask Perplexity with citations, find Wayback snapshots and search archive.org",
+  "type": "module",
+  "keywords": [
+    "tpmjs",
+    "research",
+    "research",
+    "web",
+    "search",
+    "wayback",
+    "archive",
+    "perplexity",
+    "reader"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --sourcemap --logLevel warn",
+    "dev": "tsdown --sourcemap --watch",
+    "type-check": "tsc --checkers 1 --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@tpmjs/tsconfig": "workspace:*",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "ai": "6.0.49"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tpmjs/tpmjs.git",
+    "directory": "packages/tools/official/web-research"
+  },
+  "homepage": "https://tpmjs.com",
+  "license": "MIT",
+  "tpmjs": {
+    "category": "research",
+    "frameworks": [
+      "vercel-ai"
+    ],
+    "env": [
+      {
+        "name": "FIRECRAWL_API_KEY",
+        "description": "Firecrawl key for webSearch (one of the search keys is required for webSearch)",
+        "required": false
+      },
+      {
+        "name": "BRAVE_SEARCH_API_KEY",
+        "description": "Brave Search API key for webSearch",
+        "required": false
+      },
+      {
+        "name": "SERPER_API_KEY",
+        "description": "Serper (Google) key for webSearch",
+        "required": false
+      },
+      {
+        "name": "TAVILY_API_KEY",
+        "description": "Tavily key for webSearch",
+        "required": false
+      },
+      {
+        "name": "PERPLEXITY_API_KEY",
+        "description": "Perplexity key for askPerplexity",
+        "required": false
+      },
+      {
+        "name": "JINA_API_KEY",
+        "description": "Optional Jina key for higher readPage rate limits",
+        "required": false
+      }
+    ],
+    "tools": [
+      {
+        "name": "readPage",
+        "description": "Fetch a web page and return its readable content as markdown (title, text, links), with length control."
+      },
+      {
+        "name": "webSearch",
+        "description": "Search the web through the first configured provider (Firecrawl, Brave, Serper or Tavily) and return normalised results."
+      },
+      {
+        "name": "askPerplexity",
+        "description": "Ask Perplexity (sonar) a research question and get a sourced answer with citations."
+      },
+      {
+        "name": "waybackSnapshot",
+        "description": "Find the closest Wayback Machine snapshot of a URL, optionally near a date."
+      },
+      {
+        "name": "archiveSearch",
+        "description": "Search the Internet Archive catalog (books, texts, audio, video) and return items with identifiers and links."
+      }
+    ]
+  }
+}

--- a/packages/tools/official/web-research/src/index.ts
+++ b/packages/tools/official/web-research/src/index.ts
@@ -1,0 +1,411 @@
+/**
+ * @tpmjs/tools-web-research — the everyday research kit.
+ *
+ * readPage (any URL → markdown via Jina Reader, no key needed), webSearch (Firecrawl,
+ * Brave, Serper or Tavily — first configured key wins), askPerplexity (sourced answers),
+ * waybackSnapshot (Internet Archive availability API) and archiveSearch (archive.org
+ * catalog). All plain HTTPS.
+ *
+ * @env FIRECRAWL_API_KEY | BRAVE_SEARCH_API_KEY | SERPER_API_KEY | TAVILY_API_KEY (webSearch), PERPLEXITY_API_KEY, JINA_API_KEY (optional)
+ */
+
+import { jsonSchema, tool } from 'ai';
+
+function envValue(name: string): string | undefined {
+  const value = globalThis.process?.env?.[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+async function fail(res: Response, what: string): Promise<never> {
+  const text = await res.text().catch(() => '');
+  throw new Error(`${what} failed: ${res.status}${text ? ` — ${text.slice(0, 300)}` : ''}`);
+}
+
+// ─── readPage ────────────────────────────────────────────────────────────────
+
+interface JinaReaderResponse {
+  data?: { title?: string; content?: string; url?: string; links?: Record<string, string> };
+}
+
+export const readPage = tool({
+  description:
+    'Fetch a web page and return its readable content as markdown (title, text, links), with length control. Works on most sites including JS-rendered ones.',
+  inputSchema: jsonSchema<{ url: string; maxChars?: number; withLinks?: boolean }>({
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'Page URL' },
+      maxChars: {
+        type: 'integer',
+        description: 'Truncate content to this many characters (default 20000)',
+        default: 20000,
+      },
+      withLinks: {
+        type: 'boolean',
+        description: 'Include a list of links found on the page',
+        default: false,
+      },
+    },
+    required: ['url'],
+    additionalProperties: false,
+  }),
+  async execute({ url, maxChars = 20000, withLinks = false }) {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'X-Return-Format': 'markdown',
+    };
+    if (withLinks) headers['X-With-Links-Summary'] = 'true';
+    const jina = envValue('JINA_API_KEY');
+    if (jina) headers.Authorization = `Bearer ${jina}`;
+    const res = await fetch(`https://r.jina.ai/${url}`, { headers });
+    if (!res.ok) await fail(res, `readPage(${url})`);
+    const data = (await res.json()) as JinaReaderResponse;
+    const content = data.data?.content ?? '';
+    const links =
+      withLinks && data.data?.links
+        ? Object.entries(data.data.links)
+            .slice(0, 200)
+            .map(([text, href]) => ({ text, href }))
+        : undefined;
+    return {
+      url: data.data?.url ?? url,
+      title: data.data?.title ?? null,
+      truncated: content.length > maxChars,
+      content: content.slice(0, maxChars),
+      ...(links ? { links } : {}),
+    };
+  },
+});
+
+// ─── webSearch ───────────────────────────────────────────────────────────────
+
+export interface SearchHit {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+type SearchProvider = 'firecrawl' | 'brave' | 'serper' | 'tavily';
+
+async function searchFirecrawl(query: string, limit: number): Promise<SearchHit[]> {
+  const res = await fetch('https://api.firecrawl.dev/v1/search', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${envValue('FIRECRAWL_API_KEY')}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, limit }),
+  });
+  if (!res.ok) await fail(res, 'Firecrawl search');
+  const data = (await res.json()) as {
+    data?: Array<{ title?: string; url: string; description?: string }>;
+  };
+  return (data.data ?? []).map((r) => ({
+    title: r.title ?? r.url,
+    url: r.url,
+    snippet: r.description ?? '',
+  }));
+}
+
+async function searchBrave(query: string, limit: number): Promise<SearchHit[]> {
+  const res = await fetch(
+    `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${limit}`,
+    {
+      headers: {
+        'X-Subscription-Token': envValue('BRAVE_SEARCH_API_KEY') as string,
+        Accept: 'application/json',
+      },
+    }
+  );
+  if (!res.ok) await fail(res, 'Brave search');
+  const data = (await res.json()) as {
+    web?: { results?: Array<{ title: string; url: string; description?: string }> };
+  };
+  return (data.web?.results ?? []).map((r) => ({
+    title: r.title,
+    url: r.url,
+    snippet: r.description ?? '',
+  }));
+}
+
+async function searchSerper(query: string, limit: number): Promise<SearchHit[]> {
+  const res = await fetch('https://google.serper.dev/search', {
+    method: 'POST',
+    headers: {
+      'X-API-KEY': envValue('SERPER_API_KEY') as string,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ q: query, num: limit }),
+  });
+  if (!res.ok) await fail(res, 'Serper search');
+  const data = (await res.json()) as {
+    organic?: Array<{ title: string; link: string; snippet?: string }>;
+  };
+  return (data.organic ?? []).map((r) => ({
+    title: r.title,
+    url: r.link,
+    snippet: r.snippet ?? '',
+  }));
+}
+
+async function searchTavily(query: string, limit: number): Promise<SearchHit[]> {
+  const res = await fetch('https://api.tavily.com/search', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${envValue('TAVILY_API_KEY')}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, max_results: limit }),
+  });
+  if (!res.ok) await fail(res, 'Tavily search');
+  const data = (await res.json()) as {
+    results?: Array<{ title: string; url: string; content?: string }>;
+  };
+  return (data.results ?? []).map((r) => ({
+    title: r.title,
+    url: r.url,
+    snippet: r.content ?? '',
+  }));
+}
+
+const SEARCH_PROVIDERS: Array<
+  [SearchProvider, string, (q: string, l: number) => Promise<SearchHit[]>]
+> = [
+  ['firecrawl', 'FIRECRAWL_API_KEY', searchFirecrawl],
+  ['brave', 'BRAVE_SEARCH_API_KEY', searchBrave],
+  ['serper', 'SERPER_API_KEY', searchSerper],
+  ['tavily', 'TAVILY_API_KEY', searchTavily],
+];
+
+export const webSearch = tool({
+  description:
+    'Search the web through the first configured provider (Firecrawl, Brave, Serper or Tavily) and return normalised results (title, url, snippet).',
+  inputSchema: jsonSchema<{ query: string; limit?: number; provider?: SearchProvider }>({
+    type: 'object',
+    properties: {
+      query: { type: 'string' },
+      limit: { type: 'integer', description: '1–20 results (default 8)', default: 8 },
+      provider: {
+        type: 'string',
+        enum: ['firecrawl', 'brave', 'serper', 'tavily'],
+        description: 'Force a provider',
+      },
+    },
+    required: ['query'],
+    additionalProperties: false,
+  }),
+  async execute({ query, limit = 8, provider }) {
+    const chosen = provider
+      ? SEARCH_PROVIDERS.find(([p]) => p === provider)
+      : SEARCH_PROVIDERS.find(([, key]) => envValue(key));
+    if (!chosen || !envValue(chosen[1])) {
+      throw new Error(
+        'No search provider configured. Set FIRECRAWL_API_KEY, BRAVE_SEARCH_API_KEY, SERPER_API_KEY or TAVILY_API_KEY.'
+      );
+    }
+    const results = await chosen[2](query, Math.min(20, Math.max(1, limit)));
+    return { provider: chosen[0], query, results };
+  },
+});
+
+// ─── askPerplexity ───────────────────────────────────────────────────────────
+
+export const askPerplexity = tool({
+  description:
+    'Ask Perplexity (sonar) a research question and get a sourced answer with citations.',
+  inputSchema: jsonSchema<{
+    question: string;
+    model?: string;
+    recency?: 'day' | 'week' | 'month' | 'year';
+  }>({
+    type: 'object',
+    properties: {
+      question: { type: 'string' },
+      model: {
+        type: 'string',
+        description: 'sonar (default), sonar-pro, sonar-reasoning',
+        default: 'sonar',
+      },
+      recency: {
+        type: 'string',
+        enum: ['day', 'week', 'month', 'year'],
+        description: 'Restrict sources to recent content',
+      },
+    },
+    required: ['question'],
+    additionalProperties: false,
+  }),
+  async execute({ question, model = 'sonar', recency }) {
+    const key = envValue('PERPLEXITY_API_KEY');
+    if (!key) throw new Error('PERPLEXITY_API_KEY is required.');
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: question }],
+        ...(recency ? { search_recency_filter: recency } : {}),
+      }),
+    });
+    if (!res.ok) await fail(res, 'Perplexity');
+    const data = (await res.json()) as {
+      choices: Array<{ message: { content: string } }>;
+      citations?: string[];
+    };
+    return {
+      model,
+      answer: data.choices[0]?.message.content ?? '',
+      citations: data.citations ?? [],
+    };
+  },
+});
+
+// ─── Internet Archive ────────────────────────────────────────────────────────
+
+interface WaybackClosest {
+  url: string;
+  timestamp: string;
+  status: string;
+}
+
+async function waybackAvailability(
+  url: string,
+  timestamp?: string
+): Promise<WaybackClosest | null | 'retry'> {
+  const q = new URLSearchParams({ url });
+  if (timestamp) q.set('timestamp', timestamp);
+  const res = await fetch(`https://archive.org/wayback/available?${q.toString()}`, {
+    headers: { 'User-Agent': 'tpmjs-web-research/0.1 (+https://tpmjs.com)' },
+  });
+  if (res.status === 429 || res.status >= 500) return 'retry';
+  if (!res.ok) await fail(res, 'Wayback availability');
+  const data = (await res.json()) as {
+    archived_snapshots?: { closest?: { url: string; timestamp: string; status: string } };
+  };
+  const c = data.archived_snapshots?.closest;
+  return c ? { url: c.url, timestamp: c.timestamp, status: c.status } : null;
+}
+
+/** CDX index fallback — slower but not subject to the availability API's tight rate limit. */
+async function waybackCdx(url: string, timestamp?: string): Promise<WaybackClosest | null> {
+  const q = new URLSearchParams({
+    url,
+    output: 'json',
+    limit: '1',
+    fl: 'timestamp,original,statuscode',
+    filter: 'statuscode:200',
+  });
+  if (timestamp) {
+    q.set('from', timestamp.slice(0, 8));
+    q.set('sort', 'closest');
+    q.set('closest', timestamp);
+  } else {
+    q.set('sort', 'closest');
+    q.set('closest', '99991231');
+  }
+  const res = await fetch(`https://web.archive.org/cdx/search/cdx?${q.toString()}`, {
+    headers: { 'User-Agent': 'tpmjs-web-research/0.1 (+https://tpmjs.com)' },
+  });
+  if (!res.ok) await fail(res, 'Wayback CDX');
+  const rows = (await res.json()) as string[][];
+  const hit = rows[1];
+  if (!hit) return null;
+  const [ts, original, status] = hit;
+  return {
+    url: `https://web.archive.org/web/${ts}/${original}`,
+    timestamp: ts ?? '',
+    status: status ?? '200',
+  };
+}
+
+export const waybackSnapshot = tool({
+  description:
+    'Find the closest Wayback Machine snapshot of a URL, optionally near a date (YYYYMMDD). Use it to read pages that are gone or paywalled.',
+  inputSchema: jsonSchema<{ url: string; timestamp?: string }>({
+    type: 'object',
+    properties: {
+      url: { type: 'string' },
+      timestamp: { type: 'string', description: 'Preferred time as YYYYMMDD or YYYYMMDDhhmmss' },
+    },
+    required: ['url'],
+    additionalProperties: false,
+  }),
+  async execute({ url, timestamp }) {
+    let closest = await waybackAvailability(url, timestamp);
+    if (closest === 'retry') {
+      await new Promise((r) => setTimeout(r, 1500));
+      closest = await waybackAvailability(url, timestamp);
+    }
+    const resolved = closest === 'retry' ? await waybackCdx(url, timestamp) : closest;
+    return resolved
+      ? {
+          found: true,
+          snapshotUrl: resolved.url,
+          timestamp: resolved.timestamp,
+          status: resolved.status,
+          readableUrl: `https://r.jina.ai/${resolved.url}`,
+        }
+      : {
+          found: false,
+          snapshotUrl: null,
+          hint: `No snapshot; try https://web.archive.org/save/${url} to capture one.`,
+        };
+  },
+});
+
+const first = (v: unknown): string | null =>
+  v === undefined || v === null ? null : Array.isArray(v) ? String(v[0] ?? '') : String(v);
+
+function toArchiveItem(d: Record<string, unknown>) {
+  const id = String(d.identifier);
+  return {
+    identifier: id,
+    title: String(d.title ?? ''),
+    creator: Array.isArray(d.creator) ? d.creator.join('; ') : first(d.creator),
+    date: first(d.date),
+    mediatype: String(d.mediatype ?? ''),
+    description: first(d.description)?.slice(0, 300) ?? null,
+    url: `https://archive.org/details/${id}`,
+    fullTextUrl: d.mediatype === 'texts' ? `https://archive.org/stream/${id}/${id}_djvu.txt` : null,
+  };
+}
+
+export const archiveSearch = tool({
+  description:
+    'Search the Internet Archive catalog (books, texts, audio, video, web collections) and return items with identifiers, dates and links.',
+  inputSchema: jsonSchema<{ query: string; limit?: number; mediatype?: string }>({
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Lucene-style query, e.g. "Mossman 1890 subject:Queensland"',
+      },
+      limit: { type: 'integer', description: '1–50 (default 15)', default: 15 },
+      mediatype: {
+        type: 'string',
+        description: 'texts | audio | movies | image | software | data',
+      },
+    },
+    required: ['query'],
+    additionalProperties: false,
+  }),
+  async execute({ query, limit = 15, mediatype }) {
+    const q = mediatype ? `(${query}) AND mediatype:${mediatype}` : query;
+    const params = new URLSearchParams({
+      q,
+      rows: String(Math.min(50, Math.max(1, limit))),
+      output: 'json',
+    });
+    for (const f of ['identifier', 'title', 'creator', 'date', 'mediatype', 'description'])
+      params.append('fl[]', f);
+    params.append('sort[]', 'downloads desc');
+    const res = await fetch(`https://archive.org/advancedsearch.php?${params.toString()}`);
+    if (!res.ok) await fail(res, 'archive.org search');
+    const data = (await res.json()) as {
+      response?: { numFound: number; docs: Array<Record<string, unknown>> };
+    };
+    return {
+      totalFound: data.response?.numFound ?? 0,
+      items: (data.response?.docs ?? []).map(toArchiveItem),
+    };
+  },
+});

--- a/packages/tools/official/web-research/tsconfig.json
+++ b/packages/tools/official/web-research/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tpmjs/tsconfig/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tools/official/x/CHANGELOG.md
+++ b/packages/tools/official/x/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-x
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/tools/official/x/README.md
+++ b/packages/tools/official/x/README.md
@@ -1,0 +1,48 @@
+# @tpmjs/tools-x
+
+Post to X (Twitter) as yourself: tweets with media, threads, replies, delete, read mentions and search — OAuth 1.0a user context.
+
+Part of the **ajax weapons** set: task-level, provider-agnostic tools that an agent can pick up without learning a vendor API. Credentials come from the environment; on tpmjs add them as collection env vars (the collection owner's calls get them injected, everyone else supplies their own).
+
+## Installation
+
+```bash
+npm install @tpmjs/tools-x
+```
+
+## Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `X_API_KEY` | yes | X app API key (consumer key); TWITTER_API_KEY is accepted as an alias |
+| `X_API_SECRET` | yes | X app API secret; TWITTER_API_SECRET alias |
+| `X_ACCESS_TOKEN` | yes | User access token; TWITTER_ACCESS_TOKEN alias |
+| `X_ACCESS_SECRET` | yes | User access token secret; TWITTER_ACCESS_SECRET alias |
+
+## Tools
+
+| Export | What it does |
+| --- | --- |
+| `tweet` | Post a tweet, optionally as a reply or quote, with up to 4 images attached from URLs. |
+| `tweetThread` | Post a thread: each text becomes a reply to the previous tweet. |
+| `deleteTweet` | Delete one of your tweets by id. |
+| `getTweet` | Fetch a tweet by id with author, metrics and referenced tweets. |
+| `myMentions` | Read recent tweets that mention the authenticated account. |
+| `searchTweets` | Search recent tweets (last 7 days) with the X search syntax. |
+| `xWhoAmI` | Show which X account the configured credentials belong to — use it to verify setup. |
+
+## Usage
+
+```typescript
+import { tweet, xWhoAmI } from '@tpmjs/tools-x';
+
+const ctx = { toolCallId: 'c1', messages: [] };
+console.log(await xWhoAmI.execute({}, ctx));
+await tweet.execute({ text: 'Shipped a thing.', mediaUrls: ['https://example.com/shot.png'] }, ctx);
+```
+
+Every tool throws a readable error on provider failures (status code + provider message), so agents can react instead of guessing.
+
+## License
+
+MIT

--- a/packages/tools/official/x/package.json
+++ b/packages/tools/official/x/package.json
@@ -1,0 +1,104 @@
+{
+  "name": "@tpmjs/tools-x",
+  "version": "0.1.0",
+  "description": "Post to X (Twitter) as yourself: tweets with media, threads, replies, delete, read mentions and search \u2014 OAuth 1.0a user context",
+  "type": "module",
+  "keywords": [
+    "tpmjs",
+    "communication",
+    "twitter",
+    "x",
+    "tweet",
+    "social"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --sourcemap --logLevel warn",
+    "dev": "tsdown --sourcemap --watch",
+    "type-check": "tsc --checkers 1 --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@tpmjs/tsconfig": "workspace:*",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "ai": "6.0.49"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tpmjs/tpmjs.git",
+    "directory": "packages/tools/official/x"
+  },
+  "homepage": "https://tpmjs.com",
+  "license": "MIT",
+  "tpmjs": {
+    "category": "communication",
+    "frameworks": [
+      "vercel-ai"
+    ],
+    "env": [
+      {
+        "name": "X_API_KEY",
+        "description": "X app API key (consumer key); TWITTER_API_KEY is accepted as an alias",
+        "required": true
+      },
+      {
+        "name": "X_API_SECRET",
+        "description": "X app API secret; TWITTER_API_SECRET alias",
+        "required": true
+      },
+      {
+        "name": "X_ACCESS_TOKEN",
+        "description": "User access token; TWITTER_ACCESS_TOKEN alias",
+        "required": true
+      },
+      {
+        "name": "X_ACCESS_SECRET",
+        "description": "User access token secret; TWITTER_ACCESS_SECRET alias",
+        "required": true
+      }
+    ],
+    "tools": [
+      {
+        "name": "tweet",
+        "description": "Post a tweet, optionally as a reply or quote, with up to 4 images attached from URLs."
+      },
+      {
+        "name": "tweetThread",
+        "description": "Post a thread: each text becomes a reply to the previous tweet."
+      },
+      {
+        "name": "deleteTweet",
+        "description": "Delete one of your tweets by id."
+      },
+      {
+        "name": "getTweet",
+        "description": "Fetch a tweet by id with author, metrics and referenced tweets."
+      },
+      {
+        "name": "myMentions",
+        "description": "Read recent tweets that mention the authenticated account."
+      },
+      {
+        "name": "searchTweets",
+        "description": "Search recent tweets (last 7 days) with the X search syntax."
+      },
+      {
+        "name": "xWhoAmI",
+        "description": "Show which X account the configured credentials belong to \u2014 use it to verify setup."
+      }
+    ]
+  }
+}

--- a/packages/tools/official/x/src/index.ts
+++ b/packages/tools/official/x/src/index.ts
@@ -1,0 +1,392 @@
+/**
+ * @tpmjs/tools-x — post to X (Twitter) as yourself.
+ *
+ * OAuth 1.0a user-context signing (HMAC-SHA1 via WebCrypto, no dependencies) against the
+ * X API v2 for tweets and the v1.1 media endpoint for image uploads. Works on the free
+ * API tier for posting/deleting/whoami; mentions and search need the Basic tier and
+ * return a clear error otherwise.
+ *
+ * @env X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_SECRET (TWITTER_* aliases accepted)
+ */
+
+import { jsonSchema, tool } from 'ai';
+
+interface Creds {
+  apiKey: string;
+  apiSecret: string;
+  accessToken: string;
+  accessSecret: string;
+}
+
+function envValue(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = globalThis.process?.env?.[name];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function creds(): Creds {
+  const c = {
+    apiKey: envValue('X_API_KEY', 'TWITTER_API_KEY'),
+    apiSecret: envValue('X_API_SECRET', 'TWITTER_API_SECRET'),
+    accessToken: envValue('X_ACCESS_TOKEN', 'TWITTER_ACCESS_TOKEN'),
+    accessSecret: envValue('X_ACCESS_SECRET', 'TWITTER_ACCESS_SECRET'),
+  };
+  const missing = Object.entries(c)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missing.length) {
+    throw new Error(
+      `X credentials missing: ${missing.join(', ')} (X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_SECRET or their TWITTER_* aliases).`
+    );
+  }
+  return c as Creds;
+}
+
+// ─── OAuth 1.0a ──────────────────────────────────────────────────────────────
+
+const rfc3986 = (s: string): string =>
+  encodeURIComponent(s).replace(
+    /[!'()*]/g,
+    (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+
+function nonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function hmacSha1Base64(key: string, data: string): Promise<string> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(key),
+    { name: 'HMAC', hash: 'SHA-1' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(data));
+  return btoa(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+/** Authorization header for a request whose body is JSON or multipart (body excluded from the base string). */
+async function oauthHeader(
+  method: string,
+  url: string,
+  query: Record<string, string> = {}
+): Promise<string> {
+  const c = creds();
+  const oauth: Record<string, string> = {
+    oauth_consumer_key: c.apiKey,
+    oauth_nonce: nonce(),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    oauth_token: c.accessToken,
+    oauth_version: '1.0',
+  };
+  const params = { ...oauth, ...query };
+  const paramString = Object.keys(params)
+    .sort()
+    .map((k) => `${rfc3986(k)}=${rfc3986(params[k] as string)}`)
+    .join('&');
+  const base = [method.toUpperCase(), rfc3986(url), rfc3986(paramString)].join('&');
+  const signingKey = `${rfc3986(c.apiSecret)}&${rfc3986(c.accessSecret)}`;
+  oauth.oauth_signature = await hmacSha1Base64(signingKey, base);
+  return `OAuth ${Object.keys(oauth)
+    .sort()
+    .map((k) => `${rfc3986(k)}="${rfc3986(oauth[k] as string)}"`)
+    .join(', ')}`;
+}
+
+async function xFetch<T>(
+  method: string,
+  url: string,
+  options: { query?: Record<string, string>; json?: unknown; form?: FormData } = {}
+): Promise<T> {
+  const query = options.query ?? {};
+  const qs = new URLSearchParams(query).toString();
+  const headers: Record<string, string> = { Authorization: await oauthHeader(method, url, query) };
+  let body: BodyInit | undefined;
+  if (options.json !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(options.json);
+  } else if (options.form) {
+    body = options.form;
+  }
+  const res = await fetch(qs ? `${url}?${qs}` : url, { method, headers, body });
+  const text = await res.text();
+  if (!res.ok) {
+    const hint =
+      res.status === 402 || res.status === 403
+        ? ' (this endpoint needs a paid X API tier, or the app lacks the right permission)'
+        : res.status === 429
+          ? ' (rate limited — wait and retry)'
+          : '';
+    throw new Error(
+      `X ${method} ${url.replace('https://api.x.com/2', '')} failed: ${res.status}${hint}${text ? ` — ${text.slice(0, 300)}` : ''}`
+    );
+  }
+  return (text ? JSON.parse(text) : {}) as T;
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const V2 = 'https://api.x.com/2';
+
+interface TweetData {
+  id: string;
+  text: string;
+  author_id?: string;
+  created_at?: string;
+  public_metrics?: Record<string, number>;
+  referenced_tweets?: Array<{ type: string; id: string }>;
+}
+interface UserData {
+  id: string;
+  username: string;
+  name: string;
+}
+
+let me: UserData | null = null;
+async function whoami(): Promise<UserData> {
+  if (me) return me;
+  const res = await xFetch<{ data: UserData }>('GET', `${V2}/users/me`);
+  me = res.data;
+  return me;
+}
+
+async function uploadMedia(url: string): Promise<string> {
+  const download = await fetch(url);
+  if (!download.ok) throw new Error(`Could not download media ${url}: ${download.status}`);
+  const blob = await download.blob();
+  if (blob.size > 5 * 1024 * 1024)
+    throw new Error(`Media ${url} is ${Math.round(blob.size / 1024)} KB; images must be ≤ 5 MB.`);
+  const form = new FormData();
+  form.append('media', blob, 'upload');
+  const res = await xFetch<{ media_id_string: string }>(
+    'POST',
+    'https://upload.twitter.com/1.1/media/upload.json',
+    { form }
+  );
+  return res.media_id_string;
+}
+
+async function postTweet(
+  text: string,
+  options: { replyTo?: string; quoteTweetId?: string; mediaUrls?: string[] } = {}
+): Promise<{ id: string; text: string; url: string }> {
+  if (text.length > 280 && !options.mediaUrls) {
+    // X counts weighted characters; 280 is the safe ceiling for plain text.
+    throw new Error(`Tweet is ${text.length} chars; the limit is 280.`);
+  }
+  const mediaIds = options.mediaUrls?.length
+    ? await Promise.all(options.mediaUrls.slice(0, 4).map(uploadMedia))
+    : undefined;
+  const body: Record<string, unknown> = { text };
+  if (options.replyTo) body.reply = { in_reply_to_tweet_id: options.replyTo };
+  if (options.quoteTweetId) body.quote_tweet_id = options.quoteTweetId;
+  if (mediaIds) body.media = { media_ids: mediaIds };
+  const res = await xFetch<{ data: { id: string; text: string } }>('POST', `${V2}/tweets`, {
+    json: body,
+  });
+  const user = await whoami().catch(() => null);
+  return {
+    id: res.data.id,
+    text: res.data.text,
+    url: `https://x.com/${user?.username ?? 'i'}/status/${res.data.id}`,
+  };
+}
+
+const TWEET_FIELDS = 'created_at,public_metrics,author_id,referenced_tweets,conversation_id';
+
+// ─── tools ───────────────────────────────────────────────────────────────────
+
+export const xWhoAmI = tool({
+  description:
+    'Show which X account the configured credentials belong to — use it to verify setup before posting.',
+  inputSchema: jsonSchema<Record<string, never>>({
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  }),
+  async execute(): Promise<UserData & { url: string }> {
+    const user = await whoami();
+    return { ...user, url: `https://x.com/${user.username}` };
+  },
+});
+
+export const tweet = tool({
+  description:
+    'Post a tweet, optionally as a reply or quote, with up to 4 images attached from URLs. Returns the tweet id and URL.',
+  inputSchema: jsonSchema<{
+    text: string;
+    replyTo?: string;
+    quoteTweetId?: string;
+    mediaUrls?: string[];
+  }>({
+    type: 'object',
+    properties: {
+      text: { type: 'string', description: 'Tweet text (≤ 280 characters)' },
+      replyTo: { type: 'string', description: 'Tweet id to reply to' },
+      quoteTweetId: { type: 'string', description: 'Tweet id to quote' },
+      mediaUrls: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Up to 4 image URLs to attach (≤ 5 MB each)',
+      },
+    },
+    required: ['text'],
+    additionalProperties: false,
+  }),
+  async execute({ text, replyTo, quoteTweetId, mediaUrls }) {
+    return postTweet(text, { replyTo, quoteTweetId, mediaUrls });
+  },
+});
+
+export const tweetThread = tool({
+  description:
+    'Post a thread: each text becomes a reply to the previous tweet. Returns every tweet id and the thread URL.',
+  inputSchema: jsonSchema<{ tweets: string[]; mediaUrls?: string[] }>({
+    type: 'object',
+    properties: {
+      tweets: {
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 1,
+        description: 'Tweet texts in order',
+      },
+      mediaUrls: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Images attached to the first tweet',
+      },
+    },
+    required: ['tweets'],
+    additionalProperties: false,
+  }),
+  async execute({ tweets, mediaUrls }) {
+    const posted: Array<{ id: string; text: string; url: string }> = [];
+    for (const [i, text] of tweets.entries()) {
+      const prev = posted[posted.length - 1];
+      posted.push(
+        await postTweet(text, { replyTo: prev?.id, mediaUrls: i === 0 ? mediaUrls : undefined })
+      );
+    }
+    return { count: posted.length, url: posted[0]?.url ?? null, tweets: posted };
+  },
+});
+
+export const deleteTweet = tool({
+  description: 'Delete one of your tweets by id.',
+  inputSchema: jsonSchema<{ id: string }>({
+    type: 'object',
+    properties: { id: { type: 'string' } },
+    required: ['id'],
+    additionalProperties: false,
+  }),
+  async execute({ id }) {
+    const res = await xFetch<{ data: { deleted: boolean } }>('DELETE', `${V2}/tweets/${id}`);
+    return { id, deleted: res.data.deleted };
+  },
+});
+
+export const getTweet = tool({
+  description: 'Fetch a tweet by id with author, metrics and referenced tweets.',
+  inputSchema: jsonSchema<{ id: string }>({
+    type: 'object',
+    properties: { id: { type: 'string' } },
+    required: ['id'],
+    additionalProperties: false,
+  }),
+  async execute({ id }) {
+    const res = await xFetch<{ data: TweetData; includes?: { users?: UserData[] } }>(
+      'GET',
+      `${V2}/tweets/${id}`,
+      {
+        query: {
+          'tweet.fields': TWEET_FIELDS,
+          expansions: 'author_id',
+          'user.fields': 'username,name',
+        },
+      }
+    );
+    const author = res.includes?.users?.[0];
+    return {
+      ...res.data,
+      author: author ? { username: author.username, name: author.name } : null,
+      url: `https://x.com/${author?.username ?? 'i'}/status/${res.data.id}`,
+    };
+  },
+});
+
+export const myMentions = tool({
+  description:
+    'Read recent tweets that mention the authenticated account (needs the Basic API tier).',
+  inputSchema: jsonSchema<{ limit?: number }>({
+    type: 'object',
+    properties: { limit: { type: 'integer', description: '5–100 (default 20)', default: 20 } },
+    additionalProperties: false,
+  }),
+  async execute({ limit = 20 }) {
+    const user = await whoami();
+    const res = await xFetch<{ data?: TweetData[]; includes?: { users?: UserData[] } }>(
+      'GET',
+      `${V2}/users/${user.id}/mentions`,
+      {
+        query: {
+          max_results: String(Math.min(100, Math.max(5, limit))),
+          'tweet.fields': TWEET_FIELDS,
+          expansions: 'author_id',
+          'user.fields': 'username,name',
+        },
+      }
+    );
+    const users = new Map((res.includes?.users ?? []).map((u) => [u.id, u]));
+    return {
+      mentions: (res.data ?? []).map((t) => ({
+        ...t,
+        author: users.get(t.author_id ?? '')?.username ?? null,
+        url: `https://x.com/i/status/${t.id}`,
+      })),
+    };
+  },
+});
+
+export const searchTweets = tool({
+  description:
+    'Search recent tweets (last 7 days) with the X search syntax, e.g. "from:user keyword -is:retweet" (needs the Basic API tier).',
+  inputSchema: jsonSchema<{ query: string; limit?: number }>({
+    type: 'object',
+    properties: {
+      query: { type: 'string' },
+      limit: { type: 'integer', description: '10–100 (default 20)', default: 20 },
+    },
+    required: ['query'],
+    additionalProperties: false,
+  }),
+  async execute({ query, limit = 20 }) {
+    const res = await xFetch<{ data?: TweetData[]; includes?: { users?: UserData[] } }>(
+      'GET',
+      `${V2}/tweets/search/recent`,
+      {
+        query: {
+          query,
+          max_results: String(Math.min(100, Math.max(10, limit))),
+          'tweet.fields': TWEET_FIELDS,
+          expansions: 'author_id',
+          'user.fields': 'username,name',
+        },
+      }
+    );
+    const users = new Map((res.includes?.users ?? []).map((u) => [u.id, u]));
+    return {
+      query,
+      tweets: (res.data ?? []).map((t) => ({
+        ...t,
+        author: users.get(t.author_id ?? '')?.username ?? null,
+        url: `https://x.com/i/status/${t.id}`,
+      })),
+    };
+  },
+});

--- a/packages/tools/official/x/tsconfig.json
+++ b/packages/tools/official/x/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tpmjs/tsconfig/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1417,6 +1417,19 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  packages/tools/official/discord-chat:
+    dependencies:
+      ai:
+        specifier: 6.0.49
+        version: 6.0.49(zod@4.4.3)
+    devDependencies:
+      '@tpmjs/tsconfig':
+        specifier: workspace:*
+        version: link:../../../config/tsconfig
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   packages/tools/official/dpia-outline:
     dependencies:
       ai:
@@ -1802,6 +1815,19 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  packages/tools/official/image-gen:
+    dependencies:
+      ai:
+        specifier: 6.0.49
+        version: 6.0.49(zod@4.4.3)
+    devDependencies:
+      '@tpmjs/tsconfig':
+        specifier: workspace:*
+        version: link:../../../config/tsconfig
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   packages/tools/official/interview-questions:
     dependencies:
       ai:
@@ -2003,6 +2029,19 @@ importers:
         version: '@typescript/typescript6@6.0.2'
 
   packages/tools/official/logistic-regression:
+    dependencies:
+      ai:
+        specifier: 6.0.49
+        version: 6.0.49(zod@4.4.3)
+    devDependencies:
+      '@tpmjs/tsconfig':
+        specifier: workspace:*
+        version: link:../../../config/tsconfig
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  packages/tools/official/mail:
     dependencies:
       ai:
         specifier: 6.0.49
@@ -3486,6 +3525,19 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  packages/tools/official/web-research:
+    dependencies:
+      ai:
+        specifier: 6.0.49
+        version: 6.0.49(zod@4.4.3)
+    devDependencies:
+      '@tpmjs/tsconfig':
+        specifier: workspace:*
+        version: link:../../../config/tsconfig
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   packages/tools/official/workflow-auto-repair:
     dependencies:
       ai:
@@ -3539,6 +3591,19 @@ importers:
         version: '@typescript/typescript6@6.0.2'
 
   packages/tools/official/workflow-variant-generate:
+    dependencies:
+      ai:
+        specifier: 6.0.49
+        version: 6.0.49(zod@4.4.3)
+    devDependencies:
+      '@tpmjs/tsconfig':
+        specifier: workspace:*
+        version: link:../../../config/tsconfig
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  packages/tools/official/x:
     dependencies:
       ai:
         specifier: 6.0.49


### PR DESCRIPTION
## Summary
Five new official packages that model *tasks* rather than vendor APIs — credentials from env, provider auto-detected (or forced), readable provider errors, plain `fetch` everywhere:

- **@tpmjs/tools-mail** — `sendEmail` via Resend / Postmark / SendGrid / Mailgun
- **@tpmjs/tools-discord-chat** — `discordChannels`, `discordRead`, `discordCatchUp` (everything since "24h" across channels), `discordPost` (bot, or webhook fallback), `discordReact`; channels addressed by name
- **@tpmjs/tools-x** — `tweet` (images from URLs), `tweetThread`, `deleteTweet`, `getTweet`, `myMentions`, `searchTweets`, `xWhoAmI`; OAuth 1.0a user context via WebCrypto, no deps
- **@tpmjs/tools-image-gen** — `generateImage` across fal / Replicate / OpenAI gpt-image-1 / Gemini Imagen, with Discord-webhook delivery so base64 results come back as durable URLs; `describeImage` (vision)
- **@tpmjs/tools-web-research** — `readPage` (Jina reader), `webSearch` (Firecrawl / Brave / Serper / Tavily), `askPerplexity`, `waybackSnapshot` (availability API with retry + CDX fallback), `archiveSearch`

## Test plan
- [x] biome / build / type-check / publint clean for all five
- [x] Live run with real credentials: email delivered (Resend), Discord list/read/catch-up/post/react, X whoami + signed requests (reads 402 on a credit-less account, as expected), image generated via OpenAI and delivered to Discord, readPage / webSearch / askPerplexity / archiveSearch
- [ ] First publish of each new name is a one-time maintainer publish (trusted publishing can't bootstrap new names); then add to the `ajax-weapons` collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)