### PR TITLE
feat(tools): @tpmjs/tools-youtube — upload and manage videos on your own channel

### DIFF
--- a/packages/tools/official/youtube/CHANGELOG.md
+++ b/packages/tools/official/youtube/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tpmjs/tools-youtube
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release.

--- a/packages/tools/official/youtube/README.md
+++ b/packages/tools/official/youtube/README.md
@@ -1,0 +1,87 @@
+# @tpmjs/tools-youtube
+
+Upload and manage videos on your own YouTube channel: resumable uploads straight from a URL (continued across calls for long files), processing status, metadata updates, thumbnails, playlists, categories — plus the two one-time tools that mint the credential.
+
+Part of the **ajax weapons** set: task-level tools an agent can pick up without learning a vendor API. Credentials come from the environment; on tpmjs add them as collection env vars (the collection owner's calls get them injected, everyone else supplies their own).
+
+## Installation
+
+```bash
+npm install @tpmjs/tools-youtube
+```
+
+## Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `YOUTUBE_CLIENT_ID` | yes | Google OAuth client id — a **Desktop app** client with the YouTube Data API v3 enabled |
+| `YOUTUBE_CLIENT_SECRET` | yes | Google OAuth client secret |
+| `YOUTUBE_REFRESH_TOKEN` | yes | Refresh token for the channel owner, minted once (see below) |
+| `YOUTUBE_ACCESS_TOKEN` | no | A short-lived access token, if you manage tokens yourself (skips the refresh flow) |
+
+`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are accepted as aliases.
+
+### One-time setup (about five minutes)
+
+1. In [console.cloud.google.com](https://console.cloud.google.com) create (or pick) a project, enable **YouTube Data API v3**, configure the OAuth consent screen (External is fine — add yourself as a test user, and **publish** the app so the refresh token does not expire after 7 days), then create an OAuth client of type **Desktop app**. Note the client id and secret.
+2. With `YOUTUBE_CLIENT_ID` / `YOUTUBE_CLIENT_SECRET` set, call **`youtubeAuthUrl`**, open the URL as the Google account that owns the channel and approve. The browser lands on `http://localhost:8765/callback?code=…` (the page may say it cannot be reached — that is fine). Copy the `code` parameter.
+3. Call **`youtubeExchangeCode`** with that code; store the returned `refreshToken` as `YOUTUBE_REFRESH_TOKEN`. Treat it like a password — it grants full control of the channel.
+
+## Tools
+
+| Export | What it does |
+| --- | --- |
+| `youtubeAuthUrl` | Setup step 1: build the Google consent URL for this OAuth client. |
+| `youtubeExchangeCode` | Setup step 2: exchange the consent code for the long-lived refresh token. |
+| `myChannel` | The channel these credentials control: id, title, handle, subscriber/video/view counts, uploads playlist. |
+| `uploadVideo` | Upload a video from a direct URL in resumable 8 MiB chunks; optional playlist + thumbnail; continues across calls. |
+| `videoStatus` | Upload/processing status, privacy, schedule, failure reasons and stats for one video. |
+| `myVideos` | Recent uploads, newest first, with privacy, processing state and counts. |
+| `updateVideo` | Change title, description, tags, category, privacy, schedule or made-for-kids; untouched fields are preserved. |
+| `setThumbnail` | Set a custom thumbnail from an image URL (JPEG/PNG ≤ 2 MB; phone-verified channel required). |
+| `myPlaylists` | Your playlists with ids, privacy and item counts. |
+| `addToPlaylist` | Add a video to a playlist. |
+| `deleteVideo` | Permanently delete a video (irreversible). |
+| `videoCategories` | Assignable category ids for a region. |
+
+## Usage
+
+```typescript
+import { uploadVideo, videoStatus, myVideos } from '@tpmjs/tools-youtube';
+
+const ctx = { toolCallId: 'c1', messages: [] };
+
+let result = await uploadVideo.execute(
+  {
+    videoUrl: 'https://files.example.com/talk.mp4',
+    title: 'Building a paraconsistent substrate',
+    description: 'Recorded 2026-08-22.',
+    tags: ['donto', 'knowledge graphs'],
+    privacy: 'unlisted',
+    playlistId: 'PL…',
+  },
+  ctx
+);
+// Long file? Keep calling with the returned session until it says "uploaded".
+while (result.status === 'in_progress') {
+  result = await uploadVideo.execute({ videoUrl: 'https://files.example.com/talk.mp4', sessionUri: result.sessionUri }, ctx);
+}
+await videoStatus.execute({ videoId: result.videoId }, ctx); // poll until processingStatus === 'succeeded'
+```
+
+### Long uploads
+
+`uploadVideo` streams the file from `videoUrl` and sends it to YouTube in 8 MiB resumable chunks. Each call works within a time budget (`maxSeconds`, default 75 s — under Cloudflare's 100 s limit for MCP calls, at most 280 s). When the budget runs out it returns `status: "in_progress"` with the upload `sessionUri` and how many bytes are done; call again with the same `videoUrl` and that `sessionUri` and it resumes exactly where it stopped (the session stays valid for about a day). Transient 5xx errors on a chunk are retried from the offset YouTube confirms it kept.
+
+## Things YouTube enforces (not this package)
+
+- **Un-audited API projects upload as private.** Until your Google Cloud project passes the [YouTube API Services compliance audit](https://support.google.com/youtube/contact/yt_api_form), any video uploaded through the API is locked to *private* regardless of the privacy you asked for. The result's `notes` says so when it happens; flip the video in YouTube Studio or complete the audit.
+- **Quota:** the Data API gives 10,000 units/day by default; an upload costs 1,600, so roughly six uploads a day plus a few hundred reads. Errors carry the `quotaExceeded` reason.
+- **Consent screen in "Testing"** → refresh tokens expire after 7 days. Publish the app.
+- **Custom thumbnails** need a phone-verified channel.
+
+Every tool throws a readable error on failures (HTTP status, Google's reason code, the message, and a hint), so agents can react instead of guessing.
+
+## License
+
+MIT

--- a/packages/tools/official/youtube/package.json
+++ b/packages/tools/official/youtube/package.json
@@ -1,0 +1,126 @@
+{
+  "name": "@tpmjs/tools-youtube",
+  "version": "0.1.0",
+  "description": "Upload and manage videos on your own YouTube channel: resumable uploads from a URL (continued across calls), status, updates, thumbnails, playlists — headless OAuth with a refresh token",
+  "type": "module",
+  "keywords": [
+    "tpmjs",
+    "communication",
+    "youtube",
+    "video",
+    "upload",
+    "publishing"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --sourcemap --logLevel warn",
+    "dev": "tsdown --sourcemap --watch",
+    "test": "vitest run",
+    "type-check": "tsc --checkers 1 --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@tpmjs/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "^4.0.16"
+  },
+  "dependencies": {
+    "ai": "6.0.49"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tpmjs/tpmjs.git",
+    "directory": "packages/tools/official/youtube"
+  },
+  "homepage": "https://tpmjs.com",
+  "license": "MIT",
+  "tpmjs": {
+    "category": "communication",
+    "frameworks": [
+      "vercel-ai"
+    ],
+    "env": [
+      {
+        "name": "YOUTUBE_CLIENT_ID",
+        "description": "Google OAuth client id (a \"Desktop app\" client with the YouTube Data API v3 enabled)",
+        "required": true
+      },
+      {
+        "name": "YOUTUBE_CLIENT_SECRET",
+        "description": "Google OAuth client secret",
+        "required": true
+      },
+      {
+        "name": "YOUTUBE_REFRESH_TOKEN",
+        "description": "Refresh token for the channel owner, minted once with youtubeAuthUrl → youtubeExchangeCode",
+        "required": true
+      },
+      {
+        "name": "YOUTUBE_ACCESS_TOKEN",
+        "description": "Optional short-lived access token used instead of the refresh-token flow",
+        "required": false
+      }
+    ],
+    "tools": [
+      {
+        "name": "youtubeAuthUrl",
+        "description": "One-time setup step 1: build the Google consent URL that authorises this OAuth client to manage your channel."
+      },
+      {
+        "name": "youtubeExchangeCode",
+        "description": "One-time setup step 2: exchange the consent code for the long-lived refresh token to store as YOUTUBE_REFRESH_TOKEN."
+      },
+      {
+        "name": "myChannel",
+        "description": "Show the channel these credentials control: id, title, handle, subscriber/video/view counts, uploads playlist."
+      },
+      {
+        "name": "uploadVideo",
+        "description": "Upload a video from a URL in resumable chunks; long files continue across calls via the returned sessionUri. Optional playlist and thumbnail."
+      },
+      {
+        "name": "videoStatus",
+        "description": "Upload/processing status, privacy, schedule, failure reasons and stats for one of your videos."
+      },
+      {
+        "name": "myVideos",
+        "description": "List your most recent uploads with privacy, processing state and view/like/comment counts."
+      },
+      {
+        "name": "updateVideo",
+        "description": "Change title, description, tags, category, privacy, schedule or made-for-kids on a video; untouched fields are preserved."
+      },
+      {
+        "name": "setThumbnail",
+        "description": "Set a custom thumbnail on a video from an image URL (≤ 2 MB)."
+      },
+      {
+        "name": "myPlaylists",
+        "description": "List your playlists with ids, privacy and item counts."
+      },
+      {
+        "name": "addToPlaylist",
+        "description": "Add a video to one of your playlists."
+      },
+      {
+        "name": "deleteVideo",
+        "description": "Permanently delete one of your videos (irreversible)."
+      },
+      {
+        "name": "videoCategories",
+        "description": "List the assignable YouTube category ids for a region."
+      }
+    ]
+  }
+}

--- a/packages/tools/official/youtube/src/index.test.ts
+++ b/packages/tools/official/youtube/src/index.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import mod, {
+  CHUNK_BYTES,
+  chunkStream,
+  extractVideoId,
+  myChannel,
+  uploadVideo,
+  videoStatus,
+} from './index.js';
+
+const ctx = { toolCallId: 'test', messages: [] };
+const SOURCE = 'https://files.test/clip.mp4';
+const SESSION = 'https://upload.test/session/abc';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const UPLOAD_VIDEOS = 'https://www.googleapis.com/upload/youtube/v3/videos';
+const API_VIDEOS = 'https://www.googleapis.com/youtube/v3/videos';
+
+interface Call {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  bodyLength?: number;
+  bodyText?: string;
+}
+
+interface SessionState {
+  uploaded: number;
+  done: boolean;
+  /** Fail the Nth data PUT (1-based) once with 503. */
+  failPut?: number;
+  /** Pretend the server only kept this many bytes of the failed chunk. */
+  keepOnFail?: number;
+}
+
+interface MockOptions {
+  sourceBytes: number;
+  announceLength?: boolean;
+  contentType?: string;
+  session?: Partial<SessionState>;
+  finalPrivacy?: string;
+  advanceClockPerPutMs?: number;
+}
+
+function bytesOf(n: number): ReadableStream<Uint8Array> {
+  let sent = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= n) {
+        controller.close();
+        return;
+      }
+      const size = Math.min(1_000_003, n - sent); // odd piece size so chunks never align
+      controller.enqueue(new Uint8Array(size));
+      sent += size;
+    },
+  });
+}
+
+function headerMap(init?: RequestInit): Record<string, string> {
+  const out: Record<string, string> = {};
+  const h = init?.headers;
+  if (!h) return out;
+  if (h instanceof Headers) for (const [k, v] of h) out[k.toLowerCase()] = v;
+  else if (Array.isArray(h)) for (const [k, v] of h) out[k.toLowerCase()] = v;
+  else for (const [k, v] of Object.entries(h)) out[k.toLowerCase()] = v as string;
+  return out;
+}
+
+function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+function recordCall(calls: Call[], input: string | URL | Request, init?: RequestInit): Call {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  const method = (init?.method ?? 'GET').toUpperCase();
+  const call: Call = { method, url, headers: headerMap(init) };
+  const body = init?.body;
+  if (body instanceof Uint8Array) call.bodyLength = body.length;
+  else if (typeof body === 'string') call.bodyText = body;
+  else if (body instanceof URLSearchParams) call.bodyText = body.toString();
+  calls.push(call);
+  return call;
+}
+
+function sourceResponse(opts: MockOptions, headers: Record<string, string>): Response {
+  const h: Record<string, string> = { 'content-type': opts.contentType ?? 'video/mp4' };
+  const range = headers.range;
+  const start = range ? Number(/bytes=(\d+)-/.exec(range)?.[1] ?? 0) : 0;
+  if (range) h['content-range'] = `bytes ${start}-${opts.sourceBytes - 1}/${opts.sourceBytes}`;
+  if (opts.announceLength !== false) h['content-length'] = String(opts.sourceBytes - start);
+  return new Response(bytesOf(opts.sourceBytes - start), { status: range ? 206 : 200, headers: h });
+}
+
+interface SessionMock {
+  state: SessionState;
+  dataPuts: number;
+  videoJson: () => unknown;
+}
+
+function sessionStatusResponse(mock: SessionMock): Response {
+  if (mock.state.done) return json(mock.videoJson());
+  const h: Record<string, string> = {};
+  if (mock.state.uploaded > 0) h.range = `bytes=0-${mock.state.uploaded - 1}`;
+  return new Response(null, { status: 308, headers: h });
+}
+
+function sessionDataResponse(
+  mock: SessionMock,
+  contentRange: string,
+  bodyLength: number
+): Response {
+  const m = /bytes (\d+)-(\d+)\/(\d+|\*)/.exec(contentRange);
+  if (!m) return new Response('bad content-range', { status: 400 });
+  const start = Number(m[1]);
+  const end = Number(m[2]);
+  const total = m[3];
+  if (end - start + 1 !== bodyLength) {
+    return new Response(`length mismatch ${bodyLength}`, { status: 400 });
+  }
+  if (start !== mock.state.uploaded) {
+    return new Response(`offset ${start} != ${mock.state.uploaded}`, { status: 400 });
+  }
+  mock.dataPuts += 1;
+  if (mock.state.failPut === mock.dataPuts) {
+    mock.state.failPut = undefined;
+    mock.state.uploaded = start + (mock.state.keepOnFail ?? 0);
+    return new Response('backend error', { status: 503 });
+  }
+  mock.state.uploaded = end + 1;
+  if (total !== '*' && end + 1 === Number(total)) {
+    mock.state.done = true;
+    return json(mock.videoJson());
+  }
+  return new Response(null, {
+    status: 308,
+    headers: { range: `bytes=0-${mock.state.uploaded - 1}` },
+  });
+}
+
+function videosGetResponse(): Response {
+  return json({
+    items: [
+      {
+        id: 'vid123',
+        snippet: {
+          title: 'My clip',
+          description: 'd',
+          publishedAt: '2026-08-22T00:00:00Z',
+          tags: ['a'],
+        },
+        status: { uploadStatus: 'processed', privacyStatus: 'unlisted' },
+        processingDetails: { processingStatus: 'succeeded' },
+        statistics: { viewCount: '12', likeCount: '3', commentCount: '1' },
+        contentDetails: { duration: 'PT1M2S' },
+      },
+    ],
+  });
+}
+
+function installMock(opts: MockOptions): { calls: Call[]; session: SessionState } {
+  const calls: Call[] = [];
+  const mock: SessionMock = {
+    state: { uploaded: 0, done: false, ...opts.session },
+    dataPuts: 0,
+    videoJson: () => ({
+      id: 'vid123',
+      snippet: { title: 'My clip', publishedAt: '2026-08-22T00:00:00Z' },
+      status: { uploadStatus: 'uploaded', privacyStatus: opts.finalPrivacy ?? 'private' },
+    }),
+  };
+
+  const sessionResponse = (call: Call): Response => {
+    if (opts.advanceClockPerPutMs) vi.setSystemTime(Date.now() + opts.advanceClockPerPutMs);
+    const contentRange = call.headers['content-range'] ?? '';
+    if (contentRange.startsWith('bytes */')) return sessionStatusResponse(mock);
+    return sessionDataResponse(mock, contentRange, call.bodyLength ?? 0);
+  };
+
+  const routes: Array<[(call: Call) => boolean, (call: Call) => Response]> = [
+    [(c) => c.url === TOKEN_URL, () => json({ access_token: 'tok', expires_in: 3600 })],
+    [(c) => c.url === SOURCE, (c) => sourceResponse(opts, c.headers)],
+    [
+      (c) => c.method === 'POST' && c.url.startsWith(`${UPLOAD_VIDEOS}?`),
+      () => new Response(null, { status: 200, headers: { location: SESSION } }),
+    ],
+    [(c) => c.method === 'PUT' && c.url === SESSION, sessionResponse],
+    [(c) => c.method === 'GET' && c.url.startsWith(`${API_VIDEOS}?`), () => videosGetResponse()],
+  ];
+
+  const handler = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const call = recordCall(calls, input, init);
+    const route = routes.find(([matches]) => matches(call));
+    return route
+      ? route[1](call)
+      : new Response(`unmocked ${call.method} ${call.url}`, { status: 599 });
+  };
+
+  vi.stubGlobal('fetch', vi.fn(handler));
+  return { calls, session: mock.state };
+}
+
+const dataPutsOf = (calls: Call[]) =>
+  calls.filter(
+    (c) =>
+      c.url === SESSION && c.method === 'PUT' && !c.headers['content-range']?.startsWith('bytes */')
+  );
+
+describe('@tpmjs/tools-youtube', () => {
+  beforeEach(() => {
+    process.env.YOUTUBE_CLIENT_ID = 'cid';
+    process.env.YOUTUBE_CLIENT_SECRET = 'csecret';
+    process.env.YOUTUBE_REFRESH_TOKEN = 'rtoken';
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    delete process.env.YOUTUBE_CLIENT_ID;
+    delete process.env.YOUTUBE_CLIENT_SECRET;
+    delete process.env.YOUTUBE_REFRESH_TOKEN;
+  });
+
+  it('exports 12 well-formed tools', () => {
+    const names = Object.keys(mod);
+    expect(names).toHaveLength(12);
+    for (const name of names) {
+      const t = (
+        mod as Record<string, { execute?: unknown; description?: unknown; inputSchema?: unknown }>
+      )[name];
+      expect(typeof t?.execute, name).toBe('function');
+      expect(typeof t?.description, name).toBe('string');
+      expect(t?.inputSchema, name).toBeTruthy();
+    }
+  });
+
+  it('fails with a readable message when credentials are missing', async () => {
+    delete process.env.YOUTUBE_REFRESH_TOKEN;
+    installMock({ sourceBytes: 10 });
+    await expect(myChannel.execute!({}, ctx)).rejects.toThrow(/YOUTUBE_REFRESH_TOKEN/);
+  });
+
+  it('extracts video ids from the usual URL shapes', () => {
+    expect(extractVideoId('abc123')).toBe('abc123');
+    expect(extractVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=3')).toBe('dQw4w9WgXcQ');
+    expect(extractVideoId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    expect(extractVideoId('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  describe('chunkStream', () => {
+    const pieces = (...sizes: number[]) =>
+      new ReadableStream<Uint8Array>({
+        start(c) {
+          for (const s of sizes) c.enqueue(new Uint8Array(s));
+          c.close();
+        },
+      });
+    const collect = async (stream: ReadableStream<Uint8Array>, size: number) => {
+      const out: Array<[number, boolean]> = [];
+      for await (const c of chunkStream(stream, size)) out.push([c.bytes.length, c.last]);
+      return out;
+    };
+
+    it('emits fixed chunks and a non-empty final chunk', async () => {
+      expect(await collect(pieces(4, 4, 4, 4, 1), 10)).toEqual([
+        [10, false],
+        [7, true],
+      ]);
+    });
+    it('never sends the last bytes as a non-final chunk when the size divides evenly', async () => {
+      expect(await collect(pieces(20), 10)).toEqual([
+        [10, false],
+        [10, true],
+      ]);
+      expect(await collect(pieces(10), 10)).toEqual([[10, true]]);
+    });
+  });
+
+  describe('uploadVideo', () => {
+    const SIZE = 2 * CHUNK_BYTES + 12_345;
+
+    it('uploads a known-length file in 8 MiB chunks with exact Content-Range headers', async () => {
+      const { calls } = installMock({ sourceBytes: SIZE });
+      const result = (await uploadVideo.execute!(
+        { videoUrl: SOURCE, title: 'My clip', tags: ['t'], privacy: 'private' },
+        ctx
+      )) as Record<string, unknown>;
+      expect(result.status).toBe('uploaded');
+      expect(result.videoId).toBe('vid123');
+      expect(result.url).toBe('https://www.youtube.com/watch?v=vid123');
+
+      const init = calls.find(
+        (c) => c.method === 'POST' && c.url.includes('/upload/youtube/v3/videos')
+      );
+      expect(init?.url).toContain('uploadType=resumable');
+      expect(init?.url).toContain('notifySubscribers=true');
+      expect(init?.headers['x-upload-content-length']).toBe(String(SIZE));
+      expect(init?.headers['x-upload-content-type']).toBe('video/mp4');
+      expect(JSON.parse(init?.bodyText ?? '{}')).toMatchObject({
+        snippet: { title: 'My clip', tags: ['t'] },
+        status: { privacyStatus: 'private', selfDeclaredMadeForKids: false },
+      });
+
+      const puts = dataPutsOf(calls);
+      expect(puts.map((p) => p.headers['content-range'])).toEqual([
+        `bytes 0-${CHUNK_BYTES - 1}/${SIZE}`,
+        `bytes ${CHUNK_BYTES}-${2 * CHUNK_BYTES - 1}/${SIZE}`,
+        `bytes ${2 * CHUNK_BYTES}-${SIZE - 1}/${SIZE}`,
+      ]);
+      expect(puts.map((p) => p.bodyLength)).toEqual([CHUNK_BYTES, CHUNK_BYTES, 12_345]);
+    });
+
+    it('handles an unknown-length source by closing with the exact total on the last chunk', async () => {
+      const { calls } = installMock({ sourceBytes: SIZE, announceLength: false });
+      const result = (await uploadVideo.execute!({ videoUrl: SOURCE, title: 'x' }, ctx)) as Record<
+        string,
+        unknown
+      >;
+      expect(result.status).toBe('uploaded');
+      const ranges = dataPutsOf(calls).map((p) => p.headers['content-range']);
+      expect(ranges[0]).toBe(`bytes 0-${CHUNK_BYTES - 1}/*`);
+      expect(ranges[2]).toBe(`bytes ${2 * CHUNK_BYTES}-${SIZE - 1}/${SIZE}`);
+    });
+
+    it('pauses when the time budget is spent and resumes from the session offset', async () => {
+      vi.useFakeTimers({ toFake: ['Date'] });
+      const first = installMock({ sourceBytes: SIZE, advanceClockPerPutMs: 10_000 });
+      const paused = (await uploadVideo.execute!(
+        { videoUrl: SOURCE, title: 'x', maxSeconds: 5 },
+        ctx
+      )) as Record<string, unknown>;
+      expect(paused.status).toBe('in_progress');
+      expect(paused.sessionUri).toBe(SESSION);
+      expect(paused.uploadedBytes).toBe(CHUNK_BYTES);
+      expect(paused.totalBytes).toBe(SIZE);
+      expect(dataPutsOf(first.calls)).toHaveLength(1);
+      vi.useRealTimers();
+
+      const second = installMock({ sourceBytes: SIZE, session: { uploaded: CHUNK_BYTES } });
+      const done = (await uploadVideo.execute!(
+        { videoUrl: SOURCE, sessionUri: SESSION },
+        ctx
+      )) as Record<string, unknown>;
+      expect(done.status).toBe('uploaded');
+      const sourceFetch = second.calls.find((c) => c.url === SOURCE);
+      expect(sourceFetch?.headers.range).toBe(`bytes=${CHUNK_BYTES}-`);
+      expect(dataPutsOf(second.calls).map((p) => p.headers['content-range'])).toEqual([
+        `bytes ${CHUNK_BYTES}-${2 * CHUNK_BYTES - 1}/${SIZE}`,
+        `bytes ${2 * CHUNK_BYTES}-${SIZE - 1}/${SIZE}`,
+      ]);
+    });
+
+    it('retries a failed chunk from the offset the server actually kept', async () => {
+      const { calls } = installMock({
+        sourceBytes: SIZE,
+        session: { failPut: 2, keepOnFail: 1_048_576 },
+      });
+      const result = (await uploadVideo.execute!({ videoUrl: SOURCE, title: 'x' }, ctx)) as Record<
+        string,
+        unknown
+      >;
+      expect(result.status).toBe('uploaded');
+      const ranges = dataPutsOf(calls).map((p) => p.headers['content-range']);
+      expect(ranges).toEqual([
+        `bytes 0-${CHUNK_BYTES - 1}/${SIZE}`,
+        `bytes ${CHUNK_BYTES}-${2 * CHUNK_BYTES - 1}/${SIZE}`, // fails with 503
+        `bytes ${CHUNK_BYTES + 1_048_576}-${2 * CHUNK_BYTES - 1}/${SIZE}`, // resent remainder
+        `bytes ${2 * CHUNK_BYTES}-${SIZE - 1}/${SIZE}`,
+      ]);
+    }, 15_000);
+
+    it('explains when YouTube downgrades the requested privacy', async () => {
+      installMock({ sourceBytes: 1000, finalPrivacy: 'private' });
+      const result = (await uploadVideo.execute!(
+        { videoUrl: SOURCE, title: 'x', privacy: 'public' },
+        ctx
+      )) as {
+        notes: string[];
+      };
+      expect(result.notes.join(' ')).toMatch(/compliance audit/);
+    });
+
+    it('rejects URLs that are not media files', async () => {
+      installMock({ sourceBytes: 1000, contentType: 'text/html' });
+      await expect(uploadVideo.execute!({ videoUrl: SOURCE, title: 'x' }, ctx)).rejects.toThrow(
+        /does not look like a video/
+      );
+    });
+
+    it('requires a title for a new upload', async () => {
+      installMock({ sourceBytes: 1000 });
+      await expect(uploadVideo.execute!({ videoUrl: SOURCE }, ctx)).rejects.toThrow(
+        /title is required/
+      );
+    });
+  });
+
+  it('videoStatus summarises processing and stats', async () => {
+    installMock({ sourceBytes: 1 });
+    const result = (await videoStatus.execute!(
+      { videoId: 'https://youtu.be/vid123' },
+      ctx
+    )) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      videoId: 'vid123',
+      privacy: 'unlisted',
+      uploadStatus: 'processed',
+      processingStatus: 'succeeded',
+      views: 12,
+      likes: 3,
+      duration: 'PT1M2S',
+    });
+  });
+});

--- a/packages/tools/official/youtube/src/index.ts
+++ b/packages/tools/official/youtube/src/index.ts
@@ -1,0 +1,1223 @@
+/**
+ * @tpmjs/tools-youtube — upload and manage videos on your own YouTube channel.
+ *
+ * YouTube Data API v3 with headless OAuth (a refresh token minted once from your Google
+ * account). No dependencies beyond `ai`. Uploads use the resumable protocol in 8 MiB chunks
+ * streamed straight from a URL, and can be continued across calls: when a call's time
+ * budget runs out it returns the upload session so the next call picks up where it left off.
+ *
+ * @env YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET, YOUTUBE_REFRESH_TOKEN
+ *      (or a short-lived YOUTUBE_ACCESS_TOKEN if you manage tokens yourself)
+ */
+
+import { jsonSchema, tool } from 'ai';
+
+const API = 'https://www.googleapis.com/youtube/v3';
+const UPLOAD = 'https://www.googleapis.com/upload/youtube/v3';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const DEFAULT_REDIRECT = 'http://localhost:8765/callback';
+const DEFAULT_SCOPES = [
+  'https://www.googleapis.com/auth/youtube.upload',
+  'https://www.googleapis.com/auth/youtube.force-ssl',
+];
+/** Resumable chunk size — must be a multiple of 256 KiB. */
+export const CHUNK_BYTES = 8 * 1024 * 1024;
+const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
+const DEFAULT_BUDGET_SECONDS = 75;
+const MAX_BUDGET_SECONDS = 280;
+
+// ─── env + auth ──────────────────────────────────────────────────────────────
+
+function envValue(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = globalThis.process?.env?.[name];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function clientCreds(): { clientId: string; clientSecret: string } {
+  const clientId = envValue('YOUTUBE_CLIENT_ID', 'GOOGLE_CLIENT_ID');
+  const clientSecret = envValue('YOUTUBE_CLIENT_SECRET', 'GOOGLE_CLIENT_SECRET');
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      'YouTube OAuth client missing: set YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET (a "Desktop app" OAuth client from console.cloud.google.com with the YouTube Data API v3 enabled).'
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+interface TokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+async function postToken(params: Record<string, string>): Promise<TokenResponse> {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params),
+  });
+  const text = await res.text();
+  let data: TokenResponse = {};
+  try {
+    data = text ? (JSON.parse(text) as TokenResponse) : {};
+  } catch {
+    data = { error: 'invalid_response', error_description: text.slice(0, 200) };
+  }
+  if (!res.ok) {
+    const hint =
+      data.error === 'invalid_grant'
+        ? ' (the refresh token was revoked or expired — if the OAuth consent screen is still in "Testing", tokens die after 7 days; publish the app, then re-run youtubeAuthUrl / youtubeExchangeCode)'
+        : '';
+    throw new Error(
+      `YouTube OAuth token request failed: ${res.status} ${data.error ?? ''}${data.error_description ? `: ${data.error_description}` : ''}${hint}`
+    );
+  }
+  return data;
+}
+
+/** A fresh access token per call — nothing is cached at module level (tools share one process). */
+async function accessToken(): Promise<string> {
+  const direct = envValue('YOUTUBE_ACCESS_TOKEN');
+  if (direct) return direct;
+  const refreshToken = envValue('YOUTUBE_REFRESH_TOKEN');
+  if (!refreshToken) {
+    throw new Error(
+      'YouTube credentials missing: set YOUTUBE_REFRESH_TOKEN (mint it once with youtubeAuthUrl → youtubeExchangeCode) alongside YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET, or pass a short-lived YOUTUBE_ACCESS_TOKEN.'
+    );
+  }
+  const { clientId, clientSecret } = clientCreds();
+  const data = await postToken({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  });
+  if (!data.access_token) throw new Error('YouTube OAuth refresh returned no access_token.');
+  return data.access_token;
+}
+
+// ─── API client ──────────────────────────────────────────────────────────────
+
+interface GoogleError {
+  error?: {
+    code?: number;
+    message?: string;
+    errors?: Array<{ reason?: string; message?: string; domain?: string }>;
+  };
+}
+
+function describeFailure(method: string, url: string, status: number, text: string): Error {
+  let reason = '';
+  let message = text.slice(0, 300);
+  try {
+    const parsed = JSON.parse(text) as GoogleError;
+    reason = parsed.error?.errors?.[0]?.reason ?? '';
+    message = parsed.error?.message ?? message;
+  } catch {
+    // non-JSON body — keep the raw excerpt
+  }
+  let hint = '';
+  if (status === 401)
+    hint = ' (access token rejected — refresh token revoked/expired or wrong client)';
+  else if (reason === 'quotaExceeded' || reason === 'dailyLimitExceeded')
+    hint =
+      ' (YouTube Data API daily quota exhausted — uploads cost 1,600 of the default 10,000 units/day; resets at midnight Pacific)';
+  else if (reason === 'insufficientPermissions' || reason === 'forbidden')
+    hint =
+      ' (the OAuth grant lacks the needed scope, or the channel cannot do this — e.g. custom thumbnails need a phone-verified channel)';
+  else if (reason === 'uploadLimitExceeded')
+    hint = ' (the channel hit its upload limit for the day)';
+  else if (status === 429) hint = ' (rate limited — wait and retry)';
+  const path = url.replace(API, '').replace(UPLOAD, '/upload').split('?')[0];
+  return new Error(
+    `YouTube ${method} ${path} failed: ${status}${reason ? ` ${reason}` : ''}${hint}${message ? ` — ${message}` : ''}`
+  );
+}
+
+interface FetchOptions {
+  query?: Record<string, string | number | boolean | undefined>;
+  json?: unknown;
+  body?: BodyInit;
+  headers?: Record<string, string>;
+}
+
+function withQuery(url: string, query: FetchOptions['query']): string {
+  if (!query) return url;
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(query)) if (v !== undefined) qs.set(k, String(v));
+  const s = qs.toString();
+  return s ? `${url}?${s}` : url;
+}
+
+async function ytFetch<T>(method: string, url: string, options: FetchOptions = {}): Promise<T> {
+  const token = await accessToken();
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}`, ...options.headers };
+  let body: BodyInit | undefined = options.body;
+  if (options.json !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(options.json);
+  }
+  const res = await fetch(withQuery(url, options.query), { method, headers, body });
+  const text = await res.text();
+  if (!res.ok) throw describeFailure(method, url, res.status, text);
+  return (text ? JSON.parse(text) : {}) as T;
+}
+
+// ─── shapes ──────────────────────────────────────────────────────────────────
+
+interface VideoResource {
+  id: string;
+  snippet?: {
+    title?: string;
+    description?: string;
+    tags?: string[];
+    categoryId?: string;
+    publishedAt?: string;
+    defaultLanguage?: string;
+    thumbnails?: Record<string, { url?: string }>;
+  };
+  status?: {
+    uploadStatus?: string;
+    privacyStatus?: string;
+    publishAt?: string;
+    selfDeclaredMadeForKids?: boolean;
+    failureReason?: string;
+    rejectionReason?: string;
+    embeddable?: boolean;
+    license?: string;
+  };
+  processingDetails?: {
+    processingStatus?: string;
+    processingProgress?: { partsTotal?: string; partsProcessed?: string; timeLeftMs?: string };
+    processingFailureReason?: string;
+  };
+  statistics?: { viewCount?: string; likeCount?: string; commentCount?: string };
+  contentDetails?: { duration?: string; definition?: string };
+}
+
+interface ListResponse<T> {
+  items?: T[];
+  nextPageToken?: string;
+  pageInfo?: { totalResults?: number };
+}
+
+interface ChannelResource {
+  id: string;
+  snippet?: {
+    title?: string;
+    description?: string;
+    customUrl?: string;
+    publishedAt?: string;
+    thumbnails?: Record<string, { url?: string }>;
+  };
+  statistics?: { subscriberCount?: string; videoCount?: string; viewCount?: string };
+  contentDetails?: { relatedPlaylists?: { uploads?: string } };
+}
+
+const videoUrl = (id: string): string => `https://www.youtube.com/watch?v=${id}`;
+const num = (v: string | undefined): number | undefined =>
+  v === undefined ? undefined : Number(v);
+
+function summarizeVideo(v: VideoResource): Record<string, unknown> {
+  return {
+    videoId: v.id,
+    url: videoUrl(v.id),
+    title: v.snippet?.title,
+    publishedAt: v.snippet?.publishedAt,
+    privacy: v.status?.privacyStatus,
+    publishAt: v.status?.publishAt,
+    uploadStatus: v.status?.uploadStatus,
+    processingStatus: v.processingDetails?.processingStatus,
+    failureReason: v.status?.failureReason ?? v.processingDetails?.processingFailureReason,
+    rejectionReason: v.status?.rejectionReason,
+    duration: v.contentDetails?.duration,
+    views: num(v.statistics?.viewCount),
+    likes: num(v.statistics?.likeCount),
+    comments: num(v.statistics?.commentCount),
+    tags: v.snippet?.tags,
+    categoryId: v.snippet?.categoryId,
+    thumbnail: v.snippet?.thumbnails?.high?.url ?? v.snippet?.thumbnails?.default?.url,
+  };
+}
+
+async function myChannelResource(): Promise<ChannelResource> {
+  const data = await ytFetch<ListResponse<ChannelResource>>('GET', `${API}/channels`, {
+    query: { part: 'snippet,statistics,contentDetails', mine: true },
+  });
+  const channel = data.items?.[0];
+  if (!channel)
+    throw new Error(
+      'No YouTube channel found for this Google account (create one at youtube.com first, or authorise the account that owns the channel).'
+    );
+  return channel;
+}
+
+// ─── resumable upload machinery ──────────────────────────────────────────────
+
+type Bytes = Uint8Array<ArrayBuffer>;
+
+interface Source {
+  stream: ReadableStream<Uint8Array>;
+  contentType: string;
+  /** Total size of the whole file when the server told us. */
+  totalBytes?: number;
+}
+
+const VIDEO_LIKE_TYPES = new Set([
+  'application/octet-stream',
+  'binary/octet-stream',
+  'application/mp4',
+  'application/x-matroska',
+]);
+
+function mediaType(res: Response, fallback: string): string {
+  const raw = res.headers.get('content-type') ?? fallback;
+  return (raw.split(';')[0] ?? raw).trim().toLowerCase();
+}
+
+/** Drop the first `count` bytes of a stream (used when a source ignores Range on resume). */
+function skipBytes(stream: ReadableStream<Uint8Array>, count: number): ReadableStream<Uint8Array> {
+  let remaining = count;
+  return stream.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        if (remaining === 0) {
+          controller.enqueue(chunk);
+          return;
+        }
+        if (chunk.length <= remaining) {
+          remaining -= chunk.length;
+          return;
+        }
+        controller.enqueue(chunk.subarray(remaining));
+        remaining = 0;
+      },
+    })
+  );
+}
+
+/** Work out the file's total size and how many bytes of this response to discard. */
+function sourceLayout(res: Response, offset: number): { totalBytes?: number; skip: number } {
+  if (offset > 0 && res.status === 206) {
+    const match = /bytes \d+-\d+\/(\d+|\*)/.exec(res.headers.get('content-range') ?? '');
+    const total = match?.[1];
+    return { totalBytes: total && total !== '*' ? Number(total) : undefined, skip: 0 };
+  }
+  const length = res.headers.get('content-length');
+  return { totalBytes: length ? Number(length) : undefined, skip: offset };
+}
+
+async function openSource(url: string, offset: number): Promise<Source> {
+  const headers: Record<string, string> = offset > 0 ? { Range: `bytes=${offset}-` } : {};
+  const res = await fetch(url, { headers, redirect: 'follow' });
+  if (!res.ok) {
+    throw new Error(`Could not fetch the video from ${url}: ${res.status} ${res.statusText}`);
+  }
+  if (!res.body) throw new Error(`The video URL ${url} returned no body.`);
+  const contentType = mediaType(res, 'application/octet-stream');
+  if (!contentType.startsWith('video/') && !VIDEO_LIKE_TYPES.has(contentType)) {
+    throw new Error(
+      `The URL does not look like a video file (content-type ${contentType}). Point videoUrl at the media file itself, not a page about it.`
+    );
+  }
+  const { totalBytes, skip } = sourceLayout(res, offset);
+  const stream: ReadableStream<Uint8Array> = skip > 0 ? skipBytes(res.body, skip) : res.body;
+  return { stream, contentType, totalBytes };
+}
+
+interface Chunk {
+  bytes: Bytes;
+  last: boolean;
+}
+
+function concat(parts: Uint8Array[], total: number): Bytes {
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+/** Copy exactly `size` bytes out of `parts`; return the remainder untouched. */
+function takeExact(parts: Uint8Array[], size: number): { out: Bytes; rest: Uint8Array[] } {
+  const out = new Uint8Array(size);
+  const rest: Uint8Array[] = [];
+  let filled = 0;
+  for (const p of parts) {
+    if (filled === size) {
+      rest.push(p);
+      continue;
+    }
+    const take = Math.min(p.length, size - filled);
+    out.set(p.subarray(0, take), filled);
+    filled += take;
+    if (take < p.length) rest.push(p.subarray(take));
+  }
+  return { out, rest };
+}
+
+/** Read until more than `size` bytes are buffered (so a final chunk is never empty) or the stream ends. */
+async function fillBuffer(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  parts: Uint8Array[],
+  have: number,
+  size: number
+): Promise<{ have: number; ended: boolean }> {
+  let buffered = have;
+  while (buffered <= size) {
+    const { value, done } = await reader.read();
+    if (done) return { have: buffered, ended: true };
+    if (value?.length) {
+      parts.push(value);
+      buffered += value.length;
+    }
+  }
+  return { have: buffered, ended: false };
+}
+
+/**
+ * Yield fixed-size chunks; the final chunk is always flagged `last` and, for any non-empty
+ * source, non-empty — so the upload can close the session with an exact total even when the
+ * source size was unknown. Leaving the loop early cancels the source.
+ */
+export async function* chunkStream(
+  stream: ReadableStream<Uint8Array>,
+  size: number
+): AsyncGenerator<Chunk> {
+  const reader = stream.getReader();
+  let parts: Uint8Array[] = [];
+  let have = 0;
+  let ended = false;
+  try {
+    while (true) {
+      if (!ended) {
+        const filled = await fillBuffer(reader, parts, have, size);
+        have = filled.have;
+        ended = filled.ended;
+      }
+      if (have > size) {
+        const { out, rest } = takeExact(parts, size);
+        parts = rest;
+        have -= size;
+        yield { bytes: out, last: false };
+      } else {
+        yield { bytes: concat(parts, have), last: true };
+        return;
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
+class RetryableUploadError extends Error {}
+
+type PutResult = { kind: 'continue'; uploaded: number } | { kind: 'done'; video: VideoResource };
+
+function uploadedFromRange(res: Response, fallback: number): number {
+  const range = res.headers.get('range') ?? res.headers.get('Range');
+  const match = /bytes=\d+-(\d+)/.exec(range ?? '');
+  return match?.[1] ? Number(match[1]) + 1 : fallback;
+}
+
+async function putChunk(
+  sessionUri: string,
+  token: string,
+  bytes: Bytes,
+  start: number,
+  total: number | undefined,
+  last: boolean
+): Promise<PutResult> {
+  const end = start + bytes.length - 1;
+  const totalLabel = last ? String(end + 1) : total !== undefined ? String(total) : '*';
+  if (last && total !== undefined && end + 1 !== total) {
+    throw new Error(
+      `Video source changed size mid-upload (expected ${total} bytes, got ${end + 1}). Start a new upload.`
+    );
+  }
+  const res = await fetch(sessionUri, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/octet-stream',
+      'Content-Range': `bytes ${start}-${end}/${totalLabel}`,
+    },
+    body: bytes,
+  });
+  if (res.status === 308) return { kind: 'continue', uploaded: uploadedFromRange(res, end + 1) };
+  const text = await res.text();
+  if (res.ok) return { kind: 'done', video: JSON.parse(text) as VideoResource };
+  if (res.status >= 500 || res.status === 429 || res.status === 408) {
+    throw new RetryableUploadError(
+      `YouTube upload chunk failed: ${res.status} ${text.slice(0, 200)}`
+    );
+  }
+  throw describeFailure('PUT', `${UPLOAD}/videos`, res.status, text);
+}
+
+/** Ask the session how much it has; 308 = partial (Range header), 2xx = already finished. */
+async function sessionStatus(
+  sessionUri: string,
+  token: string,
+  total: number | undefined
+): Promise<PutResult> {
+  const res = await fetch(sessionUri, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Range': `bytes */${total ?? '*'}` },
+  });
+  if (res.status === 308) return { kind: 'continue', uploaded: uploadedFromRange(res, 0) };
+  const text = await res.text();
+  if (res.ok) return { kind: 'done', video: JSON.parse(text) as VideoResource };
+  if (res.status === 404 || res.status === 410) {
+    throw new Error(
+      'The upload session expired or was not found — start a new upload without sessionUri.'
+    );
+  }
+  throw describeFailure('PUT', `${UPLOAD}/videos`, res.status, text);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** After a transient failure, work out what is still owed from the offset YouTube confirms. */
+function remainderAfter(
+  status: PutResult,
+  pending: Bytes,
+  at: number
+): { pending: Bytes; at: number } {
+  if (status.kind === 'done')
+    return { pending: pending.subarray(pending.length), at: at + pending.length };
+  const already = status.uploaded - at;
+  if (already < 0 || already > pending.length) {
+    throw new Error(
+      `Upload session offset ${status.uploaded} is outside the chunk being sent (${at}-${at + pending.length - 1}); start a new upload.`
+    );
+  }
+  return { pending: pending.subarray(already), at: status.uploaded };
+}
+
+/** Send one chunk, retrying transient failures from the offset YouTube confirms it kept. */
+async function sendChunk(
+  sessionUri: string,
+  token: string,
+  chunk: Chunk,
+  start: number,
+  total: number | undefined
+): Promise<PutResult> {
+  let pending: Bytes = chunk.bytes;
+  let at = start;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await putChunk(sessionUri, token, pending, at, total, chunk.last);
+    } catch (error) {
+      if (!(error instanceof RetryableUploadError) || attempt > 3) throw error;
+      await sleep(500 * 2 ** attempt);
+      const status = await sessionStatus(sessionUri, token, total);
+      if (status.kind === 'done') return status;
+      ({ pending, at } = remainderAfter(status, pending, at));
+      if (pending.length === 0) return { kind: 'continue', uploaded: at };
+    }
+  }
+}
+
+interface PumpOutcome {
+  done: boolean;
+  uploaded: number;
+  total?: number;
+  video?: VideoResource;
+  chunksSent: number;
+}
+
+/** Send chunks until the stream ends or the time budget is spent (always sends at least one). */
+async function pumpChunks(
+  sessionUri: string,
+  token: string,
+  source: Source,
+  startOffset: number,
+  deadline: number
+): Promise<PumpOutcome> {
+  let uploaded = startOffset;
+  let chunksSent = 0;
+  let lastChunkMs = 0;
+  for await (const chunk of chunkStream(source.stream, CHUNK_BYTES)) {
+    if (chunk.bytes.length === 0) throw new Error('The video file is empty (0 bytes).');
+    if (chunksSent > 0 && Date.now() + lastChunkMs > deadline) {
+      return { done: false, uploaded, total: source.totalBytes, chunksSent };
+    }
+    const began = Date.now();
+    const result = await sendChunk(sessionUri, token, chunk, uploaded, source.totalBytes);
+    chunksSent += 1;
+    if (result.kind === 'done') {
+      return {
+        done: true,
+        uploaded: uploaded + chunk.bytes.length,
+        total: source.totalBytes,
+        video: result.video,
+        chunksSent,
+      };
+    }
+    uploaded = result.uploaded;
+    lastChunkMs = Date.now() - began;
+  }
+  throw new Error(
+    'Upload stream ended before YouTube acknowledged completion; call again with the same sessionUri to resume.'
+  );
+}
+
+interface UploadMeta {
+  title: string;
+  description?: string;
+  tags?: string[];
+  categoryId?: string;
+  language?: string;
+  privacy: 'private' | 'unlisted' | 'public';
+  publishAt?: string;
+  madeForKids: boolean;
+  notifySubscribers: boolean;
+}
+
+async function startSession(meta: UploadMeta, source: Source, token: string): Promise<string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json; charset=UTF-8',
+    'X-Upload-Content-Type': source.contentType,
+  };
+  if (source.totalBytes !== undefined)
+    headers['X-Upload-Content-Length'] = String(source.totalBytes);
+  const body = {
+    snippet: {
+      title: meta.title,
+      description: meta.description ?? '',
+      tags: meta.tags,
+      categoryId: meta.categoryId,
+      defaultLanguage: meta.language,
+    },
+    status: {
+      privacyStatus: meta.privacy,
+      publishAt: meta.publishAt,
+      selfDeclaredMadeForKids: meta.madeForKids,
+    },
+  };
+  const url = withQuery(`${UPLOAD}/videos`, {
+    uploadType: 'resumable',
+    part: 'snippet,status',
+    notifySubscribers: meta.notifySubscribers,
+  });
+  const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  if (!res.ok) throw describeFailure('POST', `${UPLOAD}/videos`, res.status, await res.text());
+  const location = res.headers.get('location') ?? res.headers.get('Location');
+  if (!location) throw new Error('YouTube did not return an upload session (no Location header).');
+  return location;
+}
+
+// ─── tools ───────────────────────────────────────────────────────────────────
+
+export const youtubeAuthUrl = tool({
+  description:
+    'One-time setup, step 1: build the Google consent URL that authorises this OAuth client to manage your YouTube channel. Open it in a browser as the channel owner, approve, then pass the `code` from the redirect URL to youtubeExchangeCode.',
+  inputSchema: jsonSchema<{ redirectUri?: string; scopes?: string[] }>({
+    type: 'object',
+    properties: {
+      redirectUri: {
+        type: 'string',
+        description: `Redirect URI — a "Desktop app" OAuth client accepts any http://localhost URI (default ${DEFAULT_REDIRECT})`,
+      },
+      scopes: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'OAuth scopes to request (default: youtube.upload + youtube.force-ssl, which cover every tool here)',
+      },
+    },
+  }),
+  execute: async ({ redirectUri, scopes }) => {
+    const { clientId } = clientCreds();
+    const redirect = redirectUri ?? DEFAULT_REDIRECT;
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirect,
+      response_type: 'code',
+      scope: (scopes?.length ? scopes : DEFAULT_SCOPES).join(' '),
+      access_type: 'offline',
+      prompt: 'consent',
+      include_granted_scopes: 'true',
+    });
+    return {
+      url: `${AUTH_URL}?${params.toString()}`,
+      redirectUri: redirect,
+      instructions: `Open the URL signed in as the Google account that owns the channel and approve. The browser is then sent to ${redirect} — the page may say it cannot be reached; that is fine. Copy the "code" query parameter from the address bar and call youtubeExchangeCode with it (within a few minutes).`,
+    };
+  },
+});
+
+export const youtubeExchangeCode = tool({
+  description:
+    'One-time setup, step 2: exchange the consent code from youtubeAuthUrl for a long-lived refresh token. Store the returned refreshToken as the YOUTUBE_REFRESH_TOKEN environment variable (collection env var on tpmjs) — treat it like a password and do not save it into memory or notes.',
+  inputSchema: jsonSchema<{ code: string; redirectUri?: string }>({
+    type: 'object',
+    properties: {
+      code: { type: 'string', description: 'The "code" parameter from the redirect URL' },
+      redirectUri: {
+        type: 'string',
+        description: `Must match the redirectUri used for youtubeAuthUrl (default ${DEFAULT_REDIRECT})`,
+      },
+    },
+    required: ['code'],
+  }),
+  execute: async ({ code, redirectUri }) => {
+    const { clientId, clientSecret } = clientCreds();
+    const data = await postToken({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code: code.trim(),
+      redirect_uri: redirectUri ?? DEFAULT_REDIRECT,
+      grant_type: 'authorization_code',
+    });
+    if (!data.refresh_token) {
+      throw new Error(
+        'Google returned no refresh_token. Revoke the app at https://myaccount.google.com/permissions and run youtubeAuthUrl again (it must be requested with access_type=offline and prompt=consent).'
+      );
+    }
+    return {
+      refreshToken: data.refresh_token,
+      scope: data.scope,
+      accessTokenExpiresIn: data.expires_in,
+      instructions:
+        'Set YOUTUBE_REFRESH_TOKEN to refreshToken (plus YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET) wherever these tools run. If the OAuth consent screen is in "Testing" the token expires after 7 days — publish the app to make it permanent.',
+    };
+  },
+});
+
+export const myChannel = tool({
+  description:
+    'Show the YouTube channel these credentials control: id, title, handle, subscriber/video/view counts and the uploads playlist.',
+  inputSchema: jsonSchema<Record<string, never>>({ type: 'object', properties: {} }),
+  execute: async () => {
+    const c = await myChannelResource();
+    return {
+      channelId: c.id,
+      title: c.snippet?.title,
+      handle: c.snippet?.customUrl,
+      url: c.snippet?.customUrl
+        ? `https://www.youtube.com/${c.snippet.customUrl}`
+        : `https://www.youtube.com/channel/${c.id}`,
+      description: c.snippet?.description,
+      createdAt: c.snippet?.publishedAt,
+      subscribers: num(c.statistics?.subscriberCount),
+      videos: num(c.statistics?.videoCount),
+      views: num(c.statistics?.viewCount),
+      uploadsPlaylistId: c.contentDetails?.relatedPlaylists?.uploads,
+      thumbnail: c.snippet?.thumbnails?.high?.url ?? c.snippet?.thumbnails?.default?.url,
+    };
+  },
+});
+
+interface UploadInput {
+  videoUrl: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  privacy?: 'private' | 'unlisted' | 'public';
+  categoryId?: string;
+  madeForKids?: boolean;
+  publishAt?: string;
+  language?: string;
+  notifySubscribers?: boolean;
+  playlistId?: string;
+  thumbnailUrl?: string;
+  sessionUri?: string;
+  maxSeconds?: number;
+}
+
+async function finishUpload(
+  video: VideoResource,
+  input: UploadInput,
+  requestedPrivacy: string
+): Promise<Record<string, unknown>> {
+  const extras: Record<string, unknown> = {};
+  if (input.playlistId) {
+    try {
+      await addVideoToPlaylist(input.playlistId, video.id);
+      extras.addedToPlaylist = input.playlistId;
+    } catch (error) {
+      extras.playlistError = (error as Error).message;
+    }
+  }
+  if (input.thumbnailUrl) {
+    try {
+      await uploadThumbnail(video.id, input.thumbnailUrl);
+      extras.thumbnailSet = true;
+    } catch (error) {
+      extras.thumbnailError = (error as Error).message;
+    }
+  }
+  const privacy = video.status?.privacyStatus;
+  const notes: string[] = [
+    'YouTube processes the file after upload — poll videoStatus until processingStatus is "succeeded".',
+  ];
+  if (privacy && privacy !== requestedPrivacy) {
+    notes.push(
+      `Requested privacy "${requestedPrivacy}" but YouTube set "${privacy}": uploads from an API project that has not passed the YouTube API Services compliance audit are locked to private. Flip it in YouTube Studio, or complete the audit for the project.`
+    );
+  }
+  return { status: 'uploaded', ...summarizeVideo(video), ...extras, notes };
+}
+
+export const uploadVideo = tool({
+  description:
+    'Upload a video to your channel from a URL (the media file itself). Streams it to YouTube in resumable 8 MiB chunks. Long files are continued across calls: if the result says status "in_progress", call again with the same videoUrl plus the returned sessionUri until it says "uploaded". Optionally adds the video to a playlist and sets a custom thumbnail.',
+  inputSchema: jsonSchema<UploadInput>({
+    type: 'object',
+    properties: {
+      videoUrl: {
+        type: 'string',
+        description: 'Direct http(s) URL of the video file (mp4, mov, webm, mkv…)',
+      },
+      title: {
+        type: 'string',
+        maxLength: 100,
+        description: 'Video title (required for a new upload; ignored on resume)',
+      },
+      description: { type: 'string', maxLength: 5000 },
+      tags: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Keywords; total length under ~500 characters',
+      },
+      privacy: {
+        type: 'string',
+        enum: ['private', 'unlisted', 'public'],
+        default: 'private',
+        description:
+          'Visibility (default private — note that un-audited API projects are forced to private anyway)',
+      },
+      categoryId: {
+        type: 'string',
+        description:
+          'YouTube category id (see videoCategories; e.g. 22 People & Blogs, 28 Science & Technology, 27 Education, 10 Music)',
+      },
+      madeForKids: { type: 'boolean', default: false, description: 'COPPA self-declaration' },
+      publishAt: {
+        type: 'string',
+        description: 'ISO 8601 time to schedule publishing; the video stays private until then',
+      },
+      language: {
+        type: 'string',
+        description: 'BCP-47 language of the title/description, e.g. "en"',
+      },
+      notifySubscribers: { type: 'boolean', default: true },
+      playlistId: { type: 'string', description: 'Add the uploaded video to this playlist' },
+      thumbnailUrl: {
+        type: 'string',
+        description: 'Image URL (JPEG/PNG, ≤ 2 MB) to set as the custom thumbnail',
+      },
+      sessionUri: {
+        type: 'string',
+        description:
+          'Upload session returned by a previous in_progress result — continues that upload',
+      },
+      maxSeconds: {
+        type: 'number',
+        minimum: 5,
+        maximum: MAX_BUDGET_SECONDS,
+        default: DEFAULT_BUDGET_SECONDS,
+        description:
+          'Time budget for this call; when exceeded the upload pauses and returns sessionUri so it can be resumed',
+      },
+    },
+    required: ['videoUrl'],
+  }),
+  execute: async (input) => {
+    const startedAt = Date.now();
+    const budget = Math.min(
+      Math.max(input.maxSeconds ?? DEFAULT_BUDGET_SECONDS, 5),
+      MAX_BUDGET_SECONDS
+    );
+    const deadline = startedAt + budget * 1000;
+    const requestedPrivacy = input.publishAt ? 'private' : (input.privacy ?? 'private');
+    const token = await accessToken();
+
+    let sessionUri = input.sessionUri;
+    let offset = 0;
+    let source: Source;
+    if (sessionUri) {
+      const status = await sessionStatus(sessionUri, token, undefined);
+      if (status.kind === 'done') return finishUpload(status.video, input, requestedPrivacy);
+      offset = status.uploaded;
+      source = await openSource(input.videoUrl, offset);
+    } else {
+      if (!input.title?.trim()) throw new Error('title is required for a new upload.');
+      source = await openSource(input.videoUrl, 0);
+      sessionUri = await startSession(
+        {
+          title: input.title.trim(),
+          description: input.description,
+          tags: input.tags,
+          categoryId: input.categoryId,
+          language: input.language,
+          privacy: requestedPrivacy,
+          publishAt: input.publishAt,
+          madeForKids: input.madeForKids ?? false,
+          notifySubscribers: input.notifySubscribers ?? true,
+        },
+        source,
+        token
+      );
+    }
+
+    const outcome = await pumpChunks(sessionUri, token, source, offset, deadline);
+    if (outcome.done && outcome.video) return finishUpload(outcome.video, input, requestedPrivacy);
+    const total = outcome.total;
+    return {
+      status: 'in_progress',
+      sessionUri,
+      uploadedBytes: outcome.uploaded,
+      totalBytes: total,
+      percent: total ? Math.round((outcome.uploaded / total) * 1000) / 10 : undefined,
+      chunksSentThisCall: outcome.chunksSent,
+      elapsedSeconds: Math.round((Date.now() - startedAt) / 10) / 100,
+      next: 'Call uploadVideo again with the same videoUrl and this sessionUri to continue (the session stays valid for about a day).',
+    };
+  },
+});
+
+export const videoStatus = tool({
+  description:
+    'Check one of your videos: upload/processing status, privacy, schedule, failure reasons and basic stats. Use after uploadVideo until processing succeeds.',
+  inputSchema: jsonSchema<{ videoId: string }>({
+    type: 'object',
+    properties: {
+      videoId: { type: 'string', description: 'Video id (the v= parameter) or full watch URL' },
+    },
+    required: ['videoId'],
+  }),
+  execute: async ({ videoId }) => {
+    const id = extractVideoId(videoId);
+    const data = await ytFetch<ListResponse<VideoResource>>('GET', `${API}/videos`, {
+      query: { part: 'snippet,status,processingDetails,statistics,contentDetails', id },
+    });
+    const video = data.items?.[0];
+    if (!video) throw new Error(`Video ${id} was not found (or is not visible to this account).`);
+    const progress = video.processingDetails?.processingProgress;
+    return {
+      ...summarizeVideo(video),
+      processingProgress: progress
+        ? {
+            partsProcessed: num(progress.partsProcessed),
+            partsTotal: num(progress.partsTotal),
+            timeLeftMs: num(progress.timeLeftMs),
+          }
+        : undefined,
+      description: video.snippet?.description,
+    };
+  },
+});
+
+export const myVideos = tool({
+  description:
+    "List your channel's most recent uploads (newest first) with privacy, processing state and view/like/comment counts.",
+  inputSchema: jsonSchema<{ limit?: number; pageToken?: string }>({
+    type: 'object',
+    properties: {
+      limit: { type: 'integer', minimum: 1, maximum: 50, default: 10 },
+      pageToken: { type: 'string', description: 'nextPageToken from a previous call' },
+    },
+  }),
+  execute: async ({ limit, pageToken }) => {
+    const channel = await myChannelResource();
+    const uploads = channel.contentDetails?.relatedPlaylists?.uploads;
+    if (!uploads)
+      return {
+        channelId: channel.id,
+        videos: [],
+        note: 'This channel has no uploads playlist yet.',
+      };
+    const items = await ytFetch<ListResponse<{ contentDetails?: { videoId?: string } }>>(
+      'GET',
+      `${API}/playlistItems`,
+      {
+        query: {
+          part: 'contentDetails',
+          playlistId: uploads,
+          maxResults: Math.min(Math.max(limit ?? 10, 1), 50),
+          pageToken,
+        },
+      }
+    );
+    const ids = (items.items ?? [])
+      .map((i) => i.contentDetails?.videoId)
+      .filter((v): v is string => !!v);
+    if (!ids.length)
+      return { channelId: channel.id, videos: [], nextPageToken: items.nextPageToken };
+    const videos = await ytFetch<ListResponse<VideoResource>>('GET', `${API}/videos`, {
+      query: {
+        part: 'snippet,status,processingDetails,statistics,contentDetails',
+        id: ids.join(','),
+        maxResults: 50,
+      },
+    });
+    return {
+      channelId: channel.id,
+      videos: (videos.items ?? []).map(summarizeVideo),
+      nextPageToken: items.nextPageToken,
+      totalUploads: items.pageInfo?.totalResults,
+    };
+  },
+});
+
+export const updateVideo = tool({
+  description:
+    "Change a video's title, description, tags, category, privacy, schedule or made-for-kids flag. Only the fields you pass change; everything else is preserved.",
+  inputSchema: jsonSchema<{
+    videoId: string;
+    title?: string;
+    description?: string;
+    tags?: string[];
+    categoryId?: string;
+    privacy?: 'private' | 'unlisted' | 'public';
+    publishAt?: string;
+    madeForKids?: boolean;
+    language?: string;
+  }>({
+    type: 'object',
+    properties: {
+      videoId: { type: 'string', description: 'Video id or watch URL' },
+      title: { type: 'string', maxLength: 100 },
+      description: { type: 'string', maxLength: 5000 },
+      tags: { type: 'array', items: { type: 'string' }, description: 'Replaces the tag list' },
+      categoryId: { type: 'string' },
+      privacy: { type: 'string', enum: ['private', 'unlisted', 'public'] },
+      publishAt: {
+        type: 'string',
+        description: 'ISO 8601 scheduled publish time (video must be private)',
+      },
+      madeForKids: { type: 'boolean' },
+      language: { type: 'string', description: 'BCP-47 default language' },
+    },
+    required: ['videoId'],
+  }),
+  execute: async (input) => {
+    const id = extractVideoId(input.videoId);
+    const current = await ytFetch<ListResponse<VideoResource>>('GET', `${API}/videos`, {
+      query: { part: 'snippet,status', id },
+    });
+    const video = current.items?.[0];
+    if (!video?.snippet || !video.status)
+      throw new Error(`Video ${id} was not found (or is not yours).`);
+    const snippet = { ...video.snippet };
+    delete snippet.thumbnails;
+    delete snippet.publishedAt;
+    if (input.title !== undefined) snippet.title = input.title;
+    if (input.description !== undefined) snippet.description = input.description;
+    if (input.tags !== undefined) snippet.tags = input.tags;
+    if (input.categoryId !== undefined) snippet.categoryId = input.categoryId;
+    if (input.language !== undefined) snippet.defaultLanguage = input.language;
+    const status = { ...video.status };
+    delete status.uploadStatus;
+    delete status.failureReason;
+    delete status.rejectionReason;
+    if (input.privacy !== undefined) status.privacyStatus = input.privacy;
+    if (input.publishAt !== undefined) {
+      status.publishAt = input.publishAt;
+      status.privacyStatus = 'private';
+    }
+    if (input.madeForKids !== undefined) status.selfDeclaredMadeForKids = input.madeForKids;
+    const updated = await ytFetch<VideoResource>('PUT', `${API}/videos`, {
+      query: { part: 'snippet,status' },
+      json: { id, snippet, status },
+    });
+    return { updated: true, ...summarizeVideo(updated), description: updated.snippet?.description };
+  },
+});
+
+async function uploadThumbnail(videoId: string, imageUrl: string): Promise<void> {
+  const res = await fetch(imageUrl, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`Could not fetch the thumbnail from ${imageUrl}: ${res.status}`);
+  const contentType = mediaType(res, 'image/jpeg');
+  if (!contentType.startsWith('image/'))
+    throw new Error(`Thumbnail URL is not an image (content-type ${contentType}).`);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  if (bytes.length > MAX_THUMBNAIL_BYTES) {
+    throw new Error(
+      `Thumbnail is ${(bytes.length / 1024 / 1024).toFixed(1)} MB; YouTube allows at most 2 MB.`
+    );
+  }
+  await ytFetch('POST', `${UPLOAD}/thumbnails/set`, {
+    query: { videoId },
+    headers: { 'Content-Type': contentType },
+    body: bytes,
+  });
+}
+
+export const setThumbnail = tool({
+  description:
+    'Set a custom thumbnail (JPEG/PNG, ≤ 2 MB) on one of your videos from an image URL. Requires a phone-verified channel.',
+  inputSchema: jsonSchema<{ videoId: string; imageUrl: string }>({
+    type: 'object',
+    properties: {
+      videoId: { type: 'string', description: 'Video id or watch URL' },
+      imageUrl: { type: 'string', description: 'Direct URL of the image' },
+    },
+    required: ['videoId', 'imageUrl'],
+  }),
+  execute: async ({ videoId, imageUrl }) => {
+    const id = extractVideoId(videoId);
+    await uploadThumbnail(id, imageUrl);
+    return { videoId: id, url: videoUrl(id), thumbnailSet: true };
+  },
+});
+
+interface PlaylistResource {
+  id: string;
+  snippet?: { title?: string; description?: string; publishedAt?: string };
+  status?: { privacyStatus?: string };
+  contentDetails?: { itemCount?: number };
+}
+
+export const myPlaylists = tool({
+  description:
+    "List your channel's playlists with ids, titles, privacy and item counts (ids feed addToPlaylist / uploadVideo.playlistId).",
+  inputSchema: jsonSchema<{ limit?: number; pageToken?: string }>({
+    type: 'object',
+    properties: {
+      limit: { type: 'integer', minimum: 1, maximum: 50, default: 25 },
+      pageToken: { type: 'string' },
+    },
+  }),
+  execute: async ({ limit, pageToken }) => {
+    const data = await ytFetch<ListResponse<PlaylistResource>>('GET', `${API}/playlists`, {
+      query: {
+        part: 'snippet,status,contentDetails',
+        mine: true,
+        maxResults: Math.min(Math.max(limit ?? 25, 1), 50),
+        pageToken,
+      },
+    });
+    return {
+      playlists: (data.items ?? []).map((p) => ({
+        playlistId: p.id,
+        title: p.snippet?.title,
+        description: p.snippet?.description,
+        privacy: p.status?.privacyStatus,
+        items: p.contentDetails?.itemCount,
+        url: `https://www.youtube.com/playlist?list=${p.id}`,
+      })),
+      nextPageToken: data.nextPageToken,
+    };
+  },
+});
+
+async function addVideoToPlaylist(
+  playlistId: string,
+  videoId: string,
+  position?: number
+): Promise<{ playlistItemId: string }> {
+  const item = await ytFetch<{ id: string }>('POST', `${API}/playlistItems`, {
+    query: { part: 'snippet' },
+    json: { snippet: { playlistId, position, resourceId: { kind: 'youtube#video', videoId } } },
+  });
+  return { playlistItemId: item.id };
+}
+
+export const addToPlaylist = tool({
+  description: 'Add a video to one of your playlists (optionally at a position).',
+  inputSchema: jsonSchema<{ playlistId: string; videoId: string; position?: number }>({
+    type: 'object',
+    properties: {
+      playlistId: { type: 'string' },
+      videoId: { type: 'string', description: 'Video id or watch URL' },
+      position: { type: 'integer', minimum: 0, description: '0-based position; omitted = append' },
+    },
+    required: ['playlistId', 'videoId'],
+  }),
+  execute: async ({ playlistId, videoId, position }) => {
+    const id = extractVideoId(videoId);
+    const result = await addVideoToPlaylist(playlistId, id, position);
+    return {
+      added: true,
+      playlistId,
+      videoId: id,
+      ...result,
+      url: `https://www.youtube.com/playlist?list=${playlistId}`,
+    };
+  },
+});
+
+export const deleteVideo = tool({
+  description:
+    'Permanently delete one of your videos. Irreversible — confirm with the person first.',
+  inputSchema: jsonSchema<{ videoId: string }>({
+    type: 'object',
+    properties: { videoId: { type: 'string', description: 'Video id or watch URL' } },
+    required: ['videoId'],
+  }),
+  execute: async ({ videoId }) => {
+    const id = extractVideoId(videoId);
+    await ytFetch('DELETE', `${API}/videos`, { query: { id } });
+    return { deleted: true, videoId: id };
+  },
+});
+
+export const videoCategories = tool({
+  description:
+    'List the YouTube category ids a video can be assigned to in a region (for uploadVideo / updateVideo categoryId).',
+  inputSchema: jsonSchema<{ region?: string }>({
+    type: 'object',
+    properties: {
+      region: { type: 'string', default: 'US', description: 'ISO 3166-1 alpha-2 region code' },
+    },
+  }),
+  execute: async ({ region }) => {
+    const data = await ytFetch<
+      ListResponse<{ id: string; snippet?: { title?: string; assignable?: boolean } }>
+    >('GET', `${API}/videoCategories`, {
+      query: { part: 'snippet', regionCode: (region ?? 'US').toUpperCase() },
+    });
+    return {
+      region: (region ?? 'US').toUpperCase(),
+      categories: (data.items ?? [])
+        .filter((c) => c.snippet?.assignable !== false)
+        .map((c) => ({ id: c.id, title: c.snippet?.title })),
+    };
+  },
+});
+
+/** Accepts a bare id, a watch URL, a youtu.be link or a /shorts/ link. */
+export function extractVideoId(value: string): string {
+  const trimmed = value.trim();
+  try {
+    const url = new URL(trimmed);
+    const v = url.searchParams.get('v');
+    if (v) return v;
+    const parts = url.pathname.split('/').filter(Boolean);
+    const last = parts[parts.length - 1];
+    if (last) return last;
+  } catch {
+    // not a URL
+  }
+  return trimmed;
+}
+
+export default {
+  youtubeAuthUrl,
+  youtubeExchangeCode,
+  myChannel,
+  uploadVideo,
+  videoStatus,
+  myVideos,
+  updateVideo,
+  setThumbnail,
+  myPlaylists,
+  addToPlaylist,
+  deleteVideo,
+  videoCategories,
+};

--- a/packages/tools/official/youtube/tsconfig.json
+++ b/packages/tools/official/youtube/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tpmjs/tsconfig/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3654,6 +3654,22 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  packages/tools/official/youtube:
+    dependencies:
+      ai:
+        specifier: 6.0.49
+        version: 6.0.49(zod@4.4.3)
+    devDependencies:
+      '@tpmjs/tsconfig':
+        specifier: workspace:*
+        version: link:../../../config/tsconfig
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(happy-dom@20.1.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(@typescript/typescript6@6.0.2))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/tools/registryExecute:
     dependencies:
       ai:

--- a/scripts/coverage-baselines.ts
+++ b/scripts/coverage-baselines.ts
@@ -55,6 +55,10 @@ export const coverageBaselines: Record<string, CoverageBaseline> = {
     directory: 'packages/tools/official/redis',
     thresholds: { branches: 100, functions: 100, lines: 100, statements: 100 },
   },
+  '@tpmjs/tools-youtube': {
+    directory: 'packages/tools/official/youtube',
+    thresholds: { branches: 45, functions: 58, lines: 60, statements: 58 },
+  },
   '@tpmjs/ui': {
     directory: 'packages/ui',
     thresholds: { branches: 25.1, functions: 15, lines: 16.5, statements: 16 },


### PR DESCRIPTION
## Summary

Sixth **ajax weapons** package: `@tpmjs/tools-youtube` — twelve person-shaped tools over the YouTube Data API v3 with headless OAuth (refresh token minted once via `youtubeAuthUrl` → `youtubeExchangeCode`).

`myChannel` · `uploadVideo` · `videoStatus` · `myVideos` · `updateVideo` · `setThumbnail` · `myPlaylists` · `addToPlaylist` · `deleteVideo` · `videoCategories` (+ the two setup tools). No dependencies beyond `ai`; nothing cached at module level.

### Resumable, cross-call uploads
`uploadVideo` streams the file from a URL into YouTube's resumable protocol in 8 MiB chunks. Each call works within a time budget (default 75 s — under Cloudflare's 100 s limit on `tpmjs.com` MCP calls; max 280 s under the 300 s web→executor ceiling) and, when it runs out, returns `status: "in_progress"` with the `sessionUri` and bytes done; the next call with the same `videoUrl` + `sessionUri` resumes exactly there (Range request on the source, or byte-skipping when the source ignores Range). Transient 5xx chunk failures are retried from the offset YouTube confirms it kept. Unknown-length sources work: the final bytes are never sent as a non-final chunk, so the session is closed with an exact total.

### Honest errors
Google's reason code + a hint: daily quota (uploads cost 1,600/10,000 units), audit-forced private uploads (the result's `notes` explains when YouTube downgrades the requested privacy), testing-mode refresh tokens expiring after 7 days, phone verification for custom thumbnails.

## Validation
- vitest: 13 tests mocking `fetch` — exact `Content-Range` sequence for known/unknown length, pause → resume from session offset, retry-from-kept-offset, privacy-downgrade note, non-media URL rejection, title requirement, id extraction from watch/youtu.be/shorts URLs
- type-check (tsgo 7), build (tsdown), biome check, publint ("All good"), knip (workspace) — all clean

## Release
First publish is manual (trusted publishing is not registered for any package yet — #192 / #115), same as the other five weapon packages; not a changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
