### PR TITLE
feat(ham): export temporal recall tool

### DIFF
--- a/packages/tools/official/ham/README.md
+++ b/packages/tools/official/ham/README.md
@@ -57,7 +57,7 @@ so the agent sees them.
 
 | Export | HAM tool |
 | --- | --- |
-| `remember`, `recall`, `recallDeep`, `recallSequence`, `context`, `recent`, `changes`, `get` | memory retrieval and storage |
+| `remember`, `recall`, `recallDeep`, `recallSequence`, `recallTemporal`, `context`, `recent`, `changes`, `get` | memory retrieval and storage |
 | `supersede`, `retract`, `link`, `links`, `unlink`, `reflect` | lifecycle and typed relations |
 | `ask`, `inbox`, `message`, `reply`, `staleMessage` | directed agent messages |
 | `handoff`, `claimHandoff`, `completeHandoff` | structured handoffs |

--- a/packages/tools/official/ham/package.json
+++ b/packages/tools/official/ham/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tpmjs/tools-ham",
-  "version": "0.1.1",
-  "description": "HAM shared agent memory tools for AI agents \u2014 remember/recall/context, directed messages, handoffs, task board, typed links, supersede/retract, projects and repository mirroring",
+  "version": "0.2.0",
+  "description": "HAM shared agent memory tools for AI agents — remember/recall/context, directed messages, handoffs, task board, typed links, supersede/retract, projects and repository mirroring",
   "type": "module",
   "keywords": [
     "tpmjs",
@@ -136,6 +136,10 @@
       {
         "name": "recallSequence",
         "description": "Retrieve a deterministic chronological window around one scoped memory anchor."
+      },
+      {
+        "name": "recallTemporal",
+        "description": "Recall memory at an exact valid, known, or event time. Hydrates visible supersession chains and exposes a bounded rotor-resonance diagnostic; exact timestamps and validity intervals remain authoritative."
       },
       {
         "name": "recent",

--- a/packages/tools/official/ham/scripts/catalog.json
+++ b/packages/tools/official/ham/scripts/catalog.json
@@ -5,12 +5,22 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "content": { "type": "string", "description": "The memory content to store" },
-        "title": { "type": "string", "description": "Short title for the memory" },
+        "content": {
+          "type": "string",
+          "description": "The memory content to store"
+        },
+        "title": {
+          "type": "string",
+          "description": "Short title for the memory"
+        },
         "cues": {
           "type": "array",
           "maxItems": 32,
-          "items": { "type": "string", "minLength": 1, "maxLength": 200 },
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
           "description": "Exact agent-authored anchors for multi-hop retrieval; omitted means no cues"
         },
         "type": {
@@ -31,16 +41,46 @@
         },
         "scopes": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Shared scopes such as shared, project:ham, or repo:MonumentalSystems/ham"
         },
-        "project": { "type": "string" },
-        "repo": { "type": "string" },
-        "task": { "type": "string" },
-        "thread": { "type": "string" },
+        "project": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "thread": {
+          "type": "string"
+        },
         "sequence": {
           "type": "string",
           "description": "Explicit temporal lane; thread is used only as a compatibility fallback"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Event time; defaults to ingestion time"
+        },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the evidence was observed; defaults to ingestion time"
+        },
+        "valid_from": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start of the claim's real-world validity; defaults to event time"
+        },
+        "valid_to": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Optional exclusive end of the claim's real-world validity"
         },
         "status": {
           "type": "string",
@@ -51,7 +91,11 @@
           "enum": ["ephemeral", "short", "project", "durable", "foundational"],
           "description": "Expected lifetime: debug/session, bug/deploy state, project state, architecture, or enduring invariant"
         },
-        "visibility": { "type": "string", "enum": ["shared", "private"], "default": "shared" },
+        "visibility": {
+          "type": "string",
+          "enum": ["shared", "private"],
+          "default": "shared"
+        },
         "idempotency_key": {
           "type": "string",
           "description": "Stable retry key to prevent duplicate writes"
@@ -62,7 +106,9 @@
           "items": {
             "type": "object",
             "properties": {
-              "target_id": { "type": "integer" },
+              "target_id": {
+                "type": "integer"
+              },
               "relation": {
                 "type": "string",
                 "enum": ["cites", "verifies", "contradicts", "depends-on"]
@@ -150,6 +196,71 @@
         { "required": ["query"], "not": { "required": ["anchor_id"] } },
         { "required": ["anchor_id"], "not": { "required": ["query"] } }
       ]
+    }
+  },
+  {
+    "name": "ham_recall_temporal",
+    "description": "Recall memory at an exact valid, known, or event time. Hydrates visible supersession chains and exposes a bounded rotor-resonance diagnostic; exact timestamps and validity intervals remain authoritative.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Natural language search query"
+        },
+        "as_of": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["valid_at", "known_at", "event_before", "event_after", "event_near"],
+          "default": "valid_at",
+          "description": "valid_at asks when a claim was true; known_at asks what HAM knew; event modes rank events around the anchor"
+        },
+        "include_history": {
+          "type": "boolean",
+          "default": true
+        },
+        "rotor_weight": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 0.2,
+          "default": 0.05
+        },
+        "top_k": {
+          "type": "integer",
+          "default": 5
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "project": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_agents": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["query", "as_of"]
     }
   },
   {
@@ -641,36 +752,99 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "summary": { "type": "string" },
-        "completed": { "type": "array", "items": { "type": "string" } },
-        "next_steps": { "type": "array", "items": { "type": "string" } },
-        "blockers": { "type": "array", "items": { "type": "string" } },
-        "files": { "type": "array", "items": { "type": "string" } },
-        "branch": { "type": "string" },
+        "summary": {
+          "type": "string"
+        },
+        "completed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "next_steps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blockers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "branch": {
+          "type": "string"
+        },
         "cues": {
           "type": "array",
           "maxItems": 32,
-          "items": { "type": "string", "minLength": 1, "maxLength": 200 },
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
           "description": "Exact agent-authored anchors; omitted means no cues"
         },
-        "scopes": { "type": "array", "items": { "type": "string" } },
-        "project": { "type": "string" },
-        "repo": { "type": "string" },
-        "task": { "type": "string" },
-        "thread": { "type": "string" },
-        "sequence": { "type": "string" },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "project": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "thread": {
+          "type": "string"
+        },
+        "sequence": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "valid_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "valid_to": {
+          "type": "string",
+          "format": "date-time"
+        },
         "durability": {
           "type": "string",
           "enum": ["ephemeral", "short", "project", "durable", "foundational"],
           "default": "short"
         },
-        "idempotency_key": { "type": "string" },
+        "idempotency_key": {
+          "type": "string"
+        },
         "links": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "target_id": { "type": "integer" },
+              "target_id": {
+                "type": "integer"
+              },
               "relation": {
                 "type": "string",
                 "enum": ["cites", "verifies", "contradicts", "depends-on"]
@@ -716,36 +890,87 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "memory_id": { "type": "integer" },
-        "expected_version": { "type": "integer" },
-        "content": { "type": "string" },
-        "title": { "type": "string" },
-        "reason": { "type": "string" },
-        "type": { "type": "string" },
+        "memory_id": {
+          "type": "integer"
+        },
+        "expected_version": {
+          "type": "integer"
+        },
+        "content": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
         "cues": {
           "type": "array",
           "maxItems": 32,
-          "items": { "type": "string", "minLength": 1, "maxLength": 200 },
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
           "description": "Omit to inherit the superseded memory's authored cues; send an empty list to clear them deliberately."
         },
-        "scopes": { "type": "array", "items": { "type": "string" } },
-        "project": { "type": "string" },
-        "repo": { "type": "string" },
-        "task": { "type": "string" },
-        "thread": { "type": "string" },
-        "sequence": { "type": "string" },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "project": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "thread": {
+          "type": "string"
+        },
+        "sequence": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "valid_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "valid_to": {
+          "type": "string",
+          "format": "date-time"
+        },
         "durability": {
           "type": "string",
           "enum": ["ephemeral", "short", "project", "durable", "foundational"]
         },
-        "idempotency_key": { "type": "string" },
+        "idempotency_key": {
+          "type": "string"
+        },
         "links": {
           "type": "array",
           "description": "Typed relations from the replacement memory to existing memory IDs",
           "items": {
             "type": "object",
             "properties": {
-              "target_id": { "type": "integer" },
+              "target_id": {
+                "type": "integer"
+              },
               "relation": {
                 "type": "string",
                 "enum": ["cites", "verifies", "contradicts", "depends-on"]

--- a/packages/tools/official/ham/src/catalog.ts
+++ b/packages/tools/official/ham/src/catalog.ts
@@ -240,6 +240,22 @@ export const HAM_TOOL_CATALOG: readonly HamToolSpec[] = [
         sequence: {
           type: 'string',
         },
+        timestamp: {
+          type: 'string',
+          format: 'date-time',
+        },
+        observed_at: {
+          type: 'string',
+          format: 'date-time',
+        },
+        valid_from: {
+          type: 'string',
+          format: 'date-time',
+        },
+        valid_to: {
+          type: 'string',
+          format: 'date-time',
+        },
         durability: {
           type: 'string',
           enum: ['ephemeral', 'short', 'project', 'durable', 'foundational'],
@@ -637,6 +653,73 @@ export const HAM_TOOL_CATALOG: readonly HamToolSpec[] = [
     },
   },
   {
+    name: 'ham_recall_temporal',
+    description:
+      'Recall memory at an exact valid, known, or event time. Hydrates visible supersession chains and exposes a bounded rotor-resonance diagnostic; exact timestamps and validity intervals remain authoritative.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Natural language search query',
+        },
+        as_of: {
+          type: 'string',
+          format: 'date-time',
+        },
+        mode: {
+          type: 'string',
+          enum: ['valid_at', 'known_at', 'event_before', 'event_after', 'event_near'],
+          default: 'valid_at',
+          description:
+            'valid_at asks when a claim was true; known_at asks what HAM knew; event modes rank events around the anchor',
+        },
+        include_history: {
+          type: 'boolean',
+          default: true,
+        },
+        rotor_weight: {
+          type: 'number',
+          minimum: 0,
+          maximum: 0.2,
+          default: 0.05,
+        },
+        top_k: {
+          type: 'integer',
+          default: 5,
+        },
+        scopes: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        project: {
+          type: 'string',
+        },
+        repo: {
+          type: 'string',
+        },
+        task: {
+          type: 'string',
+        },
+        types: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        source_agents: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+      required: ['query', 'as_of'],
+    },
+  },
+  {
     name: 'ham_recent',
     description:
       'See recent shared work, decisions, blockers, and handoffs in the active project/repo/task context.',
@@ -801,6 +884,26 @@ export const HAM_TOOL_CATALOG: readonly HamToolSpec[] = [
         sequence: {
           type: 'string',
           description: 'Explicit temporal lane; thread is used only as a compatibility fallback',
+        },
+        timestamp: {
+          type: 'string',
+          format: 'date-time',
+          description: 'Event time; defaults to ingestion time',
+        },
+        observed_at: {
+          type: 'string',
+          format: 'date-time',
+          description: 'When the evidence was observed; defaults to ingestion time',
+        },
+        valid_from: {
+          type: 'string',
+          format: 'date-time',
+          description: "Start of the claim's real-world validity; defaults to event time",
+        },
+        valid_to: {
+          type: 'string',
+          format: 'date-time',
+          description: "Optional exclusive end of the claim's real-world validity",
         },
         status: {
           type: 'string',
@@ -1055,6 +1158,22 @@ export const HAM_TOOL_CATALOG: readonly HamToolSpec[] = [
         },
         sequence: {
           type: 'string',
+        },
+        timestamp: {
+          type: 'string',
+          format: 'date-time',
+        },
+        observed_at: {
+          type: 'string',
+          format: 'date-time',
+        },
+        valid_from: {
+          type: 'string',
+          format: 'date-time',
+        },
+        valid_to: {
+          type: 'string',
+          format: 'date-time',
         },
         durability: {
           type: 'string',

--- a/packages/tools/official/ham/src/index.ts
+++ b/packages/tools/official/ham/src/index.ts
@@ -72,6 +72,9 @@ export const recallDeep = hamTool('ham_recall_deep');
 /** Retrieve a deterministic chronological window around one scoped memory anchor. */
 export const recallSequence = hamTool('ham_recall_sequence');
 
+/** Recall memory at an exact valid, known, or event time. Hydrates visible supersession chains and exposes a bounded rotor-resonance diagnostic; exact timestamps and validity intervals remain authoritative. */
+export const recallTemporal = hamTool('ham_recall_temporal');
+
 /** See recent shared work, decisions, blockers, and handoffs in the active project/repo/task context. */
 export const recent = hamTool('ham_recent');
 


### PR DESCRIPTION
## Summary

- regenerate `@tpmjs/tools-ham` from the HAM temporal-addressing catalog
- export `recallTemporal` and include the canonical `ham_recall_temporal` input schema
- refresh temporal fields on `remember`, `handoff`, and `supersede`
- bump the package to `0.2.0` and document the new export

## Source and staging gate

Source: [MonumentalSystems/ham#85](https://github.com/MonumentalSystems/ham/pull/85) at exact commit `28a4a6e90d7f54d70d16c86fd312112413f6e7b3`.

The exact commit was deployed to a dedicated HAM staging application only. Staging `/api` reported that exact `build_sha` with `temporal_addressing: true`; HAM production was not changed.

- deterministic temporal benchmark: 11/11 checks, accuracy 1.0, 9 samples
- latency: p50 33.060 ms, p95/max 36.208 ms
- fixture cleanup: 7/7 deleted, 0 failures
- real MCP SDK: v2.0.0, protocol `2026-07-28`, server `0.13.0-dev`
- MCP catalog parity: local 39, remote 39; `ham_recall_temporal` present
- one read-only `ham_recall_temporal` call succeeded with `isError: false`
- catalog delta: 38 -> 39, added `ham_recall_temporal`, removed none; expected schema changes only on `ham_handoff`, `ham_remember`, and `ham_supersede`

Sanitized evidence SHA-256:

- temporal benchmark: `6A47D8547E88C6E1027976728A0FAC463858297102CB6272514C30FB07BF44D2`
- MCP verification: `B572955275DDE22B40F282757F236C15A5F4F362DDB86558A14E0B1779764034`

## Validation

- generator determinism check
- package typecheck
- package build
- Biome format/lint checks
- built-package runtime assertion: `recallTemporal` exported, 39 catalog entries, required args `query` and `as_of`
- repository pre-commit hook passed: secret scan, format, lint, package typecheck

The full monorepo pre-push suite was also attempted. It stopped in unrelated `@tpmjs/web` tests (three scenario quota assertions and one `ToolSurfaceSwitcher` module-resolution failure); no changed file is in `apps/web`.

## Release note

This PR does not publish to npm. Publishing remains gated on [#192](https://github.com/tpmjs/tpmjs/issues/192), the existing trusted-publisher setup issue.