### PR TITLE
fix(tools): no module-level caches in discord-chat / x (shared executor process); docs: warn tool authors

### DIFF
--- a/docs/guides/publish-a-tool.md
+++ b/docs/guides/publish-a-tool.md
@@ -277,6 +277,10 @@ Consequences for authors:
 - Tools that need credentials should fail fast when the env var is missing (as the examples above do) — that is what keeps the health check side-effect free.
 - A tool that can perform a side effect **without** a credential will be executed for real. Declare a safe configuration per tool in `tpmjs.tools[].healthCheck`: `{ "skipExecution": true }` to import-only, or `{ "testParams": { ... }, "cleanup": [ ... ] }` for a known-safe call (string values may use `{{timestamp}}`).
 
+## Tools run in a shared process — never cache across calls
+
+The executor keeps one instance of your module per package version and serves every caller from it (any user, any collection). Anything you store at module scope — a memoised API response, a resolved account id, a client built from `process.env` at import time — is visible to the next caller, who may not be the same person. Read credentials from `process.env` **inside** `execute()` on every call and keep per-call state inside the call. The executor restores injected env vars after each execution and serializes executions, but it cannot un-share your module's variables.
+
 ## Quality Score
 
 Your tool's quality score is computed by `calculateQualityScore` in `apps/web/src/app/api/sync/metrics/route.ts`:

--- a/packages/tools/official/discord-chat/CHANGELOG.md
+++ b/packages/tools/official/discord-chat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tpmjs/tools-discord-chat
 
+## 0.1.1
+
+### Patch Changes
+
+- Remove module-level caches: the tpmjs executor shares one module instance across callers, so cached data could leak between users of a public collection.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/tools/official/discord-chat/package.json
+++ b/packages/tools/official/discord-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpmjs/tools-discord-chat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Read and post in Discord the way a person does: channels by name, catch up on what happened since a time, post or reply, react \u2014 bot token or plain webhook",
   "type": "module",
   "keywords": [

--- a/packages/tools/official/discord-chat/src/index.ts
+++ b/packages/tools/official/discord-chat/src/index.ts
@@ -95,10 +95,9 @@ async function listGuilds(): Promise<RawGuild[]> {
   return api<RawGuild[]>('GET', '/users/@me/guilds');
 }
 
-let channelCache: { at: number; channels: ChannelInfo[] } | null = null;
-
+// No module-level memoisation: the executor shares one module instance across callers,
+// so anything cached here would leak one caller's data to the next.
 async function allChannels(): Promise<ChannelInfo[]> {
-  if (channelCache && Date.now() - channelCache.at < 60_000) return channelCache.channels;
   const guilds = await listGuilds();
   const out: ChannelInfo[] = [];
   for (const guild of guilds) {
@@ -115,7 +114,6 @@ async function allChannels(): Promise<ChannelInfo[]> {
       });
     }
   }
-  channelCache = { at: Date.now(), channels: out };
   return out;
 }
 

--- a/packages/tools/official/x/CHANGELOG.md
+++ b/packages/tools/official/x/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tpmjs/tools-x
 
+## 0.1.1
+
+### Patch Changes
+
+- Remove module-level caches: the tpmjs executor shares one module instance across callers, so cached data could leak between users of a public collection.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/tools/official/x/package.json
+++ b/packages/tools/official/x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpmjs/tools-x",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Post to X (Twitter) as yourself: tweets with media, threads, replies, delete, read mentions and search \u2014 OAuth 1.0a user context",
   "type": "module",
   "keywords": [

--- a/packages/tools/official/x/src/index.ts
+++ b/packages/tools/official/x/src/index.ts
@@ -148,12 +148,10 @@ interface UserData {
   name: string;
 }
 
-let me: UserData | null = null;
+// Not memoised at module scope: the executor shares one module instance across callers.
 async function whoami(): Promise<UserData> {
-  if (me) return me;
   const res = await xFetch<{ data: UserData }>('GET', `${V2}/users/me`);
-  me = res.data;
-  return me;
+  return res.data;
 }
 
 async function uploadMedia(url: string): Promise<string> {


### PR DESCRIPTION
The executor serves every caller from one module instance per package version, so a
memoised channel list (discord-chat) or resolved account (x) was visible to the next
caller of a public collection. Both are now fetched per call; the publishing guide
explains the shared-process rule.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
